### PR TITLE
doc: fix formatting in architecture documentation

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -11,11 +11,11 @@ graph TD
         P -->|Metrics| M[eBPF Maps]
     end
 
-    subgraph User Space [Linnix Agent (Cognitod)]
+    subgraph User Space ["Linnix Agent (Cognitod)"]
         RB -->|Read| I[Ingestor]
         I -->|Process| A[Analyzer]
         A -->|Store| DB[(SQLite Incidents)]
-        A -->|Analyze| LLM[Local LLM (3B)]
+        A -->|Analyze| LLM["Local LLM (3B)"]
         LLM -->|Insight| A
         A -->|Alert| N[Notifier]
     end


### PR DESCRIPTION
Fixed marmaid diagram where `()` are misinterpreted

## Summary
Explain what the PR changes and why.

## Testing
- [ ] `make test`
- [ ] Additional commands (list):

## Checklist
- [ ] Updated docs or comments if behavior changed
- [ ] Added tests or explained why they are not needed
- [ ] Linked related issues or design docs
- [ ] Checked for licensing or security implications
