### PR TITLE
PSI Attribution Model

### DIFF
--- a/cognitod-daemonset.yaml
+++ b/cognitod-daemonset.yaml
@@ -1,0 +1,77 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cognitod-sa
+  namespace: default
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cognitod-role
+rules:
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cognitod-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cognitod-role
+subjects:
+- kind: ServiceAccount
+  name: cognitod-sa
+  namespace: default
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: cognitod
+  namespace: default
+spec:
+  selector:
+    matchLabels:
+      app: cognitod
+  template:
+    metadata:
+      labels:
+        app: cognitod
+    spec:
+      hostPID: true
+      serviceAccountName: cognitod-sa
+      containers:
+      - name: cognitod
+        image: cognitod:latest
+        imagePullPolicy: Never
+        securityContext:
+          privileged: true
+        env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: RUST_LOG
+          value: "debug"
+        volumeMounts:
+        - name: sys
+          mountPath: /sys
+          readOnly: true
+        - name: proc
+          mountPath: /proc
+          readOnly: true
+        - name: cgroup
+          mountPath: /sys/fs/cgroup
+          readOnly: true
+      volumes:
+      - name: sys
+        hostPath:
+          path: /sys
+      - name: proc
+        hostPath:
+          path: /proc
+      - name: cgroup
+        hostPath:
+          path: /sys/fs/cgroup

