### PR TITLE
implement monitor-only mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,17 @@ docker-compose restart cognitod
 
 ---
 
+---
+
+## Modes
+
+Linnix runs in two modes, configured in `linnix.toml`:
+
+- **`monitor` (Default)**: Safe by default. Detects failures and proposes actions, but **NEVER** executes them automatically. Requires human approval via API.
+- **`enforce`**: Advanced mode. Automatically executes actions (like killing processes) when strict safety rules are met.
+
+---
+
 ## Human-in-the-Loop Enforcement
 
 ![Enforcement Demo](docs/images/enforcement-demo.gif)

--- a/cognitod/src/config.rs
+++ b/cognitod/src/config.rs
@@ -347,6 +347,11 @@ pub struct CircuitBreakerConfig {
     /// Require human approval even when circuit breaker triggers (override safety)
     #[serde(default = "default_require_human_approval")]
     pub require_human_approval: bool,
+
+    /// Operation mode: "monitor" (default) or "enforce"
+    /// In "monitor" mode, actions are proposed but NEVER executed automatically.
+    #[serde(default = "default_circuit_breaker_mode")]
+    pub mode: String,
 }
 
 impl Default for CircuitBreakerConfig {
@@ -360,6 +365,7 @@ impl Default for CircuitBreakerConfig {
             check_interval_secs: default_check_interval_secs(),
             grace_period_secs: default_grace_period_secs(),
             require_human_approval: default_require_human_approval(),
+            mode: default_circuit_breaker_mode(),
         }
     }
 }
@@ -394,6 +400,10 @@ fn default_grace_period_secs() -> u64 {
 
 fn default_require_human_approval() -> bool {
     false // Auto-approve when circuit breaker triggers (but still requires enabled=true)
+}
+
+fn default_circuit_breaker_mode() -> String {
+    "monitor".to_string() // Default to safe mode
 }
 
 #[cfg(test)]

--- a/cognitod/src/main.rs
+++ b/cognitod/src/main.rs
@@ -902,8 +902,11 @@ async fn main() -> Result<(), Box<dyn Error>> {
             }
 
             info!(
-                "[circuit_breaker] enabled - CPU>{}% AND PSI>{}% sustained for {}s triggers kill",
-                cb_cfg.cpu_usage_threshold, cb_cfg.cpu_psi_threshold, cb_cfg.grace_period_secs
+                "[circuit_breaker] enabled - CPU>{}% AND PSI>{}% sustained for {}s triggers kill (mode: {})",
+                cb_cfg.cpu_usage_threshold,
+                cb_cfg.cpu_psi_threshold,
+                cb_cfg.grace_period_secs,
+                cb_cfg.mode
             );
 
             let mut breach_started_at: Option<std::time::Instant> = None;
@@ -959,7 +962,11 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                         reason.clone(),
                                         "circuit_breaker".to_string(),
                                         None,
-                                        !cb_cfg.require_human_approval,
+                                        if cb_cfg.mode == "monitor" {
+                                            false // Force manual approval in monitor mode
+                                        } else {
+                                            !cb_cfg.require_human_approval
+                                        },
                                     )
                                     .await
                                 {


### PR DESCRIPTION
Introduces a "Monitor-Only" mode to ensure safety for new deployments.

**Changes:**
- **Config**: Added [mode](cci:1://file:///home/parthshah/linnix-opensource/cognitod/src/api/mod.rs:1620:0-1627:1) field to [CircuitBreakerConfig](cci:2://file:///home/parthshah/linnix-opensource/cognitod/src/config.rs:315:0-354:1) (options: `monitor`, `enforce`).
- **Safety**: Default mode is now `monitor`. In this mode, [require_human_approval](cci:1://file:///home/parthshah/linnix-opensource/cognitod/src/config.rs:400:0-402:1) is forced to `true`, meaning the system will **never** automatically kill processes, only propose actions.
- **Docs**: Updated [README.md](cci:7://file:///home/parthshah/linnix-opensource/README.md:0:0-0:0) to explain the new modes and safety guarantees.

**Why:**
Allows users to deploy Linnix safely in production to observe behavior without risking automated interventions.