### PR TITLE
Add K8s priority label ingestion and CLI display

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,5 +100,9 @@ docs/images/README.md
 !docs/AWS_EC2_DEPLOYMENT.md
 ROADMAP.md
 run_manual.sh
-docs/onboarding.md
-docs/onboarding.md
+run-cognitod-k8s.sh
+kind
+kubectl
+
+verification.yaml
+run-cognitod-k8s.sh

--- a/cognitod/src/context.rs
+++ b/cognitod/src/context.rs
@@ -109,7 +109,7 @@ impl ContextStore {
                 proc.event_type != 2
                     || proc
                         .exit_time()
-                        .is_none_or(|t| now - t < self.max_age.as_nanos() as u64)
+                        .is_none_or(|t| now.saturating_sub(t) < self.max_age.as_nanos() as u64)
             });
         }
 

--- a/cognitod/src/k8s.rs
+++ b/cognitod/src/k8s.rs
@@ -6,19 +6,14 @@ use std::sync::{Arc, RwLock};
 use std::time::Duration;
 use tokio::time::sleep;
 
-#[derive(Debug, Clone, Deserialize, serde::Serialize, PartialEq)]
+#[derive(Debug, Clone, Deserialize, serde::Serialize, PartialEq, Default)]
 #[serde(rename_all = "snake_case")]
 pub enum Priority {
     Critical,
     High,
+    #[default]
     Medium,
     Low,
-}
-
-impl Default for Priority {
-    fn default() -> Self {
-        Self::Medium
-    }
 }
 
 impl From<&str> for Priority {

--- a/linnix-cli/src/main.rs
+++ b/linnix-cli/src/main.rs
@@ -11,6 +11,7 @@ mod doctor;
 mod event;
 mod export;
 mod pretty;
+mod processes;
 mod sse;
 use alert::Alert;
 use event::ProcessEvent;
@@ -70,6 +71,8 @@ enum Command {
     },
     /// Check system health and connectivity
     Doctor,
+    /// List running processes with priority
+    Processes,
 }
 
 #[derive(clap::ValueEnum, Clone, Debug, serde::Serialize)]
@@ -130,6 +133,11 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     if let Some(Command::Doctor) = args.command {
         doctor::run_doctor(&args.url).await?;
+        return Ok(());
+    }
+
+    if let Some(Command::Processes) = args.command {
+        processes::run_processes(&client, &args.url).await?;
         return Ok(());
     }
 

--- a/linnix-cli/src/processes.rs
+++ b/linnix-cli/src/processes.rs
@@ -42,8 +42,8 @@ pub async fn run_processes(client: &Client, url: &str) -> Result<(), Box<dyn Err
         .await?;
 
     println!(
-        "{:<8} {:<8} {:<6} {:<6} {:<10} {}",
-        "PID", "PPID", "CPU%", "MEM%", "PRIORITY", "CMD"
+        "{:<8} {:<8} {:<6} {:<6} {:<10} CMD",
+        "PID", "PPID", "CPU%", "MEM%", "PRIORITY"
     );
 
     for p in processes {

--- a/linnix-cli/src/processes.rs
+++ b/linnix-cli/src/processes.rs
@@ -1,0 +1,80 @@
+use colored::*;
+use reqwest::Client;
+use serde::Deserialize;
+use std::error::Error;
+
+#[derive(Debug, Deserialize)]
+pub struct ProcessInfo {
+    pub pid: u32,
+    pub ppid: u32,
+    pub comm: String,
+    pub cpu_pct: Option<f32>,
+    pub mem_pct: Option<f32>,
+    pub priority: Option<Priority>,
+}
+
+#[derive(Debug, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum Priority {
+    Critical,
+    High,
+    Medium,
+    Low,
+}
+
+impl Priority {
+    fn color(&self) -> Color {
+        match self {
+            Self::Critical => Color::Red,
+            Self::High => Color::Yellow,
+            Self::Medium => Color::Green,
+            Self::Low => Color::Blue,
+        }
+    }
+}
+
+pub async fn run_processes(client: &Client, url: &str) -> Result<(), Box<dyn Error>> {
+    let processes: Vec<ProcessInfo> = client
+        .get(format!("{}/processes", url))
+        .send()
+        .await?
+        .json()
+        .await?;
+
+    println!(
+        "{:<8} {:<8} {:<6} {:<6} {:<10} {}",
+        "PID", "PPID", "CPU%", "MEM%", "PRIORITY", "CMD"
+    );
+
+    for p in processes {
+        let priority_str = match p.priority {
+            Some(ref prio) => format!("{:?}", prio).to_uppercase(),
+            None => "-".to_string(),
+        };
+
+        let priority_colored = if let Some(ref prio) = p.priority {
+            priority_str.color(prio.color())
+        } else {
+            priority_str.normal()
+        };
+
+        println!(
+            "{:<8} {:<8} {:<6} {:<6} {:<10} {}",
+            p.pid,
+            p.ppid,
+            format_pct(p.cpu_pct),
+            format_pct(p.mem_pct),
+            priority_colored,
+            p.comm
+        );
+    }
+
+    Ok(())
+}
+
+fn format_pct(opt: Option<f32>) -> String {
+    match opt {
+        Some(value) => format!("{:.1}", value),
+        None => "-".to_string(),
+    }
+}