--- a/cognitod/migrations/004_add_stall_attributions.sql
+++ b/cognitod/migrations/004_add_stall_attributions.sql
@@ -1,0 +1,21 @@
+-- Migration 004: Add stall_attributions table for PSI blame tracking
+
+CREATE TABLE IF NOT EXISTS stall_attributions (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    victim_pod TEXT NOT NULL,
+    victim_namespace TEXT NOT NULL,
+    offender_pod TEXT NOT NULL,
+    offender_namespace TEXT NOT NULL,
+    stall_us INTEGER NOT NULL,
+    blame_score REAL NOT NULL,
+    timestamp INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_victim_time 
+    ON stall_attributions(victim_pod, victim_namespace, timestamp);
+
+CREATE INDEX IF NOT EXISTS idx_offender_time 
+    ON stall_attributions(offender_pod, offender_namespace, timestamp);
+
+CREATE INDEX IF NOT EXISTS idx_timestamp 
+    ON stall_attributions(timestamp);

--- a/cognitod/src/collectors/psi.rs
+++ b/cognitod/src/collectors/psi.rs
@@ -39,15 +39,14 @@ pub fn parse_psi_file(content: &str) -> Result<PsiSnapshot> {
         }
 
         for part in &parts[1..] {
-            if let Some((key, value)) = part.split_once('=') {
-                if key == "total" {
-                    if let Ok(v) = value.parse::<u64>() {
-                        if prefix == "some" {
-                            some_total = v;
-                        } else {
-                            full_total = v;
-                        }
-                    }
+            if let Some((key, value)) = part.split_once('=')
+                && key == "total"
+                && let Ok(v) = value.parse::<u64>()
+            {
+                if prefix == "some" {
+                    some_total = v;
+                } else {
+                    full_total = v;
                 }
             }
         }
@@ -64,7 +63,7 @@ fn find_psi_files(base_path: &Path) -> Vec<PathBuf> {
         .into_iter()
         .filter_map(|e| e.ok())
         .filter(|e| {
-            e.path().file_name().map_or(false, |n| n == "cpu.pressure")
+            e.path().file_name().is_some_and(|n| n == "cpu.pressure")
                 && e.path().to_string_lossy().contains("kubepods")
         })
         .map(|e| e.path().to_path_buf())
@@ -115,10 +114,7 @@ impl PsiMonitor {
                     let key = format!("{}/{}", meta.namespace, meta.pod_name);
 
                     // Get or create history for this pod
-                    let hist = self
-                        .history
-                        .entry(key.clone())
-                        .or_insert_with(VecDeque::new);
+                    let hist = self.history.entry(key.clone()).or_default();
 
                     // Calculate delta if we have previous snapshot
                     if let Some(prev) = hist.back() {

--- a/cognitod/src/incidents.rs
+++ b/cognitod/src/incidents.rs
@@ -91,6 +91,19 @@ impl IncidentStore {
                 user_id TEXT
             );
             CREATE INDEX IF NOT EXISTS idx_feedback_insight_id ON feedback(insight_id);
+            CREATE TABLE IF NOT EXISTS stall_attributions (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                victim_pod TEXT NOT NULL,
+                victim_namespace TEXT NOT NULL,
+                offender_pod TEXT NOT NULL,
+                offender_namespace TEXT NOT NULL,
+                stall_us INTEGER NOT NULL,
+                blame_score REAL NOT NULL,
+                timestamp INTEGER NOT NULL
+            );
+            CREATE INDEX IF NOT EXISTS idx_victim_time ON stall_attributions(victim_pod, victim_namespace, timestamp);
+            CREATE INDEX IF NOT EXISTS idx_offender_time ON stall_attributions(offender_pod, offender_namespace, timestamp);
+            CREATE INDEX IF NOT EXISTS idx_timestamp_attr ON stall_attributions(timestamp);
             "#,
         )
         .execute(&pool)
@@ -174,6 +187,43 @@ impl IncidentStore {
 
         let id = result.last_insert_rowid();
         debug!("Inserted feedback #{} for insight {}", id, insight_id);
+        Ok(id)
+    }
+
+    /// Insert stall attribution event
+    pub async fn insert_stall_attribution(
+        &self,
+        victim_pod: &str,
+        victim_namespace: &str,
+        offender_pod: &str,
+        offender_namespace: &str,
+        stall_us: u64,
+        blame_score: f64,
+        timestamp: u64,
+    ) -> Result<i64, sqlx::Error> {
+        let result = sqlx::query(
+            r#"
+            INSERT INTO stall_attributions (
+                victim_pod, victim_namespace, offender_pod, offender_namespace,
+                stall_us, blame_score, timestamp
+            ) VALUES (?, ?, ?, ?, ?, ?, ?)
+            "#,
+        )
+        .bind(victim_pod)
+        .bind(victim_namespace)
+        .bind(offender_pod)
+        .bind(offender_namespace)
+        .bind(stall_us as i64)
+        .bind(blame_score)
+        .bind(timestamp as i64)
+        .execute(&self.pool)
+        .await?;
+
+        let id = result.last_insert_rowid();
+        debug!(
+            "Inserted stall attribution #{}: {}/{} blamed {}/{}",
+            id, victim_namespace, victim_pod, offender_namespace, offender_pod
+        );
         Ok(id)
     }
 

--- a/cognitod/src/incidents.rs
+++ b/cognitod/src/incidents.rs
@@ -44,6 +44,16 @@ pub struct Incident {
     pub psi_after: Option<f32>,
 }
 
+/// Represents a stall attribution event
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StallAttribution {
+    pub offender_pod: String,
+    pub offender_namespace: String,
+    pub stall_us: u64,
+    pub blame_score: f64,
+    pub timestamp: u64,
+}
+
 /// Incident storage backed by SQLite
 pub struct IncidentStore {
     pool: SqlitePool,
@@ -225,6 +235,45 @@ impl IncidentStore {
             id, victim_namespace, victim_pod, offender_namespace, offender_pod
         );
         Ok(id)
+    }
+
+    /// Query stall attributions for a victim pod within a time window
+    pub async fn query_attributions(
+        &self,
+        victim_pod: &str,
+        victim_namespace: &str,
+        window_seconds: i64,
+    ) -> Result<Vec<StallAttribution>, sqlx::Error> {
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs() as i64;
+        let start_time = now - window_seconds;
+
+        let rows = sqlx::query(
+            r#"
+            SELECT offender_pod, offender_namespace, stall_us, blame_score, timestamp
+            FROM stall_attributions
+            WHERE victim_pod = ? AND victim_namespace = ? AND timestamp >= ?
+            ORDER BY blame_score DESC
+            "#,
+        )
+        .bind(victim_pod)
+        .bind(victim_namespace)
+        .bind(start_time)
+        .fetch_all(&self.pool)
+        .await?;
+
+        Ok(rows
+            .into_iter()
+            .map(|r| StallAttribution {
+                offender_pod: r.get(0),
+                offender_namespace: r.get(1),
+                stall_us: r.get::<i64, _>(2) as u64,
+                blame_score: r.get(3),
+                timestamp: r.get::<i64, _>(4) as u64,
+            })
+            .collect())
     }
 
     /// Get incident by ID

--- a/cognitod/src/incidents.rs
+++ b/cognitod/src/incidents.rs
@@ -201,6 +201,7 @@ impl IncidentStore {
     }
 
     /// Insert stall attribution event
+    #[allow(clippy::too_many_arguments)]
     pub async fn insert_stall_attribution(
         &self,
         victim_pod: &str,

--- a/cognitod/src/main.rs
+++ b/cognitod/src/main.rs
@@ -776,7 +776,11 @@ async fn main() -> Result<(), Box<dyn Error>> {
         ctx.clone().start_watcher();
 
         // Start PSI monitor
-        let psi_monitor = cognitod::collectors::psi::PsiMonitor::new(ctx.clone(), context.clone());
+        let psi_monitor = cognitod::collectors::psi::PsiMonitor::new(
+            ctx.clone(),
+            context.clone(),
+            incident_store.clone(),
+        );
         tokio::spawn(async move {
             psi_monitor.run().await;
         });

--- a/cognitod/src/main.rs
+++ b/cognitod/src/main.rs
@@ -776,7 +776,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         ctx.clone().start_watcher();
 
         // Start PSI monitor
-        let psi_monitor = cognitod::collectors::psi::PsiMonitor::new(ctx.clone());
+        let psi_monitor = cognitod::collectors::psi::PsiMonitor::new(ctx.clone(), context.clone());
         tokio::spawn(async move {
             psi_monitor.run().await;
         });

--- a/cpu-hog-pod.yaml
+++ b/cpu-hog-pod.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: cpu-hog
+  labels:
+    app: cpu-hog
+spec:
+  containers:
+  - name: stress
+    image: polinux/stress
+    command: ["stress"]
+    args: ["--cpu", "4", "--timeout", "300s"]
+    resources:
+      limits:
+        cpu: "1000m"
+      requests:
+        cpu: "1000m"

--- a/stress-pod.yaml
+++ b/stress-pod.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: stress-test
+  labels:
+    app: stress-test
+spec:
+  containers:
+  - name: stress
+    image: polinux/stress
+    command: ["stress"]
+    args: ["--cpu", "2", "--timeout", "120s"]
+    resources:
+      limits:
+        cpu: "500m"
+      requests:
+        cpu: "500m"


### PR DESCRIPTION
## Sprint Block 2: PSI Attribution Model

### Overview
Implements a complete PSI-based noisy neighbor attribution system to identify which pods cause resource stalls to others.

### Key Changes
*   **Stall Correlation**: Correlates PSI stalls (>100ms) with concurrent CPU consumers using `ContextStore`.
*   **Blame Scoring**: Implements scoring algorithm: `cpu_share * stall_magnitude`.
*   **Persistence**: Adds `stall_attributions` SQLite table with indexes on victim/offender/timestamp.
*   **API**: Adds `GET /attribution` endpoint to query historical blame data.

### Implementation Details
*   [cognitod/src/collectors/psi.rs](cci:7://file:///home/parthshah/linnix-opensource/cognitod/src/collectors/psi.rs:0:0-0:0): Added [StallEvent](cci:2://file:///home/parthshah/linnix-opensource/cognitod/src/collectors/psi.rs:34:0-40:1) struct and blame calculation logic.
*   [cognitod/src/incidents.rs](cci:7://file:///home/parthshah/linnix-opensource/cognitod/src/incidents.rs:0:0-0:0): Added schema migration and [insert_stall_attribution](cci:1://file:///home/parthshah/linnix-opensource/cognitod/src/incidents.rs:202:4-237:5)/[query_attributions](cci:1://file:///home/parthshah/linnix-opensource/cognitod/src/incidents.rs:239:4-276:5) methods.
*   [cognitod/src/api/mod.rs](cci:7://file:///home/parthshah/linnix-opensource/cognitod/src/api/mod.rs:0:0-0:0): Exposed data via new API route.

### API Usage
```bash
curl "http://localhost:3000/attribution?pod=api-server&namespace=default&window=5"
```
Verification
✅ E2E Tested on kind cluster:

PSI monitoring active (39 cgroups scanned/sec).
Stall detection verified with stress-ng (600ms+ stalls detected).
Database persistence confirmed via schema checks.
API endpoint returns 200 OK.