### PR TITLE
PSI per-cgroup collection with delta tracking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -836,6 +836,7 @@ dependencies = [
  "tower",
  "tracing",
  "uuid",
+ "walkdir",
 ]
 
 [[package]]

--- a/cognitod/Cargo.toml
+++ b/cognitod/Cargo.toml
@@ -45,6 +45,7 @@ chrono = "0.4"
 tracing = "0.1"
 uuid = { version = "1.18.1", features = ["v4", "serde"] }
 sha2 = "0.10.9"
+walkdir = "2.5.0"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "time", "test-util"] }

--- a/cognitod/src/collectors/mod.rs
+++ b/cognitod/src/collectors/mod.rs
@@ -1,0 +1,1 @@
+pub mod psi;

--- a/cognitod/src/collectors/psi.rs
+++ b/cognitod/src/collectors/psi.rs
@@ -39,15 +39,14 @@ pub fn parse_psi_file(content: &str) -> Result<PsiSnapshot> {
         }
 
         for part in &parts[1..] {
-            if let Some((key, value)) = part.split_once('=') {
-                if key == "total" {
-                    if let Ok(v) = value.parse::<u64>() {
-                        if prefix == "some" {
-                            some_total = v;
-                        } else {
-                            full_total = v;
-                        }
-                    }
+            if let Some((key, value)) = part.split_once('=')
+                && key == "total"
+                && let Ok(v) = value.parse::<u64>()
+            {
+                if prefix == "some" {
+                    some_total = v;
+                } else {
+                    full_total = v;
                 }
             }
         }
@@ -64,7 +63,7 @@ fn find_psi_files(base_path: &Path) -> Vec<PathBuf> {
         .into_iter()
         .filter_map(|e| e.ok())
         .filter(|e| {
-            e.path().file_name().map_or(false, |n| n == "cpu.pressure")
+            e.path().file_name().is_some_and(|n| n == "cpu.pressure")
                 && e.path().to_string_lossy().contains("kubepods")
         })
         .map(|e| e.path().to_path_buf())
@@ -115,10 +114,7 @@ impl PsiMonitor {
                     let key = format!("{}/{}", meta.namespace, meta.pod_name);
 
                     // Get or create history for this pod
-                    let hist = self
-                        .history
-                        .entry(key.clone())
-                        .or_insert_with(VecDeque::new);
+                    let hist = self.history.entry(key.clone()).or_default();
 
                     // Calculate delta if we have previous snapshot
                     if let Some(prev) = hist.back() {

--- a/cognitod/src/collectors/psi.rs
+++ b/cognitod/src/collectors/psi.rs
@@ -1,0 +1,173 @@
+use anyhow::Result;
+use log::{debug, info};
+use std::collections::{HashMap, VecDeque};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::time::sleep;
+use walkdir::WalkDir;
+
+use crate::k8s::K8sContext;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct PsiSnapshot {
+    pub some_total: u64,
+    pub full_total: u64,
+}
+
+#[derive(Debug, Clone)]
+pub struct PsiDelta {
+    pub pod_name: String,
+    pub namespace: String,
+    pub delta_stall_us: u64,
+    pub timestamp: std::time::Instant,
+}
+
+pub fn parse_psi_file(content: &str) -> Result<PsiSnapshot> {
+    let mut some_total = 0u64;
+    let mut full_total = 0u64;
+
+    for line in content.lines() {
+        let parts: Vec<&str> = line.split_whitespace().collect();
+        if parts.is_empty() {
+            continue;
+        }
+
+        let prefix = parts[0];
+        if prefix != "some" && prefix != "full" {
+            continue;
+        }
+
+        for part in &parts[1..] {
+            if let Some((key, value)) = part.split_once('=') {
+                if key == "total" {
+                    if let Ok(v) = value.parse::<u64>() {
+                        if prefix == "some" {
+                            some_total = v;
+                        } else {
+                            full_total = v;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(PsiSnapshot {
+        some_total,
+        full_total,
+    })
+}
+
+fn find_psi_files(base_path: &Path) -> Vec<PathBuf> {
+    WalkDir::new(base_path)
+        .into_iter()
+        .filter_map(|e| e.ok())
+        .filter(|e| {
+            e.path().file_name().map_or(false, |n| n == "cpu.pressure")
+                && e.path().to_string_lossy().contains("kubepods")
+        })
+        .map(|e| e.path().to_path_buf())
+        .collect()
+}
+
+fn extract_container_id(cgroup_path: &Path) -> Option<String> {
+    let parent = cgroup_path.parent()?;
+    let dir_name = parent.file_name()?.to_string_lossy();
+    let clean = dir_name.trim_end_matches(".scope");
+    let id = clean
+        .rfind('-')
+        .map(|idx| &clean[idx + 1..])
+        .unwrap_or(clean);
+
+    (id.len() == 64).then(|| id.to_string())
+}
+
+const HISTORY_SIZE: usize = 10;
+
+pub struct PsiMonitor {
+    k8s_ctx: Arc<K8sContext>,
+    history: HashMap<String, VecDeque<PsiSnapshot>>,
+}
+
+impl PsiMonitor {
+    pub fn new(k8s_ctx: Arc<K8sContext>) -> Self {
+        Self {
+            k8s_ctx,
+            history: HashMap::new(),
+        }
+    }
+
+    pub async fn run(mut self) {
+        info!("[psi] starting PSI monitor");
+        let base_path = Path::new("/sys/fs/cgroup");
+
+        loop {
+            let psi_files = find_psi_files(base_path);
+            debug!("[psi] scanning {} cgroups", psi_files.len());
+
+            for path in psi_files {
+                if let Some(container_id) = extract_container_id(&path)
+                    && let Some(meta) = self.k8s_ctx.get_metadata(&container_id)
+                    && let Ok(content) = std::fs::read_to_string(&path)
+                    && let Ok(snapshot) = parse_psi_file(&content)
+                {
+                    let key = format!("{}/{}", meta.namespace, meta.pod_name);
+
+                    // Get or create history for this pod
+                    let hist = self
+                        .history
+                        .entry(key.clone())
+                        .or_insert_with(VecDeque::new);
+
+                    // Calculate delta if we have previous snapshot
+                    if let Some(prev) = hist.back() {
+                        let delta_stall = snapshot.some_total.saturating_sub(prev.some_total);
+                        if delta_stall > 0 {
+                            info!(
+                                "[psi] {}/{} delta_stall_us={}",
+                                meta.namespace, meta.pod_name, delta_stall
+                            );
+                        }
+                    }
+
+                    // Add new snapshot to history
+                    hist.push_back(snapshot);
+
+                    // Keep only last N snapshots
+                    if hist.len() > HISTORY_SIZE {
+                        hist.pop_front();
+                    }
+                }
+            }
+
+            sleep(Duration::from_secs(1)).await;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_psi_file() {
+        let content = "some avg10=0.00 avg60=0.00 avg300=0.00 total=123456\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=654321";
+        let snapshot = parse_psi_file(content).unwrap();
+
+        assert_eq!(snapshot.some_total, 123456);
+        assert_eq!(snapshot.full_total, 654321);
+    }
+
+    #[test]
+    fn test_extract_container_id() {
+        let path = Path::new(
+            "/sys/fs/cgroup/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod123.slice/cri-containerd-e4063920952d766348421832d2df465324397166164478852332152342342342.scope/cpu.pressure",
+        );
+        let id = extract_container_id(path).unwrap();
+        assert_eq!(
+            id,
+            "e4063920952d766348421832d2df465324397166164478852332152342342342"
+        );
+    }
+}

--- a/cognitod/src/k8s.rs
+++ b/cognitod/src/k8s.rs
@@ -215,14 +215,16 @@ impl K8sContext {
                 };
 
                 if id.len() == 64 {
-                    let map = self.container_map.read().unwrap();
-                    if let Some(meta) = map.get(id) {
-                        return Some(meta.clone());
-                    }
+                    return self.get_metadata(id);
                 }
             }
         }
         None
+    }
+
+    pub fn get_metadata(&self, container_id: &str) -> Option<K8sMetadata> {
+        let map = self.container_map.read().unwrap();
+        map.get(container_id).cloned()
     }
 }
 

--- a/cognitod/src/lib.rs
+++ b/cognitod/src/lib.rs
@@ -2,6 +2,7 @@
 // Both local stable and Docker stable support it without feature flags
 
 pub mod alerts;
+pub mod collectors;
 pub mod config;
 pub mod context;
 pub mod enforcement;

--- a/cognitod/src/main.rs
+++ b/cognitod/src/main.rs
@@ -774,6 +774,12 @@ async fn main() -> Result<(), Box<dyn Error>> {
             ctx.node_name
         );
         ctx.clone().start_watcher();
+
+        // Start PSI monitor
+        let psi_monitor = cognitod::collectors::psi::PsiMonitor::new(ctx.clone());
+        tokio::spawn(async move {
+            psi_monitor.run().await;
+        });
     } else {
         info!("[cognitod] K8s context not available (missing env/tokens)");
     }


### PR DESCRIPTION
Implements Sprint Block 1: PSI collection for per-pod stall detection.

**Changes:**
- Add PSI file discovery and parsing for kubepods cgroups
- Implement ring buffer with delta calculation between samples
- Integrate with K8sContext for pod metadata enrichment
- Spawn PsiMonitor task alongside K8s watcher

**Testing:**
E2E tested on kind cluster. stress-test pod shows 754ms stall with 2 CPU workers on 500m limit.

**Log output:**
```
[psi] scanning 39 cgroups
[psi] default/stress-test delta_stall_us=754716
```