--- a/test-k8s-priority.sh
+++ b/test-k8s-priority.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -e
+
+echo "Building linnix-cli..."
+cargo build -p linnix-cli
+
+echo "Verifying 'processes' command existence..."
+./target/debug/linnix-cli processes --help
+
+echo "✅ 'linnix-cli processes' command exists."
+echo ""
+echo "To verify full functionality:"
+echo "1. Run cognitod in a K8s cluster (or with KUBECONFIG set)."
+echo "2. Annotate a pod: kubectl annotate pod <pod> linnix.dev/priority=critical"
+echo "3. Run: ./target/debug/linnix-cli processes"
+echo "4. Verify the PRIORITY column shows 'CRITICAL'."


### PR DESCRIPTION
## Summary

Adds Kubernetes priority label ingestion and CLI display functionality. Cognitod now reads \`linnix.dev/priority\` and \`linnix.dev/slo-tier\` labels from pods and exposes this metadata via the API and CLI.

## Changes

### Core Features
- **K8s Integration** (\`cognitod/src/k8s.rs\`):
  - Added \`Priority\` enum (Critical/High/Medium/Low) with Medium as default
  - Extended \`K8sMetadata\` to include \`priority\` and \`slo_tier\` fields
  - Added support for local K8s connection via \`K8S_API_URL\`/\`K8S_TOKEN\` env vars
  - Pod watcher now extracts \`linnix.dev/priority\` and \`linnix.dev/slo-tier\` labels

- **API** (\`cognitod/src/api/mod.rs\`):
  - Added \`priority\` field to \`ProcessInfo\` response
  - Created \`ProcessInfo::from_event\` helper to centralize metadata enrichment

- **CLI** (\`linnix-cli/src/processes.rs\`):
  - New \`linnix-cli processes\` command
  - Color-coded priority display (Critical=Red, High=Yellow, Medium=Green, Low=Blue)

### Bug Fixes
- Fixed integer overflow in \`cognitod/src/context.rs:112\` using \`saturating_sub()\`

## Testing

✅ **E2E Verified** with local kind cluster:
- Deployed test pod with \`linnix.dev/priority=critical\` label
- Confirmed nginx processes show \`CRITICAL\` priority in CLI output
- Verified API returns full K8s metadata including priority and slo-tier

**Example Output:**
\`\`\`
PID      PPID     CPU%   MEM%   PRIORITY   CMD
355853   355798   0.0    0.0    CRITICAL   nginx
\`\`\`