### PR TITLE
Add Kubernetes Support (DaemonSet + EKS Config)

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,21 @@ Prevents system thrashing by monitoring **Pressure Stall Information (PSI)**.
 - **Grace Period**: Configurable delay (default 15s) prevents killing processes during transient spikes.
 - **Incident Analysis**: Automatically captures system state and uses LLM to analyze the root cause.
 
-**Configuration:**
+### Deploy to Kubernetes
+
+Linnix can be deployed as a DaemonSet to monitor every node in your cluster.
+
+```bash
+# Apply the manifests
+kubectl apply -f k8s/
+
+# Check status
+kubectl get daemonset -n default linnix-agent
+```
+
+See [k8s/README.md](k8s/README.md) for advanced configuration (RBAC, capabilities).
+
+## Configuration:
 ```toml
 [circuit_breaker]
 enabled = true

--- a/infrastructure/eks-cluster.yaml
+++ b/infrastructure/eks-cluster.yaml
@@ -1,0 +1,26 @@
+apiVersion: eksctl.io/v1alpha5
+kind: ClusterConfig
+
+metadata:
+  name: linnix-demo
+  region: us-east-1
+  version: "1.30"
+
+managedNodeGroups:
+  - name: linnix-nodes
+    instanceType: t3.medium
+    minSize: 2
+    maxSize: 3
+    desiredCapacity: 2
+    volumeSize: 20
+    # Amazon Linux 2023 has kernel 6.1+ with BTF enabled by default
+    amiFamily: AmazonLinux2023
+    iam:
+      withAddonPolicies:
+        cloudWatch: true
+        autoScaler: true
+
+addons:
+  - name: vpc-cni
+  - name: coredns
+  - name: kube-proxy

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -1,0 +1,38 @@
+# Linnix on Kubernetes
+
+This directory contains manifests to deploy Linnix as a DaemonSet on your Kubernetes cluster.
+
+## Quick Start
+
+```bash
+kubectl apply -f k8s/
+```
+
+This will create:
+- `ConfigMap/linnix-config`: Default configuration (monitor mode).
+- `ServiceAccount/linnix-agent`: Identity for the agent.
+- `DaemonSet/linnix-agent`: The agent pod on every node.
+
+## Configuration
+
+Edit `k8s/configmap.yaml` to change settings.
+
+### Capabilities & Privileges
+
+Linnix requires eBPF privileges. The default `daemonset.yaml` uses `privileged: true` for simplicity.
+
+For tighter security, you can disable privileged mode and use capabilities (requires kernel 5.8+ and container runtime support):
+
+```yaml
+securityContext:
+  privileged: false
+  capabilities:
+    add: ["BPF", "PERFMON", "SYS_RESOURCE", "SYS_ADMIN"]
+```
+
+### Host Mounts
+
+Linnix mounts:
+- `/sys/kernel/btf/vmlinux`: For BTF type information (required for CO-RE).
+- `/sys/kernel/debug`: For debugfs (tracepoints).
+- `hostPID: true`: To correlate events with host processes.

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -41,6 +41,20 @@ Linnix mounts:
 
 ### AWS EKS
 
+**Option A: Quick Start with `eksctl` (Recommended)**
+
+We provide a configuration file to spin up a compatible cluster (Amazon Linux 2023, Kernel 6.1+):
+
+```bash
+# Create cluster (takes ~15 mins)
+eksctl create cluster -f infrastructure/eks-cluster.yaml
+
+# Deploy Linnix
+kubectl apply -f k8s/
+```
+
+**Option B: Existing Cluster**
+
 1. **Connect to Cluster**:
    ```bash
    aws eks update-kubeconfig --region region-code --name my-cluster

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -36,3 +36,21 @@ Linnix mounts:
 - `/sys/kernel/btf/vmlinux`: For BTF type information (required for CO-RE).
 - `/sys/kernel/debug`: For debugfs (tracepoints).
 - `hostPID: true`: To correlate events with host processes.
+
+## Cloud Provider Notes
+
+### AWS EKS
+
+1. **Connect to Cluster**:
+   ```bash
+   aws eks update-kubeconfig --region region-code --name my-cluster
+   ```
+
+2. **Kernel Support**:
+   Ensure your node group uses **Amazon Linux 2023** or a recent **Bottlerocket** OS (Kernel 5.10+ with BTF enabled).
+   Older Amazon Linux 2 might require a kernel upgrade for full eBPF support.
+
+3. **Deploy**:
+   ```bash
+   kubectl apply -f k8s/
+   ```

--- a/k8s/configmap.yaml
+++ b/k8s/configmap.yaml
@@ -9,6 +9,7 @@ data:
   linnix.toml: |
     [api]
     listen_addr = "0.0.0.0:3000"
+    # auth_token = "your-secret-token"  # IMPORTANT: Set this for production!
 
     [runtime]
     offline = false

--- a/k8s/configmap.yaml
+++ b/k8s/configmap.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: linnix-config
+  namespace: default
+  labels:
+    app: linnix
+data:
+  linnix.toml: |
+    [api]
+    listen_addr = "0.0.0.0:3000"
+
+    [runtime]
+    offline = false
+    cpu_target_pct = 25
+    rss_cap_mb = 512
+
+    [circuit_breaker]
+    enabled = true
+    mode = "monitor"  # Safe by default
+    cpu_usage_threshold = 90.0
+    cpu_psi_threshold = 40.0
+    grace_period_secs = 15
+    require_human_approval = true
+
+    [reasoner]
+    enabled = false  # Disable LLM by default in K8s to save resources
+    endpoint = "http://localhost:8090/v1/chat/completions"
+
+    [prometheus]
+    enabled = true

