### PR TITLE
ci: skip Docker push on fork PRs

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -61,7 +61,7 @@ jobs:
           # TODO: ARM64 support blocked by bpf-linker LLVM issues in QEMU
           # See: https://github.com/aya-rs/bpf-linker/issues
           platforms: linux/amd64
-          push: true
+          push: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork != true }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
@@ -112,7 +112,7 @@ jobs:
           context: ./docker/llama-cpp
           file: ./docker/llama-cpp/Dockerfile
           platforms: linux/amd64,linux/arm64
-          push: true
+          push: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork != true }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha


### PR DESCRIPTION
Fixes permission error when fork PRs try to push Docker images to ghcr.io.

Changes `push: true` to a conditional expression that only pushes when:
- Event is not a pull_request, OR
- PR is from the same repo (not a fork)

This allows fork PRs to build and test without failing on the push step.