### PR TITLE
Enhance pressure attribution with fork metrics and configurable…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,6 @@ kubectl
 
 verification.yaml
 run-cognitod-k8s.sh
+scripts/full_test_suite.sh
+scripts/generate_wiki.sh
+scripts/validate_api_docs.sh

--- a/cognitod/migrations/005_add_attribution_details.sql
+++ b/cognitod/migrations/005_add_attribution_details.sql
@@ -1,0 +1,4 @@
+-- Add detailed attribution metrics
+ALTER TABLE stall_attributions ADD COLUMN cpu_share REAL DEFAULT 0.0;
+ALTER TABLE stall_attributions ADD COLUMN fork_count INTEGER DEFAULT 0;
+ALTER TABLE stall_attributions ADD COLUMN short_job_count INTEGER DEFAULT 0;

--- a/cognitod/src/api/mod.rs
+++ b/cognitod/src/api/mod.rs
@@ -2116,7 +2116,7 @@ mod tests {
     #[tokio::test]
     async fn heartbeats_emit_every_10s() {
         tokio::time::pause();
-        let ctx = Arc::new(ContextStore::new(Duration::from_secs(60), 10));
+        let ctx = Arc::new(ContextStore::new(Duration::from_secs(60), 10, None));
         let _metrics = Arc::new(Metrics::new());
         let rx = ctx.broadcaster().subscribe();
 
@@ -2139,7 +2139,7 @@ mod tests {
 
     #[tokio::test]
     async fn drops_are_counted() {
-        let ctx = Arc::new(ContextStore::new(Duration::from_secs(60), 100));
+        let ctx = Arc::new(ContextStore::new(Duration::from_secs(60), 100, None));
         let metrics = Arc::new(Metrics::new());
         let rx = ctx.broadcaster().subscribe();
         let metrics_clone = metrics.clone();
@@ -2184,7 +2184,7 @@ mod tests {
 
     #[tokio::test]
     async fn status_keys_present() {
-        let ctx = Arc::new(ContextStore::new(Duration::from_secs(60), 10));
+        let ctx = Arc::new(ContextStore::new(Duration::from_secs(60), 10, None));
         let metrics = Arc::new(Metrics::new());
         let app_state = Arc::new(AppState {
             context: Arc::clone(&ctx),
@@ -2227,7 +2227,7 @@ mod tests {
 
     #[tokio::test]
     async fn metrics_includes_probe_state() {
-        let ctx = Arc::new(ContextStore::new(Duration::from_secs(60), 10));
+        let ctx = Arc::new(ContextStore::new(Duration::from_secs(60), 10, None));
         let metrics = Arc::new(Metrics::new());
         metrics.set_rss_probe_mode(RssProbeMode::CoreMm.metric_value());
         metrics.set_kernel_btf_available(true);
@@ -2263,7 +2263,7 @@ mod tests {
 
     #[tokio::test]
     async fn prometheus_endpoint_respects_flag() {
-        let ctx = Arc::new(ContextStore::new(Duration::from_secs(60), 10));
+        let ctx = Arc::new(ContextStore::new(Duration::from_secs(60), 10, None));
         let metrics = Arc::new(Metrics::new());
         let app_state = Arc::new(AppState {
             context: Arc::clone(&ctx),
@@ -2296,7 +2296,7 @@ mod tests {
 
     #[tokio::test]
     async fn prometheus_endpoint_returns_metrics_when_enabled() {
-        let ctx = Arc::new(ContextStore::new(Duration::from_secs(60), 10));
+        let ctx = Arc::new(ContextStore::new(Duration::from_secs(60), 10, None));
         let metrics = Arc::new(Metrics::new());
         metrics.events_total.fetch_add(42, Ordering::Relaxed);
         let app_state = Arc::new(AppState {
@@ -2345,7 +2345,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_no_auth_allows_requests() {
-        let ctx = Arc::new(ContextStore::new(Duration::from_secs(60), 10));
+        let ctx = Arc::new(ContextStore::new(Duration::from_secs(60), 10, None));
         let metrics = Arc::new(Metrics::new());
         let app_state = Arc::new(AppState {
             context: Arc::clone(&ctx),
@@ -2378,7 +2378,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_auth_required_when_token_set() {
-        let ctx = Arc::new(ContextStore::new(Duration::from_secs(60), 10));
+        let ctx = Arc::new(ContextStore::new(Duration::from_secs(60), 10, None));
         let metrics = Arc::new(Metrics::new());
         let app_state = Arc::new(AppState {
             context: Arc::clone(&ctx),
@@ -2411,7 +2411,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_auth_with_valid_bearer_token() {
-        let ctx = Arc::new(ContextStore::new(Duration::from_secs(60), 10));
+        let ctx = Arc::new(ContextStore::new(Duration::from_secs(60), 10, None));
         let metrics = Arc::new(Metrics::new());
         let app_state = Arc::new(AppState {
             context: Arc::clone(&ctx),
@@ -2445,7 +2445,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_auth_with_invalid_token() {
-        let ctx = Arc::new(ContextStore::new(Duration::from_secs(60), 10));
+        let ctx = Arc::new(ContextStore::new(Duration::from_secs(60), 10, None));
         let metrics = Arc::new(Metrics::new());
         let app_state = Arc::new(AppState {
             context: Arc::clone(&ctx),
@@ -2479,7 +2479,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_auth_with_malformed_header() {
-        let ctx = Arc::new(ContextStore::new(Duration::from_secs(60), 10));
+        let ctx = Arc::new(ContextStore::new(Duration::from_secs(60), 10, None));
         let metrics = Arc::new(Metrics::new());
         let app_state = Arc::new(AppState {
             context: Arc::clone(&ctx),

--- a/cognitod/src/collectors/psi.rs
+++ b/cognitod/src/collectors/psi.rs
@@ -328,12 +328,12 @@ impl PsiMonitor {
             let key = format!("{}/{}", c.namespace, c.pod);
             offenders.insert(key, (c.namespace.clone(), c.pod.clone()));
         }
-        for (key, _) in &event.fork_counts {
+        for key in event.fork_counts.keys() {
             if let Some((ns, pod)) = key.split_once('/') {
                 offenders.insert(key.clone(), (ns.to_string(), pod.to_string()));
             }
         }
-        for (key, _) in &event.short_job_counts {
+        for key in event.short_job_counts.keys() {
             if let Some((ns, pod)) = key.split_once('/') {
                 offenders.insert(key.clone(), (ns.to_string(), pod.to_string()));
             }

--- a/cognitod/src/collectors/psi.rs
+++ b/cognitod/src/collectors/psi.rs
@@ -38,6 +38,8 @@ pub struct StallEvent {
     pub stall_delta_us: u64,
     pub timestamp: Instant,
     pub concurrent_consumers: Vec<CpuConsumer>,
+    pub fork_counts: HashMap<String, u64>,
+    pub short_job_counts: HashMap<String, u64>,
 }
 
 #[derive(Debug, Clone)]
@@ -49,6 +51,9 @@ pub struct BlameAttribution {
     pub blame_score: f64,
     pub stall_us: u64,
     pub timestamp: u64,
+    pub cpu_share: f64,
+    pub fork_count: u64,
+    pub short_job_count: u64,
 }
 
 pub fn parse_psi_file(content: &str) -> Result<PsiSnapshot> {
@@ -118,6 +123,8 @@ pub struct PsiMonitor {
     context: Arc<ContextStore>,
     incident_store: Option<Arc<crate::incidents::IncidentStore>>,
     history: HashMap<String, VecDeque<PsiSnapshot>>,
+    pressure_start_time: HashMap<String, Instant>,
+    sustained_pressure_duration: Duration,
 }
 
 impl PsiMonitor {
@@ -125,12 +132,15 @@ impl PsiMonitor {
         k8s_ctx: Arc<K8sContext>,
         context: Arc<ContextStore>,
         incident_store: Option<Arc<crate::incidents::IncidentStore>>,
+        sustained_pressure_seconds: u64,
     ) -> Self {
         Self {
             k8s_ctx,
             context,
             incident_store,
             history: HashMap::new(),
+            pressure_start_time: HashMap::new(),
+            sustained_pressure_duration: Duration::from_secs(sustained_pressure_seconds),
         }
     }
 
@@ -175,59 +185,98 @@ impl PsiMonitor {
                             meta.namespace, meta.pod_name, delta_stall
                         );
 
-                        // If stall exceeds threshold, collect CPU consumers
+                        // If stall exceeds threshold, check for sustained pressure
                         if delta_stall >= STALL_THRESHOLD_US {
-                            let consumers = self.get_concurrent_cpu_consumers();
-                            let stall_event = StallEvent {
-                                victim_pod: meta.pod_name.clone(),
-                                victim_namespace: meta.namespace.clone(),
-                                stall_delta_us: delta_stall,
-                                timestamp: Instant::now(),
-                                concurrent_consumers: consumers.clone(),
-                            };
+                            let now = Instant::now();
+                            let start_time =
+                                *self.pressure_start_time.entry(key.clone()).or_insert(now);
 
-                            info!(
-                                "[psi] StallEvent: {}/{} stalled {}us with {} concurrent consumers",
-                                stall_event.victim_namespace,
-                                stall_event.victim_pod,
-                                stall_event.stall_delta_us,
-                                consumers.len()
-                            );
-
-                            // Calculate blame attributions
-                            let attributions = self.calculate_blame_attributions(&stall_event);
-
-                            // Log top 3 attributions
-                            for (i, attr) in attributions.iter().take(3).enumerate() {
+                            // Check if pressure is sustained for > configured duration
+                            if now.duration_since(start_time) >= self.sustained_pressure_duration {
                                 info!(
-                                    "[psi]   blame {}: {}/{} score={:.3} cpu_share",
-                                    i + 1,
-                                    attr.offender_namespace,
-                                    attr.offender_pod,
-                                    attr.blame_score
+                                    "[psi] Sustained pressure detected for {}/{} (>{:?})",
+                                    meta.namespace, meta.pod_name, self.sustained_pressure_duration
                                 );
-                            }
 
-                            // Persist to database if available
-                            if let Some(ref store) = self.incident_store {
-                                for attr in &attributions {
-                                    if let Err(e) = store
-                                        .insert_stall_attribution(
-                                            &attr.victim_pod,
-                                            &attr.victim_namespace,
-                                            &attr.offender_pod,
-                                            &attr.offender_namespace,
-                                            attr.stall_us,
-                                            attr.blame_score,
-                                            attr.timestamp,
-                                        )
-                                        .await
-                                    {
-                                        debug!("[psi] Failed to persist attribution: {}", e);
+                                // Collect metrics
+                                let consumers = self.get_concurrent_cpu_consumers();
+                                let (fork_counts, short_job_counts) =
+                                    self.context.get_pod_activity_window(
+                                        self.sustained_pressure_duration,
+                                        &self.k8s_ctx,
+                                    );
+
+                                let stall_event = StallEvent {
+                                    victim_pod: meta.pod_name.clone(),
+                                    victim_namespace: meta.namespace.clone(),
+                                    stall_delta_us: delta_stall,
+                                    timestamp: now,
+                                    concurrent_consumers: consumers.clone(),
+                                    fork_counts,
+                                    short_job_counts,
+                                };
+
+                                info!(
+                                    "[psi] StallEvent: {}/{} stalled {}us with {} concurrent consumers",
+                                    stall_event.victim_namespace,
+                                    stall_event.victim_pod,
+                                    stall_event.stall_delta_us,
+                                    consumers.len()
+                                );
+
+                                // Calculate blame attributions
+                                let attributions = self.calculate_blame_attributions(&stall_event);
+
+                                // Log top 3 attributions
+                                for (i, attr) in attributions.iter().take(3).enumerate() {
+                                    info!(
+                                        "[psi]   blame {}: {}/{} score={:.3} (cpu={:.2}, forks={}, short={})",
+                                        i + 1,
+                                        attr.offender_namespace,
+                                        attr.offender_pod,
+                                        attr.blame_score,
+                                        attr.cpu_share,
+                                        attr.fork_count,
+                                        attr.short_job_count
+                                    );
+                                }
+
+                                // Persist to database if available
+                                if let Some(ref store) = self.incident_store {
+                                    for attr in &attributions {
+                                        if let Err(e) = store
+                                            .insert_stall_attribution(
+                                                &attr.victim_pod,
+                                                &attr.victim_namespace,
+                                                &attr.offender_pod,
+                                                &attr.offender_namespace,
+                                                attr.stall_us,
+                                                attr.blame_score,
+                                                attr.timestamp,
+                                                attr.cpu_share,
+                                                attr.fork_count,
+                                                attr.short_job_count,
+                                            )
+                                            .await
+                                        {
+                                            debug!("[psi] Failed to persist attribution: {}", e);
+                                        }
                                     }
                                 }
+
+                                // Reset start time to avoid spamming every second after 15s
+                                // Or keep it to report continuous pressure?
+                                // Let's reset to require another 15s block, or just update start time?
+                                // For now, let's just update start time to now to report every 15s if it continues.
+                                self.pressure_start_time.insert(key.clone(), now);
                             }
+                        } else {
+                            // Pressure dropped, reset timer
+                            self.pressure_start_time.remove(&key);
                         }
+                    } else {
+                        // No pressure, reset timer
+                        self.pressure_start_time.remove(&key);
                     }
                 }
             }
@@ -269,34 +318,93 @@ impl PsiMonitor {
             .map(|c| c.cpu_percent)
             .sum();
 
-        if total_cpu == 0.0 {
-            return Vec::new();
-        }
-
         let timestamp = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap()
             .as_secs();
 
-        event
-            .concurrent_consumers
-            .iter()
-            .map(|consumer| {
-                // Blame score: normalized CPU share weighted by stall magnitude
-                let cpu_share = (consumer.cpu_percent / total_cpu) as f64;
-                let blame_score = cpu_share * (event.stall_delta_us as f64 / 1_000_000.0); // normalize to seconds
+        // Collect all potential offenders (CPU consumers + forkers + short-job creators)
+        let mut offenders: HashMap<String, (String, String)> = HashMap::new(); // key -> (ns, pod)
 
-                BlameAttribution {
+        for c in &event.concurrent_consumers {
+            let key = format!("{}/{}", c.namespace, c.pod);
+            offenders.insert(key, (c.namespace.clone(), c.pod.clone()));
+        }
+        for (key, _) in &event.fork_counts {
+            if let Some((ns, pod)) = key.split_once('/') {
+                offenders.insert(key.clone(), (ns.to_string(), pod.to_string()));
+            }
+        }
+        for (key, _) in &event.short_job_counts {
+            if let Some((ns, pod)) = key.split_once('/') {
+                offenders.insert(key.clone(), (ns.to_string(), pod.to_string()));
+            }
+        }
+
+        let mut attributions = Vec::new();
+
+        for (key, (ns, pod)) in offenders {
+            // CPU Share
+            let cpu_percent = event
+                .concurrent_consumers
+                .iter()
+                .find(|c| c.namespace == ns && c.pod == pod)
+                .map(|c| c.cpu_percent)
+                .unwrap_or(0.0);
+
+            let cpu_share = if total_cpu > 0.0 {
+                (cpu_percent / total_cpu) as f64
+            } else {
+                0.0
+            };
+
+            // Fork Count
+            let fork_count = *event.fork_counts.get(&key).unwrap_or(&0);
+
+            // Short Job Count
+            let short_job_count = *event.short_job_counts.get(&key).unwrap_or(&0);
+
+            // Blame Score Calculation
+            // Weighted sum of normalized factors.
+            // CPU is primary, but forks/short-jobs indicate "bad behavior"
+            // Heuristic:
+            // - CPU share is 0.0-1.0
+            // - Forks: >100/15s is high. Normalize by 100?
+            // - Short Jobs: >50/15s is high. Normalize by 50?
+
+            let fork_score = (fork_count as f64 / 100.0).min(1.0);
+            let short_job_score = (short_job_count as f64 / 50.0).min(1.0);
+
+            // Composite score
+            let raw_score = cpu_share + fork_score + short_job_score;
+
+            // Weight by stall magnitude (in seconds)
+            let blame_score = raw_score * (event.stall_delta_us as f64 / 1_000_000.0);
+
+            if blame_score > 0.0 {
+                attributions.push(BlameAttribution {
                     victim_pod: event.victim_pod.clone(),
                     victim_namespace: event.victim_namespace.clone(),
-                    offender_pod: consumer.pod.clone(),
-                    offender_namespace: consumer.namespace.clone(),
+                    offender_pod: pod,
+                    offender_namespace: ns,
                     blame_score,
                     stall_us: event.stall_delta_us,
                     timestamp,
-                }
-            })
-            .collect()
+                    cpu_share,
+                    fork_count,
+                    short_job_count,
+                });
+            }
+        }
+
+        // Sort by blame score descending
+        attributions.sort_by(|a, b| {
+            b.blame_score
+                .partial_cmp(&a.blame_score)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
+
+        attributions
     }
 }
 
@@ -323,5 +431,77 @@ mod tests {
             id,
             "e4063920952d766348421832d2df465324397166164478852332152342342342"
         );
+    }
+
+    #[test]
+    fn test_calculate_blame_attributions_with_forks() {
+        // Set env vars to force K8sContext creation
+        unsafe {
+            std::env::set_var("K8S_API_URL", "http://localhost:8001");
+            std::env::set_var("K8S_TOKEN", "dummy");
+        }
+
+        let monitor = PsiMonitor::new(
+            K8sContext::new().expect("Failed to create K8sContext"),
+            Arc::new(ContextStore::new(Duration::from_secs(60), 1000)),
+            None,
+            15,
+        );
+
+        let mut fork_counts = HashMap::new();
+        fork_counts.insert("default/fork-bomb".to_string(), 200);
+
+        let mut short_job_counts = HashMap::new();
+        short_job_counts.insert("default/short-job-pod".to_string(), 100);
+
+        let event = StallEvent {
+            victim_pod: "victim".to_string(),
+            victim_namespace: "default".to_string(),
+            stall_delta_us: 1_000_000, // 1 second stall
+            timestamp: Instant::now(),
+            concurrent_consumers: vec![
+                CpuConsumer {
+                    pod: "cpu-hog".to_string(),
+                    namespace: "default".to_string(),
+                    cpu_percent: 50.0,
+                },
+                CpuConsumer {
+                    pod: "fork-bomb".to_string(),
+                    namespace: "default".to_string(),
+                    cpu_percent: 10.0,
+                },
+            ],
+            fork_counts,
+            short_job_counts,
+        };
+
+        let attributions = monitor.calculate_blame_attributions(&event);
+
+        // We expect 3 offenders: cpu-hog, fork-bomb, short-job-pod
+        assert_eq!(attributions.len(), 3);
+
+        // Verify fork-bomb score
+        // CPU share: 10/60 = 0.166
+        // Fork score: 200/100 = 2.0 -> capped at 1.0
+        // Total raw: 1.166
+        // Blame: 1.166 * 1.0 = 1.166
+        let fork_attr = attributions
+            .iter()
+            .find(|a| a.offender_pod == "fork-bomb")
+            .unwrap();
+        assert!(fork_attr.blame_score > 1.0);
+        assert_eq!(fork_attr.fork_count, 200);
+
+        // Verify short-job-pod score
+        // CPU share: 0
+        // Short job score: 100/50 = 2.0 -> capped at 1.0
+        // Total raw: 1.0
+        // Blame: 1.0 * 1.0 = 1.0
+        let short_attr = attributions
+            .iter()
+            .find(|a| a.offender_pod == "short-job-pod")
+            .unwrap();
+        assert!((short_attr.blame_score - 1.0).abs() < 0.001);
+        assert_eq!(short_attr.short_job_count, 100);
     }
 }

--- a/cognitod/src/config.rs
+++ b/cognitod/src/config.rs
@@ -81,6 +81,8 @@ pub struct Config {
     pub noise_budget: NoiseBudgetConfig,
     #[serde(default)]
     pub privacy: PrivacyConfig,
+    #[serde(default)]
+    pub psi: PsiConfig,
 }
 
 #[derive(Debug, Deserialize, Clone)]
@@ -310,6 +312,25 @@ impl OfflineGuard {
             true
         }
     }
+}
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct PsiConfig {
+    /// Duration in seconds of sustained pressure required to trigger attribution
+    #[serde(default = "default_psi_sustained_pressure_seconds")]
+    pub sustained_pressure_seconds: u64,
+}
+
+impl Default for PsiConfig {
+    fn default() -> Self {
+        Self {
+            sustained_pressure_seconds: default_psi_sustained_pressure_seconds(),
+        }
+    }
+}
+
+fn default_psi_sustained_pressure_seconds() -> u64 {
+    15
 }
 
 #[derive(Debug, Deserialize, Clone, Default)]

--- a/cognitod/src/main.rs
+++ b/cognitod/src/main.rs
@@ -780,6 +780,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
             ctx.clone(),
             context.clone(),
             incident_store.clone(),
+            config.psi.sustained_pressure_seconds,
         );
         tokio::spawn(async move {
             psi_monitor.run().await;

--- a/cognitod/src/main.rs
+++ b/cognitod/src/main.rs
@@ -524,7 +524,22 @@ async fn main() -> Result<(), Box<dyn Error>> {
         );
     }
 
-    let context = Arc::new(context::ContextStore::new(Duration::from_secs(300), 1000));
+    let k8s_context = cognitod::k8s::K8sContext::new();
+    if let Some(ctx) = &k8s_context {
+        info!(
+            "[cognitod] K8s context initialized (node: {})",
+            ctx.node_name
+        );
+        ctx.clone().start_watcher();
+    } else {
+        info!("[cognitod] K8s context not available (missing env/tokens)");
+    }
+
+    let context = Arc::new(context::ContextStore::new(
+        Duration::from_secs(300),
+        1000,
+        k8s_context.clone(),
+    ));
     let insight_store = {
         let path = config.logging.insights_file.trim();
         let path = if path.is_empty() {
@@ -767,15 +782,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     // KB Index removed (YAGNI cleanup)
 
-    let k8s_context = cognitod::k8s::K8sContext::new();
+    // Start PSI monitor (after incident store is ready)
     if let Some(ctx) = &k8s_context {
-        info!(
-            "[cognitod] K8s context initialized (node: {})",
-            ctx.node_name
-        );
-        ctx.clone().start_watcher();
-
-        // Start PSI monitor
         let psi_monitor = cognitod::collectors::psi::PsiMonitor::new(
             ctx.clone(),
             context.clone(),
@@ -785,8 +793,6 @@ async fn main() -> Result<(), Box<dyn Error>> {
         tokio::spawn(async move {
             psi_monitor.run().await;
         });
-    } else {
-        info!("[cognitod] K8s context not available (missing env/tokens)");
     }
 
     // Initialize Slack Notifier

--- a/configs/linnix.toml
+++ b/configs/linnix.toml
@@ -41,3 +41,7 @@ enabled = true
 #     "mailto://user:pass@smtp.gmail.com"
 # ]
 # min_severity = "medium"  # Options: info, low, medium, high (default: info)
+
+[psi]
+# Duration in seconds of sustained pressure required to trigger attribution
+sustained_pressure_seconds = 15


### PR DESCRIPTION
## Summary
This PR enhances the pressure attribution logic to better identify workloads that cause system pressure through rapid process churn (forks/short-lived jobs) in addition to high CPU usage. It also makes the sustained pressure duration configurable.

## Changes
- **Sustained Pressure Detection**: Added logic to detect pressure sustained for a configurable duration (default 15s).
- **New Metrics**: Now tracks `fork_count` and `short_job_count` per pod during pressure events.
- **Attribution Logic**: Updated blame score calculation to include CPU share, fork rate, and short-job rate.
- **Database**: Added `cpu_share`, `fork_count`, and `short_job_count` columns to `stall_attributions` table.
- **API**: Exposed new metrics via the `/attribution` endpoint.
- **Configuration**: Added `[psi] sustained_pressure_seconds` to [linnix.toml](cci:7://file:///home/parthshah/linnix-opensource/configs/linnix.toml:0:0-0:0).

## Verification
- **Unit Tests**: Added tests for new attribution logic and config parsing.
- **Manual Verification**: Verified in a local Kind cluster using `stress-ng` to simulate CPU hogs and fork bombs. Confirmed that the API returns the new metrics and identifies the offenders correctly.