### PR TITLE
chore: remove command not longer available

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test release
+.PHONY: test
 
 test:
 	RUSTFLAGS="-D warnings" cargo nextest run --workspace --profile default
@@ -6,6 +6,3 @@ test:
 	cargo fmt --all -- --check
 	cargo clippy --all-targets --all-features -- -D warnings
 	cargo deny check
-
-release:
-	./scripts/release.sh


### PR DESCRIPTION
## Summary
The Makefile include a `release` command that is suppose to invoke the release.sh script that is not longer available as removed as part of https://github.com/linnix-os/linnix/commit/a815b7c2f65324a30af462eb998e9c4ef79189e8 

## Testing
- [x] `make test`
- [ ] Additional commands (list):

## Checklist
- [x] Updated docs or comments if behavior changed
- [ ] Added tests or explained why they are not needed
- [ ] Linked related issues or design docs
- [ ] Checked for licensing or security implications