--- a/k8s/daemonset.yaml
+++ b/k8s/daemonset.yaml
@@ -1,0 +1,63 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: linnix-agent
+  namespace: default
+  labels:
+    app: linnix
+spec:
+  selector:
+    matchLabels:
+      app: linnix
+  template:
+    metadata:
+      labels:
+        app: linnix
+    spec:
+      serviceAccountName: linnix-agent
+      hostPID: true  # Required to monitor host processes
+      containers:
+        - name: cognitod
+          image: ghcr.io/linnix-os/cognitod:latest
+          imagePullPolicy: Always
+          args: ["--config", "/etc/linnix/linnix.toml"]
+          securityContext:
+            privileged: true  # Simplest for eBPF. Can be refined with caps.
+            # capabilities:
+            #   add: ["BPF", "PERFMON", "SYS_RESOURCE", "SYS_ADMIN"]
+          volumeMounts:
+            - name: config
+              mountPath: /etc/linnix
+              readOnly: true
+            - name: sys-btf
+              mountPath: /sys/kernel/btf/vmlinux
+              readOnly: true
+            - name: debugfs
+              mountPath: /sys/kernel/debug
+            # Mount host /proc to monitor processes
+            # Note: In container, this might be mounted at /host/proc if configured,
+            # but standard hostPID: true makes /proc the host's /proc?
+            # No, hostPID: true means we see host PIDs in our /proc.
+          resources:
+            limits:
+              memory: 512Mi
+              cpu: 500m
+            requests:
+              memory: 128Mi
+              cpu: 100m
+          ports:
+            - containerPort: 3000
+              hostPort: 3000
+              name: http
+      volumes:
+        - name: config
+          configMap:
+            name: linnix-config
+        - name: sys-btf
+          hostPath:
+            path: /sys/kernel/btf/vmlinux
+            type: File
+        - name: debugfs
+          hostPath:
+            path: /sys/kernel/debug
+            type: Directory

--- a/k8s/daemonset.yaml
+++ b/k8s/daemonset.yaml
@@ -20,7 +20,6 @@ spec:
         - name: cognitod
           image: ghcr.io/linnix-os/cognitod:latest
           imagePullPolicy: Always
-          args: ["--config", "/etc/linnix/linnix.toml"]
           securityContext:
             privileged: true  # Simplest for eBPF. Can be refined with caps.
             # capabilities:

--- a/k8s/daemonset.yaml
+++ b/k8s/daemonset.yaml
@@ -46,7 +46,6 @@ spec:
               cpu: 100m
           ports:
             - containerPort: 3000
-              hostPort: 3000
               name: http
       volumes:
         - name: config

--- a/k8s/rbac.yaml
+++ b/k8s/rbac.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: linnix-agent
+  namespace: default
+  labels:
+    app: linnix
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: linnix-agent
+rules:
+  # Future: Allow Linnix to query Pods/Nodes for metadata enrichment
+  - apiGroups: [""]
+    resources: ["pods", "nodes"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: linnix-agent
+subjects:
+  - kind: ServiceAccount
+    name: linnix-agent
+    namespace: default
+roleRef:
+  kind: ClusterRole
+  name: linnix-agent
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
Enables deployment to Kubernetes clusters with production-ready manifests and AWS EKS support.

## Changes

### Kubernetes Manifests (`k8s/`)
- **[daemonset.yaml](cci:7://file:///home/parthshah/linnix-opensource/k8s/daemonset.yaml:0:0-0:0)**: Deploys cognitod to every node with:
  - `hostPID: true` for host process monitoring
  - Privileged mode for eBPF (CAP_BPF + CAP_PERFMON)
  - Resource limits (512Mi memory, 500m CPU)
  - Mounts for BTF ([/sys/kernel/btf/vmlinux](cci:7://file:///sys/kernel/btf/vmlinux:0:0-0:0)) and debugfs
- **[configmap.yaml](cci:7://file:///home/parthshah/linnix-opensource/k8s/configmap.yaml:0:0-0:0)**: Default config (monitor mode, reasoner disabled to save resources)
- **[rbac.yaml](cci:7://file:///home/parthshah/linnix-opensource/k8s/rbac.yaml:0:0-0:0)**: ServiceAccount + ClusterRole for future K8s API access

### Infrastructure (`infrastructure/`)
- **[eks-cluster.yaml](cci:7://file:///home/parthshah/linnix-opensource/infrastructure/eks-cluster.yaml:0:0-0:0)**: eksctl config for one-command EKS provisioning
  - 2x t3.medium nodes
  - Amazon Linux 2023 (Kernel 6.1+ with BTF)
  - VPC CNI, CoreDNS, kube-proxy addons

### Documentation
- **[k8s/README.md](cci:7://file:///home/parthshah/linnix-opensource/k8s/README.md:0:0-0:0)**: Deployment guide with eksctl quick-start
- **[README.md](cci:7://file:///home/parthshah/linnix-opensource/README.md:0:0-0:0)**: Added "Deploy to Kubernetes" section

## Testing

✅ **Local (kind)**
- Pod running (1/1)
- eBPF capturing Fork/Exec/Exit events

✅ **AWS EKS**
- Cluster: `linnix-demo` (us-east-1, K8s 1.30)
- Pods: 2/2 running across 2 nodes
- eBPF: Capturing events from host processes
- Cleanup: Verified (all resources deleted, $0 charges)

## Deployment

**Quick Start:**
```bash
# Local testing
kind create cluster
kubectl apply -f k8s/

# AWS EKS
eksctl create cluster -f infrastructure/eks-cluster.yaml
kubectl apply -f k8s/