### PR TITLE
feat(claw): wire BPF mandate enforcement, LSM receipts, PSI detectors

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -28,9 +28,8 @@ CHANGELOG.md
 .github/
 .gitlab-ci.yml
 
-# Testing
-tests/
-**/tests/
+# Testing (top-level only; crate tests/ dirs needed for Cargo.toml [[test]])
+/tests/
 *.test
 
 # Enterprise/Training artifacts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,9 @@ jobs:
         with:
           tool: nextest
       - name: Run unit tests
-        run: cargo nextest run --workspace --profile default
+        run: cargo nextest run --workspace --profile default -E 'not binary(bdd_spend)'
+      - name: Run BDD tests (Cucumber)
+        run: cargo test --test bdd_spend
 
   test-e2e:
     runs-on: ubuntu-latest
@@ -39,7 +41,7 @@ jobs:
         with:
           tool: nextest
       - name: Run end-to-end tests
-        run: cargo nextest run --workspace --profile e2e --config-file nextest.toml
+        run: cargo nextest run --workspace --profile e2e --config-file nextest.toml -E 'not binary(bdd_spend)'
 
   lint-audit:
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -525,6 +525,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
 name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -783,6 +789,7 @@ dependencies = [
  "anstyle",
  "clap_lex",
  "strsim",
+ "terminal_size",
 ]
 
 [[package]]
@@ -791,7 +798,7 @@ version = "4.5.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a0b5487afeab2deb2ff4e03a807ad1a03ac532ff5a2cee5d86884440c7f7671"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.108",
@@ -812,6 +819,7 @@ dependencies = [
  "axum",
  "aya",
  "aya-log",
+ "base64 0.22.1",
  "bindgen",
  "btf",
  "bytes",
@@ -819,12 +827,19 @@ dependencies = [
  "chrono",
  "clap",
  "ctrlc",
+ "cucumber",
  "dashmap",
+ "ed25519-dalek",
  "env_logger",
  "flate2",
+ "futures",
  "futures-util",
+ "hex",
+ "hkdf",
+ "hmac",
  "hyper 1.7.0",
  "jsonschema",
+ "k256",
  "libc",
  "linnix-ai-ebpf-common",
  "log",
@@ -842,6 +857,7 @@ dependencies = [
  "sqlx",
  "sysinfo 0.36.1",
  "tempfile",
+ "tiny-keccak",
  "tokio",
  "tokio-stream",
  "toml",
@@ -873,6 +889,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
+]
+
+[[package]]
+name = "console"
+version = "0.15.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "unicode-width",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -971,6 +1000,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -989,6 +1030,92 @@ dependencies = [
  "dispatch2",
  "nix 0.30.1",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "cucumber"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cd12917efc3a8b069a4975ef3cb2f2d835d42d04b3814d90838488f9dd9bf69"
+dependencies = [
+ "anyhow",
+ "clap",
+ "console",
+ "cucumber-codegen",
+ "cucumber-expressions",
+ "derive_more",
+ "drain_filter_polyfill",
+ "either",
+ "futures",
+ "gherkin",
+ "globwalk",
+ "humantime",
+ "inventory",
+ "itertools 0.13.0",
+ "lazy-regex",
+ "linked-hash-map",
+ "once_cell",
+ "pin-project",
+ "regex",
+ "sealed",
+ "smart-default",
+]
+
+[[package]]
+name = "cucumber-codegen"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e19cd9e8e7cfd79fbf844eb6a7334117973c01f6bad35571262b00891e60f1c"
+dependencies = [
+ "cucumber-expressions",
+ "inflections",
+ "itertools 0.13.0",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn 2.0.108",
+ "synthez",
+]
+
+[[package]]
+name = "cucumber-expressions"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d794fed319eea24246fb5f57632f7ae38d61195817b7eb659455aa5bdd7c1810"
+dependencies = [
+ "derive_more",
+ "either",
+ "nom 7.1.3",
+ "nom_locate",
+ "regex",
+ "regex-syntax 0.7.5",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "digest",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -1022,6 +1149,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
 dependencies = [
  "powerfmt",
+]
+
+[[package]]
+name = "derive_more"
+version = "0.99.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -1093,12 +1231,76 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
+name = "drain_filter_polyfill"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "669a445ee724c5c69b1b06fe0b63e70a1c84bc9bb7d9696cd4f4e3ec45050408"
+
+[[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der",
+ "digest",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+ "spki",
+]
+
+[[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "pkcs8",
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "rand_core 0.6.4",
+ "serde",
+ "sha2",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "digest",
+ "ff",
+ "generic-array",
+ "group",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "sec1",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -1109,6 +1311,12 @@ checksum = "3d248bdd43ce613d87415282f69b9bb99d947d290b10962dd6c56233312c2ad5"
 dependencies = [
  "log",
 ]
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "encoding_rs"
@@ -1224,6 +1432,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "ff"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
+dependencies = [
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1309,6 +1533,21 @@ checksum = "3027ae1df8d41b4bed2241c8fdad4acc1e7af60c8e17743534b545e77182d678"
 dependencies = [
  "lazy_static",
  "num",
+]
+
+[[package]]
+name = "futures"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
 ]
 
 [[package]]
@@ -1403,6 +1642,7 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",
@@ -1422,6 +1662,7 @@ checksum = "4bb6743198531e02858aeaea5398fcc883e71851fcbcb5a2f773e2fb6cb1edf2"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -1452,10 +1693,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "gherkin"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20b79820c0df536d1f3a089a2fa958f61cb96ce9e0f3f8f507f5a31179567755"
+dependencies = [
+ "heck 0.4.1",
+ "peg",
+ "quote",
+ "serde",
+ "serde_json",
+ "syn 2.0.108",
+ "textwrap",
+ "thiserror 1.0.69",
+ "typed-builder",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "globset"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax 0.8.8",
+]
+
+[[package]]
+name = "globwalk"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf760ebf69878d9fd8f110c89703d90ce35095324d1f1edcb595c63945ee757"
+dependencies = [
+ "bitflags 2.10.0",
+ "ignore",
+ "walkdir",
+]
 
 [[package]]
 name = "gloo-timers"
@@ -1467,6 +1749,17 @@ dependencies = [
  "futures-core",
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core 0.6.4",
+ "subtle",
 ]
 
 [[package]]
@@ -1538,6 +1831,12 @@ checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
 dependencies = [
  "hashbrown 0.15.5",
 ]
+
+[[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "heck"
@@ -1679,6 +1978,12 @@ dependencies = [
  "tokio",
  "url",
 ]
+
+[[package]]
+name = "humantime"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
 
 [[package]]
 name = "hyper"
@@ -1913,6 +2218,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "ignore"
+version = "0.4.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3d782a365a015e0f5c04902246139249abf769125006fbe7649e2ee88169b4a"
+dependencies = [
+ "crossbeam-deque",
+ "globset",
+ "log",
+ "memchr",
+ "regex-automata",
+ "same-file",
+ "walkdir",
+ "winapi-util",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1920,6 +2241,21 @@ checksum = "6717a8d2a5a929a1a2eb43a12812498ed141a0bcfb7e8f7844fbdbe4303bba9f"
 dependencies = [
  "equivalent",
  "hashbrown 0.16.0",
+]
+
+[[package]]
+name = "inflections"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a257582fdcde896fd96463bf2d40eefea0580021c0712a0e2b028b60b47a837a"
+
+[[package]]
+name = "inventory"
+version = "0.3.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "009ae045c87e7082cb72dab0ccd01ae075dd00141ddc108f43a0ea150a9e7227"
+dependencies = [
+ "rustversion",
 ]
 
 [[package]]
@@ -2042,6 +2378,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "k256"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6e3919bbaa2945715f0bb6d3934a173d1e9a59ac23767fbaaef277265a7411b"
+dependencies = [
+ "cfg-if",
+ "ecdsa",
+ "elliptic-curve",
+ "once_cell",
+ "sha2",
+ "signature",
+]
+
+[[package]]
 name = "kv-log-macro"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2064,7 +2414,7 @@ dependencies = [
  "petgraph",
  "pico-args",
  "regex",
- "regex-syntax",
+ "regex-syntax 0.8.8",
  "string_cache",
  "term",
  "tiny-keccak",
@@ -2079,6 +2429,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "507460a910eb7b32ee961886ff48539633b788a36b65692b95f225b844c82553"
 dependencies = [
  "regex-automata",
+]
+
+[[package]]
+name = "lazy-regex"
+version = "3.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bae91019476d3ec7147de9aa291cadb6d870abf2f3015d2da73a90325ac1496"
+dependencies = [
+ "lazy-regex-proc_macros",
+ "once_cell",
+ "regex",
+]
+
+[[package]]
+name = "lazy-regex-proc_macros"
+version = "3.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4de9c1e1439d8b7b3061b2d209809f447ca33241733d9a3c01eabf2dc8d94358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -2139,6 +2512,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linnix-ai-ebpf-common"
@@ -2366,6 +2745,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "nom_locate"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e3c83c053b0713da60c5b8de47fe8e494fe3ece5267b2f23090a07a053ba8f3"
+dependencies = [
+ "bytecount",
+ "memchr",
+ "nom 7.1.3",
 ]
 
 [[package]]
@@ -2638,6 +3028,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "peg"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f76678828272f177ac33b7e2ac2e3e73cc6c1cd1e3e387928aa69562fa51367"
+dependencies = [
+ "peg-macros",
+ "peg-runtime",
+]
+
+[[package]]
+name = "peg-macros"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "636d60acf97633e48d266d7415a9355d4389cea327a193f87df395d88cd2b14d"
+dependencies = [
+ "peg-runtime",
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "peg-runtime"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9555b1514d2d99d78150d3c799d4c357a3e2c2a8062cd108e93a06d9057629c5"
+
+[[package]]
 name = "pem-rfc7468"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2676,6 +3093,26 @@ name = "pico-args"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
+
+[[package]]
+name = "pin-project"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.108",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -3051,7 +3488,7 @@ dependencies = [
  "aho-corasick",
  "memchr",
  "regex-automata",
- "regex-syntax",
+ "regex-syntax 0.8.8",
 ]
 
 [[package]]
@@ -3062,8 +3499,14 @@ checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.8.8",
 ]
+
+[[package]]
+name = "regex-syntax"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
 
 [[package]]
 name = "regex-syntax"
@@ -3173,6 +3616,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac",
+ "subtle",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3211,6 +3664,15 @@ name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
 
 [[package]]
 name = "rustix"
@@ -3310,6 +3772,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "sealed"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4a8caec23b7800fb97971a1c6ae365b6239aaeddfb934d6265f8505e795699d"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.108",
+]
+
+[[package]]
+name = "sec1"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct",
+ "der",
+ "generic-array",
+ "pkcs8",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "security-framework"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3331,6 +3819,12 @@ dependencies = [
  "core-foundation-sys",
  "libc",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "serde"
@@ -3511,6 +4005,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "smart-default"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eb01866308440fc64d6c44d9e86c5cc17adfe33c4d6eed55da9145044d0ffc1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.108",
+]
+
+[[package]]
+name = "smawk"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
+
+[[package]]
 name = "socket2"
 version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3617,7 +4128,7 @@ checksum = "19a9c1841124ac5a61741f96e1d9e2ec77424bf323962dd894bdb93f37d5219b"
 dependencies = [
  "dotenvy",
  "either",
- "heck",
+ "heck 0.5.0",
  "hex",
  "once_cell",
  "proc-macro2",
@@ -3827,6 +4338,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "synthez"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3d2c2202510a1e186e63e596d9318c91a8cbe85cd1a56a7be0c333e5f59ec8d"
+dependencies = [
+ "syn 2.0.108",
+ "synthez-codegen",
+ "synthez-core",
+]
+
+[[package]]
+name = "synthez-codegen"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f724aa6d44b7162f3158a57bccd871a77b39a4aef737e01bcdff41f4772c7746"
+dependencies = [
+ "syn 2.0.108",
+ "synthez-core",
+]
+
+[[package]]
+name = "synthez-core"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78bfa6ec52465e2425fd43ce5bbbe0f0b623964f7c63feb6b10980e816c654ea"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "sealed",
+ "syn 2.0.108",
+]
+
+[[package]]
 name = "sysinfo"
 version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3921,10 +4465,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "terminal_size"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60b8cb979cb11c32ce1603f8137b22262a9d131aaa5c37b5678025f22b8becd0"
+dependencies = [
+ "rustix 1.1.2",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "termtree"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
+
+[[package]]
+name = "textwrap"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057"
+dependencies = [
+ "smawk",
+ "unicode-linebreak",
+ "unicode-width",
+]
 
 [[package]]
 name = "thiserror"
@@ -4229,6 +4794,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "typed-builder"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fe83c85a85875e8c4cb9ce4a890f05b23d38cd0d47647db7895d3d2a79566d2"
+dependencies = [
+ "typed-builder-macro",
+]
+
+[[package]]
+name = "typed-builder-macro"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29a3151c41d0b13e3d011f98adc24434560ef06673a155a6c7f66b9879eecce2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.108",
+]
+
+[[package]]
 name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4247,6 +4832,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
 
 [[package]]
+name = "unicode-linebreak"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
+
+[[package]]
 name = "unicode-normalization"
 version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4260,6 +4851,12 @@ name = "unicode-properties"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "unicode-xid"

--- a/cognitod/Cargo.toml
+++ b/cognitod/Cargo.toml
@@ -12,7 +12,7 @@ reqwest = { version = "0.12.15", features = ["json"] }
 axum = {version = "0.8.3", features =["macros"]}
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"
-tokio = { version = "1.47.0", features = ["rt-multi-thread", "macros", "time", "signal", "sync", "fs", "process"] }
+tokio = { version = "1.47.0", features = ["rt-multi-thread", "macros", "time", "signal", "sync", "fs", "process", "net"] }
 # async handlers and config
 async-trait = "0.1"
 toml = "0.8"
@@ -50,6 +50,15 @@ memmap2 = "0.9"
 nix = { version = "0.29", features = ["time"] }
 ctrlc = "3.4"
 
+# Linnix-Claw Phase 1: Receipt & Identity
+ed25519-dalek = { version = "2.1", features = ["rand_core"] }
+k256 = { version = "0.13", features = ["ecdsa", "sha256"] }
+hkdf = "0.12"
+hmac = "0.12"
+base64 = "0.22"
+hex = "0.4"
+tiny-keccak = { version = "2.0", features = ["keccak"] }
+
 [[bin]]
 name = "cognitod"
 path = "src/main.rs"
@@ -62,10 +71,17 @@ path = "src/bin/sequencer_test.rs"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "time", "test-util"] }
 tempfile = "3"
 reqwest-eventsource = "0.4"
+cucumber = "0.21"
+futures = "0.3"
+
+[[test]]
+name = "bdd_spend"
+harness = false   # cucumber provides its own main()
 
 [features]
 default = []
 ilm-test = []
+compliance = []   # Enable OFAC/KYT/Travel Rule compliance controls (§10.3)
 
 # Metadata for cargo-deb and cargo-generate-rpm
 [package.metadata.deb]

--- a/cognitod/src/agent_card.rs
+++ b/cognitod/src/agent_card.rs
@@ -1,0 +1,286 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// cognitod/src/agent_card.rs — A2A Agent Card with Linnix-Claw extension (§4)
+//
+// Serves `GET /.well-known/agent-card.json` per the A2A v0.3.0 spec
+// (Linux Foundation) with the `x-linnix-claw` extension advertising
+// kernel attestation, settlement preferences, and pricing.
+
+use base64::{Engine, engine::general_purpose::STANDARD as BASE64};
+use serde::Serialize;
+
+use crate::identity::AgentIdentity;
+
+// =============================================================================
+// AGENT CARD STRUCTURES (§4)
+// =============================================================================
+
+/// A2A-compliant agent card with Linnix-Claw extensions.
+#[derive(Debug, Clone, Serialize)]
+pub struct AgentCard {
+    pub name: String,
+    pub description: String,
+    pub version: String,
+
+    #[serde(rename = "supportedInterfaces")]
+    pub supported_interfaces: Vec<SupportedInterface>,
+
+    pub capabilities: Capabilities,
+
+    pub skills: Vec<Skill>,
+
+    /// Linnix-Claw extension namespace (§4).
+    #[serde(rename = "x-linnix-claw")]
+    pub x_linnix_claw: ClawExtension,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct SupportedInterface {
+    pub url: String,
+    #[serde(rename = "protocolBinding")]
+    pub protocol_binding: String,
+    #[serde(rename = "protocolVersion")]
+    pub protocol_version: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct Capabilities {
+    pub streaming: bool,
+    #[serde(rename = "pushNotifications")]
+    pub push_notifications: bool,
+    #[serde(rename = "kernelAttestation")]
+    pub kernel_attestation: bool,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct Skill {
+    pub id: String,
+    pub name: String,
+    pub description: String,
+    pub tags: Vec<String>,
+    #[serde(rename = "inputModes")]
+    pub input_modes: Vec<String>,
+    #[serde(rename = "outputModes")]
+    pub output_modes: Vec<String>,
+}
+
+/// Linnix-Claw-specific extension fields (§4).
+#[derive(Debug, Clone, Serialize)]
+pub struct ClawExtension {
+    pub version: String,
+    pub did: String,
+    #[serde(rename = "publicKey")]
+    pub public_key: String,
+    #[serde(rename = "ethereumAddress")]
+    pub ethereum_address: String,
+    #[serde(rename = "kernelAttestation")]
+    pub kernel_attestation: bool,
+    #[serde(rename = "enforcementMode")]
+    pub enforcement_mode: String,
+    pub settlement: SettlementInfo,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct SettlementInfo {
+    pub chains: Vec<ChainInfo>,
+    #[serde(rename = "acceptedTokens")]
+    pub accepted_tokens: Vec<TokenInfo>,
+    #[serde(rename = "receiptAuth")]
+    pub receipt_auth: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ChainInfo {
+    pub network: String,
+    #[serde(rename = "chainId")]
+    pub chain_id: u64,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct TokenInfo {
+    pub symbol: String,
+    pub address: String,
+    #[serde(rename = "chainId")]
+    pub chain_id: u64,
+}
+
+// =============================================================================
+// BUILDER
+// =============================================================================
+
+/// Build the agent card from runtime state.
+pub fn build_agent_card(
+    identity: Option<&AgentIdentity>,
+    bpf_lsm_available: bool,
+    enforcement_mode: &str,
+    listen_addr: &str,
+) -> AgentCard {
+    let hostname = std::fs::read_to_string("/etc/hostname")
+        .map(|h| h.trim().to_string())
+        .unwrap_or_else(|_| "unknown".to_string());
+
+    let (did, public_key, eth_address) = if let Some(id) = identity {
+        (
+            id.did().to_string(),
+            format!(
+                "ed25519:{}",
+                BASE64.encode(id.ed25519_verifying_key().as_bytes())
+            ),
+            format!("0x{}", hex::encode(id.ethereum_address())),
+        )
+    } else {
+        (
+            format!("did:linnix:{hostname}"),
+            "none".to_string(),
+            "0x0000000000000000000000000000000000000000".to_string(),
+        )
+    };
+
+    let base_url = if listen_addr.starts_with("0.0.0.0") {
+        format!(
+            "http://{}:{}",
+            hostname,
+            listen_addr.split(':').next_back().unwrap_or("3000")
+        )
+    } else {
+        format!("http://{listen_addr}")
+    };
+
+    AgentCard {
+        name: format!("Linnix Agent ({hostname})"),
+        description: "eBPF-powered Linux observability agent with kernel-level mandate enforcement"
+            .to_string(),
+        version: env!("CARGO_PKG_VERSION").to_string(),
+
+        supported_interfaces: vec![SupportedInterface {
+            url: format!("{base_url}/a2a"),
+            protocol_binding: "jsonrpc".to_string(),
+            protocol_version: "0.3.0".to_string(),
+        }],
+
+        capabilities: Capabilities {
+            streaming: true,
+            push_notifications: false,
+            kernel_attestation: bpf_lsm_available,
+        },
+
+        skills: vec![
+            Skill {
+                id: "authorize-command".to_string(),
+                name: "Authorize Command Execution".to_string(),
+                description: "Create a time-bounded kernel mandate for a specific command"
+                    .to_string(),
+                tags: vec!["security".into(), "ebpf".into(), "mandate".into()],
+                input_modes: vec!["application/json".into()],
+                output_modes: vec!["application/json".into()],
+            },
+            Skill {
+                id: "verify-receipt".to_string(),
+                name: "Verify Execution Receipt".to_string(),
+                description: "Verify dual-signed (Ed25519 + secp256k1) execution receipt"
+                    .to_string(),
+                tags: vec!["crypto".into(), "receipt".into(), "verification".into()],
+                input_modes: vec!["application/json".into()],
+                output_modes: vec!["application/json".into()],
+            },
+            Skill {
+                id: "observe-processes".to_string(),
+                name: "Observe Process Lifecycle".to_string(),
+                description:
+                    "Stream real-time process fork/exec/exit events with CPU/memory telemetry"
+                        .to_string(),
+                tags: vec!["observability".into(), "ebpf".into(), "telemetry".into()],
+                input_modes: vec!["text/plain".into()],
+                output_modes: vec!["text/event-stream".into()],
+            },
+        ],
+
+        x_linnix_claw: ClawExtension {
+            version: "0.1.0".to_string(),
+            did,
+            public_key,
+            ethereum_address: eth_address,
+            kernel_attestation: bpf_lsm_available,
+            enforcement_mode: enforcement_mode.to_string(),
+            settlement: SettlementInfo {
+                chains: vec![
+                    ChainInfo {
+                        network: "base".to_string(),
+                        chain_id: 8453,
+                    },
+                    ChainInfo {
+                        network: "arbitrum".to_string(),
+                        chain_id: 42161,
+                    },
+                ],
+                accepted_tokens: vec![
+                    TokenInfo {
+                        symbol: "USDC".to_string(),
+                        address: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913".to_string(),
+                        chain_id: 8453,
+                    },
+                    TokenInfo {
+                        symbol: "USDC".to_string(),
+                        address: "0xaf88d065e77c8cC2239327C5EDb3A432268e5831".to_string(),
+                        chain_id: 42161,
+                    },
+                ],
+                receipt_auth: "ed25519+secp256k1".to_string(),
+            },
+        },
+    }
+}
+
+// =============================================================================
+// TESTS
+// =============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn agent_card_has_required_fields() {
+        let card = build_agent_card(None, true, "monitor", "0.0.0.0:3000");
+        assert_eq!(card.x_linnix_claw.version, "0.1.0");
+        assert!(card.x_linnix_claw.kernel_attestation);
+        assert_eq!(card.x_linnix_claw.enforcement_mode, "monitor");
+        assert!(!card.skills.is_empty());
+        assert!(!card.x_linnix_claw.settlement.chains.is_empty());
+    }
+
+    #[test]
+    fn agent_card_serializes_to_json() {
+        let card = build_agent_card(None, false, "enforce", "127.0.0.1:3000");
+        let json = serde_json::to_string_pretty(&card).unwrap();
+        assert!(json.contains("x-linnix-claw"));
+        assert!(json.contains("kernelAttestation"));
+        assert!(json.contains("supportedInterfaces"));
+        assert!(json.contains("authorize-command"));
+    }
+
+    #[test]
+    fn agent_card_with_identity() {
+        let id = crate::identity::AgentIdentity::from_seed([42u8; 32], "did:web:test.local".into())
+            .unwrap();
+        let card = build_agent_card(Some(&id), true, "enforce", "0.0.0.0:3000");
+        assert_eq!(card.x_linnix_claw.did, "did:web:test.local");
+        assert!(card.x_linnix_claw.public_key.starts_with("ed25519:"));
+        assert!(card.x_linnix_claw.ethereum_address.starts_with("0x"));
+        assert_eq!(card.x_linnix_claw.ethereum_address.len(), 42); // 0x + 40 hex chars
+    }
+
+    #[test]
+    fn settlement_chains_default() {
+        let card = build_agent_card(None, true, "monitor", "0.0.0.0:3000");
+        let chain_ids: Vec<u64> = card
+            .x_linnix_claw
+            .settlement
+            .chains
+            .iter()
+            .map(|c| c.chain_id)
+            .collect();
+        assert!(chain_ids.contains(&8453)); // Base
+        assert!(chain_ids.contains(&42161)); // Arbitrum
+    }
+}

--- a/cognitod/src/alerts.rs
+++ b/cognitod/src/alerts.rs
@@ -122,6 +122,24 @@ pub enum Detector {
         #[allow(dead_code)]
         duration: u64,
     },
+    /// Alert when the system-wide CPU PSI (some avg10) exceeds a threshold
+    /// sustained for `duration` seconds.
+    SystemPsiCpu {
+        threshold_pct: f32,
+        duration: u64,
+    },
+    /// Alert when system-wide memory PSI (full avg10) exceeds threshold
+    /// sustained for `duration` seconds.
+    SystemPsiMemory {
+        threshold_pct: f32,
+        duration: u64,
+    },
+    /// Alert when system-wide IO PSI (full avg10) exceeds threshold
+    /// sustained for `duration` seconds.
+    SystemPsiIo {
+        threshold_pct: f32,
+        duration: u64,
+    },
 }
 
 #[derive(Debug, Clone)]
@@ -186,6 +204,18 @@ enum RawDetector {
     },
     ZombieCount {
         threshold: u64,
+        duration: u64,
+    },
+    SystemPsiCpu {
+        threshold_pct: f32,
+        duration: u64,
+    },
+    SystemPsiMemory {
+        threshold_pct: f32,
+        duration: u64,
+    },
+    SystemPsiIo {
+        threshold_pct: f32,
         duration: u64,
     },
 }
@@ -266,6 +296,27 @@ impl TryFrom<RawRule> for RuleConfig {
                 threshold,
                 duration,
             },
+            RawDetector::SystemPsiCpu {
+                threshold_pct,
+                duration,
+            } => Detector::SystemPsiCpu {
+                threshold_pct,
+                duration,
+            },
+            RawDetector::SystemPsiMemory {
+                threshold_pct,
+                duration,
+            } => Detector::SystemPsiMemory {
+                threshold_pct,
+                duration,
+            },
+            RawDetector::SystemPsiIo {
+                threshold_pct,
+                duration,
+            } => Detector::SystemPsiIo {
+                threshold_pct,
+                duration,
+            },
         };
 
         Ok(RuleConfig {
@@ -286,6 +337,9 @@ struct RuleState {
     cpu_exceed: HashMap<String, Instant>,
     rss_exceed: HashMap<String, Instant>,
     active: HashMap<String, Instant>,
+    /// Tracks when a PSI threshold was first breached per rule name.
+    /// Used by SystemPsiCpu/Memory/Io detectors for sustained-pressure windows.
+    psi_breach: HashMap<String, Instant>,
 }
 
 pub struct RuleEngine {
@@ -371,6 +425,7 @@ impl RuleEngine {
                 cpu_exceed: HashMap::new(),
                 rss_exceed: HashMap::new(),
                 active: HashMap::new(),
+                psi_breach: HashMap::new(),
             }),
             tx,
             alerts_file,
@@ -869,12 +924,101 @@ impl Handler for RuleEngine {
                     }
                 }
                 Detector::ZombieCount { .. } => {}
+                // PSI detectors fire from on_snapshot, not on individual events.
+                Detector::SystemPsiCpu { .. }
+                | Detector::SystemPsiMemory { .. }
+                | Detector::SystemPsiIo { .. } => {}
             }
         }
     }
 
-    async fn on_snapshot(&self, _snapshot: &SystemSnapshot) {
-        // placeholder for detectors needing snapshots
+    async fn on_snapshot(&self, snapshot: &SystemSnapshot) {
+        let now = Instant::now();
+        let mut state = self.state.lock().await;
+
+        for rule in &self.rules {
+            match &rule.cfg.detector {
+                Detector::SystemPsiCpu {
+                    threshold_pct,
+                    duration,
+                } => {
+                    let current = snapshot.psi_cpu_some_avg10;
+                    let key = rule.cfg.name.clone();
+                    if current > *threshold_pct {
+                        let breach_start = state.psi_breach.entry(key.clone()).or_insert(now);
+                        let elapsed = now.duration_since(*breach_start).as_secs();
+                        if elapsed >= *duration {
+                            state.psi_breach.remove(&key);
+                            drop(state);
+                            self.emit_alert(
+                                &rule.cfg,
+                                format!(
+                                    "CPU PSI {:.1}% > {:.1}% sustained {}s",
+                                    current, threshold_pct, duration
+                                ),
+                            )
+                            .await;
+                            state = self.state.lock().await;
+                        }
+                    } else {
+                        state.psi_breach.remove(&key);
+                    }
+                }
+                Detector::SystemPsiMemory {
+                    threshold_pct,
+                    duration,
+                } => {
+                    let current = snapshot.psi_memory_full_avg10;
+                    let key = rule.cfg.name.clone();
+                    if current > *threshold_pct {
+                        let breach_start = state.psi_breach.entry(key.clone()).or_insert(now);
+                        let elapsed = now.duration_since(*breach_start).as_secs();
+                        if elapsed >= *duration {
+                            state.psi_breach.remove(&key);
+                            drop(state);
+                            self.emit_alert(
+                                &rule.cfg,
+                                format!(
+                                    "memory PSI (full) {:.1}% > {:.1}% sustained {}s",
+                                    current, threshold_pct, duration
+                                ),
+                            )
+                            .await;
+                            state = self.state.lock().await;
+                        }
+                    } else {
+                        state.psi_breach.remove(&key);
+                    }
+                }
+                Detector::SystemPsiIo {
+                    threshold_pct,
+                    duration,
+                } => {
+                    let current = snapshot.psi_io_full_avg10;
+                    let key = rule.cfg.name.clone();
+                    if current > *threshold_pct {
+                        let breach_start = state.psi_breach.entry(key.clone()).or_insert(now);
+                        let elapsed = now.duration_since(*breach_start).as_secs();
+                        if elapsed >= *duration {
+                            state.psi_breach.remove(&key);
+                            drop(state);
+                            self.emit_alert(
+                                &rule.cfg,
+                                format!(
+                                    "IO PSI (full) {:.1}% > {:.1}% sustained {}s",
+                                    current, threshold_pct, duration
+                                ),
+                            )
+                            .await;
+                            state = self.state.lock().await;
+                        }
+                    } else {
+                        state.psi_breach.remove(&key);
+                    }
+                }
+                _ => {}
+            }
+        }
     }
 }
 
@@ -906,6 +1050,7 @@ mod tests {
                 cpu_exceed: HashMap::new(),
                 rss_exceed: HashMap::new(),
                 active: HashMap::new(),
+                psi_breach: HashMap::new(),
             }),
             tx,
             alerts_file: "/dev/null".into(),

--- a/cognitod/src/api/mod.rs
+++ b/cognitod/src/api/mod.rs
@@ -1355,48 +1355,45 @@ async fn create_mandate(
 
     // §8.5 Spend-limit check: if the mandate has a spend cap, verify it
     // doesn't exceed any configured limit (per-mandate, hourly, daily, monthly).
-    if let Some(amount_cents) = req.max_spend_cents {
-        if let Some(ref tracker) = state.spend_tracker {
-            if let Err(violation) = tracker
-                .check_spend(amount_cents, req.counterparty_did.as_deref())
-                .await
-            {
-                state.claw_metrics.inc_rejected();
-                return Err((
-                    StatusCode::TOO_MANY_REQUESTS,
-                    Json(json!({
-                        "error": "spend_limit_exceeded",
-                        "message": violation.to_string()
-                    })),
-                ));
-            }
-        }
+    if let Some(amount_cents) = req.max_spend_cents
+        && let Some(ref tracker) = state.spend_tracker
+        && let Err(violation) = tracker
+            .check_spend(amount_cents, req.counterparty_did.as_deref())
+            .await
+    {
+        state.claw_metrics.inc_rejected();
+        return Err((
+            StatusCode::TOO_MANY_REQUESTS,
+            Json(json!({
+                "error": "spend_limit_exceeded",
+                "message": violation.to_string()
+            })),
+        ));
     }
 
     // §10.3 Compliance screening: if the mandate has commerce fields,
     // run OFAC/KYT/jurisdiction checks before creating the mandate.
-    if req.is_commerce_request() {
-        if let Some(ref engine) = state.compliance_engine {
-            if let Some(ref did) = req.counterparty_did {
-                let results = engine
-                    .pre_task_screen(
-                        did,
-                        req.wallet_address.as_deref(),
-                        req.jurisdiction.as_deref(),
-                        req.max_spend_cents.unwrap_or(0),
-                    )
-                    .await;
-                if cognitod::compliance::ComplianceEngine::has_hard_block(&results) {
-                    state.claw_metrics.inc_rejected();
-                    return Err((
-                        StatusCode::FORBIDDEN,
-                        Json(json!({
-                            "error": "compliance_blocked",
-                            "message": "counterparty failed compliance screening"
-                        })),
-                    ));
-                }
-            }
+    if req.is_commerce_request()
+        && let Some(ref engine) = state.compliance_engine
+        && let Some(ref did) = req.counterparty_did
+    {
+        let results = engine
+            .pre_task_screen(
+                did,
+                req.wallet_address.as_deref(),
+                req.jurisdiction.as_deref(),
+                req.max_spend_cents.unwrap_or(0),
+            )
+            .await;
+        if cognitod::compliance::ComplianceEngine::has_hard_block(&results) {
+            state.claw_metrics.inc_rejected();
+            return Err((
+                StatusCode::FORBIDDEN,
+                Json(json!({
+                    "error": "compliance_blocked",
+                    "message": "counterparty failed compliance screening"
+                })),
+            ));
         }
     }
 
@@ -1408,12 +1405,12 @@ async fn create_mandate(
             state.claw_metrics.inc_created();
 
             // Record spend after successful mandate creation (§8.5).
-            if let Some(amount_cents) = req.max_spend_cents {
-                if let Some(ref tracker) = state.spend_tracker {
-                    tracker
-                        .record_spend(amount_cents, req.counterparty_did.clone())
-                        .await;
-                }
+            if let Some(amount_cents) = req.max_spend_cents
+                && let Some(ref tracker) = state.spend_tracker
+            {
+                tracker
+                    .record_spend(amount_cents, req.counterparty_did.clone())
+                    .await;
             }
 
             Ok((StatusCode::CREATED, Json(resp)))
@@ -1476,21 +1473,18 @@ async fn get_mandate_receipt(
 
             // §9 Privacy redaction: redact binary path at read-time to
             // preserve the unredacted audit trail in memory.
-            if let Some(ref redactor) = state.receipt_redactor {
-                if let Some(exec) = receipt_json.get_mut("execution") {
-                    if let Some(binary) = exec
-                        .get("binary")
-                        .and_then(|b| b.as_str())
-                        .map(String::from)
-                    {
-                        if let Some(obj) = exec.as_object_mut() {
-                            obj.insert(
-                                "binary".to_string(),
-                                serde_json::Value::String(redactor.redact_binary(&binary)),
-                            );
-                        }
-                    }
-                }
+            if let Some(ref redactor) = state.receipt_redactor
+                && let Some(exec) = receipt_json.get_mut("execution")
+                && let Some(binary) = exec
+                    .get("binary")
+                    .and_then(|b| b.as_str())
+                    .map(String::from)
+                && let Some(obj) = exec.as_object_mut()
+            {
+                obj.insert(
+                    "binary".to_string(),
+                    serde_json::Value::String(redactor.redact_binary(&binary)),
+                );
             }
 
             Ok(Json(receipt_json))

--- a/cognitod/src/api/mod.rs
+++ b/cognitod/src/api/mod.rs
@@ -1353,12 +1353,69 @@ async fn create_mandate(
         ));
     }
 
+    // §8.5 Spend-limit check: if the mandate has a spend cap, verify it
+    // doesn't exceed any configured limit (per-mandate, hourly, daily, monthly).
+    if let Some(amount_cents) = req.max_spend_cents {
+        if let Some(ref tracker) = state.spend_tracker {
+            if let Err(violation) = tracker
+                .check_spend(amount_cents, req.counterparty_did.as_deref())
+                .await
+            {
+                state.claw_metrics.inc_rejected();
+                return Err((
+                    StatusCode::TOO_MANY_REQUESTS,
+                    Json(json!({
+                        "error": "spend_limit_exceeded",
+                        "message": violation.to_string()
+                    })),
+                ));
+            }
+        }
+    }
+
+    // §10.3 Compliance screening: if the mandate has commerce fields,
+    // run OFAC/KYT/jurisdiction checks before creating the mandate.
+    if req.is_commerce_request() {
+        if let Some(ref engine) = state.compliance_engine {
+            if let Some(ref did) = req.counterparty_did {
+                let results = engine
+                    .pre_task_screen(
+                        did,
+                        req.wallet_address.as_deref(),
+                        req.jurisdiction.as_deref(),
+                        req.max_spend_cents.unwrap_or(0),
+                    )
+                    .await;
+                if cognitod::compliance::ComplianceEngine::has_hard_block(&results) {
+                    state.claw_metrics.inc_rejected();
+                    return Err((
+                        StatusCode::FORBIDDEN,
+                        Json(json!({
+                            "error": "compliance_blocked",
+                            "message": "counterparty failed compliance screening"
+                        })),
+                    ));
+                }
+            }
+        }
+    }
+
     let t0 = std::time::Instant::now();
-    match mgr.create(req).await {
+    match mgr.create(req.clone()).await {
         Ok(resp) => {
             let elapsed_ns = t0.elapsed().as_nanos() as u64;
             state.claw_metrics.observe_mandate_latency_ns(elapsed_ns);
             state.claw_metrics.inc_created();
+
+            // Record spend after successful mandate creation (§8.5).
+            if let Some(amount_cents) = req.max_spend_cents {
+                if let Some(ref tracker) = state.spend_tracker {
+                    tracker
+                        .record_spend(amount_cents, req.counterparty_did.clone())
+                        .await;
+                }
+            }
+
             Ok((StatusCode::CREATED, Json(resp)))
         }
         Err(e) => {
@@ -1415,7 +1472,28 @@ async fn get_mandate_receipt(
                 StatusCode::NOT_FOUND,
                 Json(json!({"error": "receipt not yet available"})),
             ))?;
-            Ok(Json(serde_json::to_value(&receipt).unwrap_or_default()))
+            let mut receipt_json = serde_json::to_value(&receipt).unwrap_or_default();
+
+            // §9 Privacy redaction: redact binary path at read-time to
+            // preserve the unredacted audit trail in memory.
+            if let Some(ref redactor) = state.receipt_redactor {
+                if let Some(exec) = receipt_json.get_mut("execution") {
+                    if let Some(binary) = exec
+                        .get("binary")
+                        .and_then(|b| b.as_str())
+                        .map(String::from)
+                    {
+                        if let Some(obj) = exec.as_object_mut() {
+                            obj.insert(
+                                "binary".to_string(),
+                                serde_json::Value::String(redactor.redact_binary(&binary)),
+                            );
+                        }
+                    }
+                }
+            }
+
+            Ok(Json(receipt_json))
         }
         _ => Err((
             StatusCode::NOT_FOUND,
@@ -1872,6 +1950,12 @@ pub struct AppState {
     pub commerce_policy: Option<cognitod::commerce::CommercePolicy>,
     /// Claw SLO metrics (§10.5).
     pub claw_metrics: Arc<cognitod::claw_metrics::ClawMetrics>,
+    /// Spend-limit tracker (§8.5).
+    pub spend_tracker: Option<Arc<cognitod::spend::SpendTracker>>,
+    /// OFAC/KYT/Travel Rule compliance engine (§10.3).
+    pub compliance_engine: Option<Arc<cognitod::compliance::ComplianceEngine>>,
+    /// Privacy redactor for receipt responses (§9).
+    pub receipt_redactor: Option<cognitod::privacy::ReceiptRedactor>,
 }
 
 pub fn all_routes(app_state: Arc<AppState>) -> Router {
@@ -2524,6 +2608,9 @@ mod tests {
             mandate: None,
             identity: None,
             commerce_policy: None,
+            spend_tracker: None,
+            compliance_engine: None,
+            receipt_redactor: None,
             claw_metrics: Arc::new(cognitod::claw_metrics::ClawMetrics::new()),
         });
         let Json(resp) = super::status_handler(State(app_state)).await;
@@ -2576,6 +2663,9 @@ mod tests {
             mandate: None,
             identity: None,
             commerce_policy: None,
+            spend_tracker: None,
+            compliance_engine: None,
+            receipt_redactor: None,
             claw_metrics: Arc::new(cognitod::claw_metrics::ClawMetrics::new()),
         });
 
@@ -2611,6 +2701,9 @@ mod tests {
             mandate: None,
             identity: None,
             commerce_policy: None,
+            spend_tracker: None,
+            compliance_engine: None,
+            receipt_redactor: None,
             claw_metrics: Arc::new(cognitod::claw_metrics::ClawMetrics::new()),
         });
         let router = super::all_routes(Arc::clone(&app_state));
@@ -2649,6 +2742,9 @@ mod tests {
             mandate: None,
             identity: None,
             commerce_policy: None,
+            spend_tracker: None,
+            compliance_engine: None,
+            receipt_redactor: None,
             claw_metrics: Arc::new(cognitod::claw_metrics::ClawMetrics::new()),
         });
         let router = super::all_routes(Arc::clone(&app_state));
@@ -2701,6 +2797,9 @@ mod tests {
             mandate: None,
             identity: None,
             commerce_policy: None,
+            spend_tracker: None,
+            compliance_engine: None,
+            receipt_redactor: None,
             claw_metrics: Arc::new(cognitod::claw_metrics::ClawMetrics::new()),
         });
         let router = super::all_routes(app_state);
@@ -2738,6 +2837,9 @@ mod tests {
             mandate: None,
             identity: None,
             commerce_policy: None,
+            spend_tracker: None,
+            compliance_engine: None,
+            receipt_redactor: None,
             claw_metrics: Arc::new(cognitod::claw_metrics::ClawMetrics::new()),
         });
         let router = super::all_routes(app_state);
@@ -2775,6 +2877,9 @@ mod tests {
             mandate: None,
             identity: None,
             commerce_policy: None,
+            spend_tracker: None,
+            compliance_engine: None,
+            receipt_redactor: None,
             claw_metrics: Arc::new(cognitod::claw_metrics::ClawMetrics::new()),
         });
         let router = super::all_routes(app_state);
@@ -2813,6 +2918,9 @@ mod tests {
             mandate: None,
             identity: None,
             commerce_policy: None,
+            spend_tracker: None,
+            compliance_engine: None,
+            receipt_redactor: None,
             claw_metrics: Arc::new(cognitod::claw_metrics::ClawMetrics::new()),
         });
         let router = super::all_routes(app_state);
@@ -2851,6 +2959,9 @@ mod tests {
             mandate: None,
             identity: None,
             commerce_policy: None,
+            spend_tracker: None,
+            compliance_engine: None,
+            receipt_redactor: None,
             claw_metrics: Arc::new(cognitod::claw_metrics::ClawMetrics::new()),
         });
         let router = super::all_routes(app_state);
@@ -2895,6 +3006,9 @@ mod tests {
             mandate: Some(Arc::new(mgr)),
             identity: None,
             commerce_policy: None,
+            spend_tracker: None,
+            compliance_engine: None,
+            receipt_redactor: None,
             claw_metrics: Arc::new(cognitod::claw_metrics::ClawMetrics::new()),
         })
     }
@@ -2940,6 +3054,9 @@ mod tests {
             mandate: None,
             identity: None,
             commerce_policy: None,
+            spend_tracker: None,
+            compliance_engine: None,
+            receipt_redactor: None,
             claw_metrics: Arc::new(cognitod::claw_metrics::ClawMetrics::new()),
         });
         let router = super::all_routes(app_state);

--- a/cognitod/src/api/mod.rs
+++ b/cognitod/src/api/mod.rs
@@ -1304,6 +1304,248 @@ async fn reject_action(
     }
 }
 
+// =============================================================================
+// MANDATE API HANDLERS
+// =============================================================================
+
+#[derive(Deserialize)]
+struct ListMandatesQuery {
+    #[serde(default)]
+    status: Option<cognitod::mandate::MandateStatus>,
+}
+
+async fn create_mandate(
+    State(state): State<Arc<AppState>>,
+    Json(req): Json<cognitod::mandate::MandateRequest>,
+) -> Result<
+    (StatusCode, Json<cognitod::mandate::MandateResponse>),
+    (StatusCode, Json<serde_json::Value>),
+> {
+    // §11.1 Commerce policy gate: if the request has settlement fields
+    // (task_id or max_spend_cents) and BPF LSM is not available, reject
+    // unless the operator has opted in to degraded commerce.
+    if req.is_commerce_request()
+        && let Some(ref policy) = state.commerce_policy
+        && let Err(rejection) = policy.check_commerce(true)
+    {
+        state.claw_metrics.inc_commerce_rejection();
+        state.claw_metrics.inc_rejected();
+        return Err((
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(json!({
+                "error": "kernel_enforcement_unavailable",
+                "message": rejection.message,
+                "enforcement_mode": rejection.enforcement_mode
+            })),
+        ));
+    }
+
+    let mgr = state.mandate.as_ref().ok_or((
+        StatusCode::SERVICE_UNAVAILABLE,
+        Json(json!({"error": "mandate system not enabled"})),
+    ))?;
+
+    if mgr.is_backpressure_active() {
+        state.claw_metrics.inc_rejected();
+        return Err((
+            StatusCode::TOO_MANY_REQUESTS,
+            Json(json!({"error": "mandate map backpressure active, retry later"})),
+        ));
+    }
+
+    let t0 = std::time::Instant::now();
+    match mgr.create(req).await {
+        Ok(resp) => {
+            let elapsed_ns = t0.elapsed().as_nanos() as u64;
+            state.claw_metrics.observe_mandate_latency_ns(elapsed_ns);
+            state.claw_metrics.inc_created();
+            Ok((StatusCode::CREATED, Json(resp)))
+        }
+        Err(e) => {
+            state.claw_metrics.inc_rejected();
+            Err((
+                StatusCode::BAD_REQUEST,
+                Json(json!({"error": e.to_string()})),
+            ))
+        }
+    }
+}
+
+async fn get_mandate_by_id(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<String>,
+) -> Result<Json<cognitod::mandate::MandateResponse>, StatusCode> {
+    let mgr = state
+        .mandate
+        .as_ref()
+        .ok_or(StatusCode::SERVICE_UNAVAILABLE)?;
+
+    mgr.get(&id).await.map(Json).ok_or(StatusCode::NOT_FOUND)
+}
+
+/// GET /mandates/{id}/receipt
+///
+/// Returns the dual-signed execution receipt for a completed mandate.
+/// - 200: Receipt found and returned
+/// - 202: Mandate exists and is active but not yet executed
+/// - 404: Mandate not found or revoked/expired without receipt
+/// - 503: Mandate system not enabled
+async fn get_mandate_receipt(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<String>,
+) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
+    let mgr = state.mandate.as_ref().ok_or((
+        StatusCode::SERVICE_UNAVAILABLE,
+        Json(json!({"error": "mandate system not enabled"})),
+    ))?;
+
+    // Check if mandate exists and get its status
+    let status = mgr.get_status(&id).await.ok_or((
+        StatusCode::NOT_FOUND,
+        Json(json!({"error": format!("mandate {} not found", id)})),
+    ))?;
+
+    match status {
+        cognitod::mandate::MandateStatus::Active => Err((
+            StatusCode::ACCEPTED,
+            Json(json!({"status": "pending", "message": "mandate is active but not yet executed"})),
+        )),
+        cognitod::mandate::MandateStatus::Executed => {
+            let receipt = mgr.get_receipt(&id).await.ok_or((
+                StatusCode::NOT_FOUND,
+                Json(json!({"error": "receipt not yet available"})),
+            ))?;
+            Ok(Json(serde_json::to_value(&receipt).unwrap_or_default()))
+        }
+        _ => Err((
+            StatusCode::NOT_FOUND,
+            Json(json!({"error": format!("mandate {} is {:?}, no receipt available", id, status)})),
+        )),
+    }
+}
+
+async fn revoke_mandate(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<String>,
+) -> Result<StatusCode, (StatusCode, Json<serde_json::Value>)> {
+    let mgr = state.mandate.as_ref().ok_or((
+        StatusCode::SERVICE_UNAVAILABLE,
+        Json(json!({"error": "mandate system not enabled"})),
+    ))?;
+
+    mgr.revoke(&id)
+        .await
+        .map(|_| {
+            state.claw_metrics.inc_revoked();
+            StatusCode::NO_CONTENT
+        })
+        .map_err(|e| (StatusCode::NOT_FOUND, Json(json!({"error": e.to_string()}))))
+}
+
+async fn list_mandates(
+    State(state): State<Arc<AppState>>,
+    Query(query): Query<ListMandatesQuery>,
+) -> Result<Json<Vec<cognitod::mandate::MandateResponse>>, StatusCode> {
+    let mgr = state
+        .mandate
+        .as_ref()
+        .ok_or(StatusCode::SERVICE_UNAVAILABLE)?;
+
+    Ok(Json(mgr.list(query.status).await))
+}
+
+async fn get_mandate_stats(
+    State(state): State<Arc<AppState>>,
+) -> Result<Json<cognitod::mandate::MandateStats>, StatusCode> {
+    let mgr = state
+        .mandate
+        .as_ref()
+        .ok_or(StatusCode::SERVICE_UNAVAILABLE)?;
+
+    Ok(Json(mgr.stats().await))
+}
+
+async fn get_mandate_health(
+    State(state): State<Arc<AppState>>,
+) -> Result<Json<cognitod::mandate::MandateHealth>, StatusCode> {
+    let mgr = state
+        .mandate
+        .as_ref()
+        .ok_or(StatusCode::SERVICE_UNAVAILABLE)?;
+
+    Ok(Json(mgr.health()))
+}
+
+/// POST /mandates/batch — Create multiple mandates in a single request.
+///
+/// Up to 64 mandates per batch. Each is created independently — individual
+/// failures do not prevent other mandates from being created.
+/// Returns 429 if backpressure is active.
+async fn create_mandate_batch(
+    State(state): State<Arc<AppState>>,
+    Json(req): Json<cognitod::mandate::BatchMandateRequest>,
+) -> Result<Json<cognitod::mandate::BatchMandateResponse>, (StatusCode, Json<serde_json::Value>)> {
+    let mgr = state.mandate.as_ref().ok_or((
+        StatusCode::SERVICE_UNAVAILABLE,
+        Json(json!({"error": "mandate system not enabled"})),
+    ))?;
+
+    if mgr.is_backpressure_active() {
+        return Err((
+            StatusCode::TOO_MANY_REQUESTS,
+            Json(json!({"error": "mandate map backpressure active, retry later"})),
+        ));
+    }
+
+    if req.mandates.is_empty() {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            Json(json!({"error": "batch must contain at least one mandate"})),
+        ));
+    }
+
+    if req.mandates.len() > 64 {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            Json(json!({"error": "batch size exceeds maximum of 64"})),
+        ));
+    }
+
+    Ok(Json(mgr.create_batch(req).await))
+}
+
+/// GET /.well-known/agent-card.json — A2A Agent Card (§4)
+///
+/// Returns the A2A-compliant agent card with `x-linnix-claw` extension
+/// advertising kernel attestation, settlement preferences, and skills.
+async fn get_agent_card(
+    State(state): State<Arc<AppState>>,
+) -> Json<cognitod::agent_card::AgentCard> {
+    let bpf_available = state
+        .mandate
+        .as_ref()
+        .map(|m| m.health().bpf_lsm_loaded)
+        .unwrap_or(false);
+
+    let enforcement_mode = state
+        .mandate
+        .as_ref()
+        .map(|m| m.health().enforcement_mode.clone())
+        .unwrap_or_else(|| "disabled".to_string());
+
+    let listen_addr =
+        std::env::var("LINNIX_LISTEN_ADDR").unwrap_or_else(|_| "0.0.0.0:3000".to_string());
+
+    let identity = state.identity.as_deref();
+
+    Json(cognitod::agent_card::build_agent_card(
+        identity,
+        bpf_available,
+        &enforcement_mode,
+        &listen_addr,
+    ))
+}
+
 #[derive(Serialize)]
 struct DropBreakdown {
     event_type: u32,
@@ -1540,6 +1782,9 @@ pub async fn prometheus_metrics(State(app_state): State<Arc<AppState>>) -> Respo
         );
     }
 
+    // Claw SLO metrics (§10.5)
+    body.push_str(&app_state.claw_metrics.render_prometheus());
+
     Response::builder()
         .status(StatusCode::OK)
         .header(
@@ -1620,6 +1865,13 @@ pub struct AppState {
     pub enforcement: Option<Arc<crate::enforcement::EnforcementQueue>>,
     pub incident_store: Option<Arc<IncidentStore>>,
     pub k8s: Option<Arc<cognitod::k8s::K8sContext>>,
+    pub mandate: Option<Arc<cognitod::mandate::MandateManager>>,
+    /// Agent identity for receipt signing and agent card.
+    pub identity: Option<Arc<cognitod::identity::AgentIdentity>>,
+    /// Commerce policy for §11.1 deployment-mode gating.
+    pub commerce_policy: Option<cognitod::commerce::CommercePolicy>,
+    /// Claw SLO metrics (§10.5).
+    pub claw_metrics: Arc<cognitod::claw_metrics::ClawMetrics>,
 }
 
 pub fn all_routes(app_state: Arc<AppState>) -> Router {
@@ -1659,7 +1911,16 @@ pub fn all_routes(app_state: Arc<AppState>) -> Router {
         .route("/actions", get(get_actions))
         .route("/actions/{id}", get(get_action_by_id))
         .route("/actions/{id}/approve", axum::routing::post(approve_action))
-        .route("/actions/{id}/reject", axum::routing::post(reject_action));
+        .route("/actions/{id}/reject", axum::routing::post(reject_action))
+        .route("/mandates", post(create_mandate))
+        .route("/mandates", get(list_mandates))
+        .route("/mandates/batch", post(create_mandate_batch))
+        .route("/mandates/stats", get(get_mandate_stats))
+        .route("/mandates/{id}", get(get_mandate_by_id))
+        .route("/mandates/{id}", axum::routing::delete(revoke_mandate))
+        .route("/mandates/{id}/receipt", get(get_mandate_receipt))
+        .route("/health/mandate", get(get_mandate_health))
+        .route("/.well-known/agent-card.json", get(get_agent_card));
 
     if prometheus_enabled {
         router = router.route("/metrics/prometheus", get(prometheus_metrics));
@@ -1672,6 +1933,65 @@ pub fn all_routes(app_state: Arc<AppState>) -> Router {
         ));
     }
 
+    router.with_state(app_state)
+}
+
+/// Build routes for the Unix domain socket listener.
+///
+/// UDS connections bypass token auth — local process identity is verified
+/// by socket credentials (`SO_PEERCRED`). The routes are identical to `all_routes`
+/// but never apply the auth middleware layer.
+pub fn uds_routes(app_state: Arc<AppState>) -> Router {
+    let prometheus_enabled = app_state.prometheus_enabled;
+
+    let mut router = Router::new()
+        .route("/", get(crate::ui::dashboard_handler))
+        .route("/dashboard", get(crate::ui::dashboard_handler))
+        .route("/context", get(get_context_route))
+        .route("/processes", get(get_processes))
+        .route("/processes/live", get(stream_processes_live))
+        .route("/processes/{pid}", get(get_process_by_pid))
+        .route("/ppid/{ppid}", get(get_by_ppid))
+        .route("/graph/{pid}", get(get_graph))
+        .route("/events", get(stream_events))
+        .route("/stream", get(stream_events))
+        .route("/system", get(system_snapshot))
+        .route("/timeline", get(get_timeline))
+        .route("/metrics/system", get(get_system_metrics))
+        .route("/alerts", get(stream_alerts))
+        .route("/insights", get(get_insights))
+        .route("/insights/recent", get(get_recent_insights))
+        .route("/insights/{id}", get(get_insight_by_id))
+        .route("/insights/{id}/feedback", post(submit_feedback))
+        .route("/api/feedback", post(submit_feedback_api))
+        .route("/api/slack/interactions", post(handle_slack_interaction))
+        .route("/incidents", get(get_incidents))
+        .route("/incidents/summary", get(get_incident_summary))
+        .route("/incidents/stats", get(get_incident_stats))
+        .route("/incidents/{id}", get(get_incident_by_id))
+        .route("/attribution", get(get_attributions))
+        .route("/metrics", get(metrics_handler))
+        .route("/status", get(status_handler))
+        .route("/healthz", get(healthz))
+        .route("/actions", get(get_actions))
+        .route("/actions/{id}", get(get_action_by_id))
+        .route("/actions/{id}/approve", axum::routing::post(approve_action))
+        .route("/actions/{id}/reject", axum::routing::post(reject_action))
+        .route("/mandates", post(create_mandate))
+        .route("/mandates", get(list_mandates))
+        .route("/mandates/batch", post(create_mandate_batch))
+        .route("/mandates/stats", get(get_mandate_stats))
+        .route("/mandates/{id}", get(get_mandate_by_id))
+        .route("/mandates/{id}", axum::routing::delete(revoke_mandate))
+        .route("/mandates/{id}/receipt", get(get_mandate_receipt))
+        .route("/health/mandate", get(get_mandate_health))
+        .route("/.well-known/agent-card.json", get(get_agent_card));
+
+    if prometheus_enabled {
+        router = router.route("/metrics/prometheus", get(prometheus_metrics));
+    }
+
+    // NOTE: No auth middleware — UDS connections are trusted (local process identity).
     router.with_state(app_state)
 }
 
@@ -2201,6 +2521,10 @@ mod tests {
             auth_token: None,
             incident_store: None,
             k8s: None,
+            mandate: None,
+            identity: None,
+            commerce_policy: None,
+            claw_metrics: Arc::new(cognitod::claw_metrics::ClawMetrics::new()),
         });
         let Json(resp) = super::status_handler(State(app_state)).await;
         let val = serde_json::to_value(resp).unwrap();
@@ -2249,6 +2573,10 @@ mod tests {
             auth_token: None,
             incident_store: None,
             k8s: None,
+            mandate: None,
+            identity: None,
+            commerce_policy: None,
+            claw_metrics: Arc::new(cognitod::claw_metrics::ClawMetrics::new()),
         });
 
         let Json(resp) = super::metrics_handler(State(app_state)).await;
@@ -2280,6 +2608,10 @@ mod tests {
             auth_token: None,
             incident_store: None,
             k8s: None,
+            mandate: None,
+            identity: None,
+            commerce_policy: None,
+            claw_metrics: Arc::new(cognitod::claw_metrics::ClawMetrics::new()),
         });
         let router = super::all_routes(Arc::clone(&app_state));
         let response = router
@@ -2314,6 +2646,10 @@ mod tests {
             auth_token: None,
             incident_store: None,
             k8s: None,
+            mandate: None,
+            identity: None,
+            commerce_policy: None,
+            claw_metrics: Arc::new(cognitod::claw_metrics::ClawMetrics::new()),
         });
         let router = super::all_routes(Arc::clone(&app_state));
         let response = router
@@ -2362,6 +2698,10 @@ mod tests {
             auth_token: None,
             incident_store: None,
             k8s: None,
+            mandate: None,
+            identity: None,
+            commerce_policy: None,
+            claw_metrics: Arc::new(cognitod::claw_metrics::ClawMetrics::new()),
         });
         let router = super::all_routes(app_state);
         let response = router
@@ -2395,6 +2735,10 @@ mod tests {
             incident_store: None,
             auth_token: Some("secret123".to_string()),
             k8s: None,
+            mandate: None,
+            identity: None,
+            commerce_policy: None,
+            claw_metrics: Arc::new(cognitod::claw_metrics::ClawMetrics::new()),
         });
         let router = super::all_routes(app_state);
         let response = router
@@ -2428,6 +2772,10 @@ mod tests {
             incident_store: None,
             auth_token: Some("secret123".to_string()),
             k8s: None,
+            mandate: None,
+            identity: None,
+            commerce_policy: None,
+            claw_metrics: Arc::new(cognitod::claw_metrics::ClawMetrics::new()),
         });
         let router = super::all_routes(app_state);
         let response = router
@@ -2462,6 +2810,10 @@ mod tests {
             incident_store: None,
             auth_token: Some("secret123".to_string()),
             k8s: None,
+            mandate: None,
+            identity: None,
+            commerce_policy: None,
+            claw_metrics: Arc::new(cognitod::claw_metrics::ClawMetrics::new()),
         });
         let router = super::all_routes(app_state);
         let response = router
@@ -2496,6 +2848,10 @@ mod tests {
             incident_store: None,
             auth_token: Some("secret123".to_string()),
             k8s: None,
+            mandate: None,
+            identity: None,
+            commerce_policy: None,
+            claw_metrics: Arc::new(cognitod::claw_metrics::ClawMetrics::new()),
         });
         let router = super::all_routes(app_state);
         let response = router
@@ -2509,5 +2865,370 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    // =========================================================================
+    // Mandate API integration tests
+    // =========================================================================
+
+    fn app_state_with_mandate() -> Arc<AppState> {
+        let mgr = cognitod::mandate::MandateManager::new(
+            [0x0706050403020100, 0x0f0e0d0c0b0a0908],
+            false,
+            linnix_ai_ebpf_common::MandateMode::Monitor,
+        );
+        Arc::new(AppState {
+            context: Arc::new(ContextStore::new(Duration::from_secs(60), 10, None)),
+            metrics: Arc::new(Metrics::new()),
+            alerts: None,
+            insights: Arc::new(InsightStore::new(16, None)),
+            offline: Arc::new(OfflineGuard::new(false)),
+            transport: "perf",
+            probe_state: ProbeState::disabled(),
+            enforcement: None,
+            reasoner: ReasonerConfig::default(),
+            prometheus_enabled: false,
+            alert_history: Arc::new(AlertHistory::new(16)),
+            auth_token: None,
+            incident_store: None,
+            k8s: None,
+            mandate: Some(Arc::new(mgr)),
+            identity: None,
+            commerce_policy: None,
+            claw_metrics: Arc::new(cognitod::claw_metrics::ClawMetrics::new()),
+        })
+    }
+
+    #[tokio::test]
+    async fn mandate_health_returns_ok() {
+        let app_state = app_state_with_mandate();
+        let router = super::all_routes(app_state);
+        let resp = router
+            .oneshot(
+                Request::builder()
+                    .uri("/health/mandate")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+        let val: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(val["enforcement_mode"], "monitor");
+        assert_eq!(val["bpf_lsm_loaded"], false);
+        assert_eq!(val["siphash_key_set"], true);
+    }
+
+    #[tokio::test]
+    async fn mandate_health_503_when_disabled() {
+        let app_state = Arc::new(AppState {
+            context: Arc::new(ContextStore::new(Duration::from_secs(60), 10, None)),
+            metrics: Arc::new(Metrics::new()),
+            alerts: None,
+            insights: Arc::new(InsightStore::new(16, None)),
+            offline: Arc::new(OfflineGuard::new(false)),
+            transport: "perf",
+            probe_state: ProbeState::disabled(),
+            enforcement: None,
+            reasoner: ReasonerConfig::default(),
+            prometheus_enabled: false,
+            alert_history: Arc::new(AlertHistory::new(16)),
+            auth_token: None,
+            incident_store: None,
+            k8s: None,
+            mandate: None,
+            identity: None,
+            commerce_policy: None,
+            claw_metrics: Arc::new(cognitod::claw_metrics::ClawMetrics::new()),
+        });
+        let router = super::all_routes(app_state);
+        let resp = router
+            .oneshot(
+                Request::builder()
+                    .uri("/health/mandate")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
+    }
+
+    #[tokio::test]
+    async fn mandate_create_get_revoke_lifecycle() {
+        let app_state = app_state_with_mandate();
+        let pid = std::process::id();
+
+        // POST /mandates — create
+        let router = super::all_routes(Arc::clone(&app_state));
+        let body = serde_json::json!({
+            "pid": pid,
+            "args": ["/usr/bin/curl", "https://example.com"],
+            "ttl_ms": 10000
+        });
+        let resp = router
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/mandates")
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::CREATED);
+        let resp_body = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+        let created: serde_json::Value = serde_json::from_slice(&resp_body).unwrap();
+        let mandate_id = created["id"].as_str().unwrap().to_string();
+        assert_eq!(created["status"], "active");
+        assert_eq!(created["key"]["pid"], pid);
+        assert!(created["key"]["cmd_hash"].as_u64().unwrap() > 0);
+
+        // GET /mandates/{id} — retrieve
+        let router = super::all_routes(Arc::clone(&app_state));
+        let resp = router
+            .oneshot(
+                Request::builder()
+                    .uri(format!("/mandates/{}", mandate_id))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let resp_body = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+        let fetched: serde_json::Value = serde_json::from_slice(&resp_body).unwrap();
+        assert_eq!(fetched["id"], mandate_id);
+        assert_eq!(fetched["status"], "active");
+
+        // DELETE /mandates/{id} — revoke
+        let router = super::all_routes(Arc::clone(&app_state));
+        let resp = router
+            .oneshot(
+                Request::builder()
+                    .method("DELETE")
+                    .uri(format!("/mandates/{}", mandate_id))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+
+        // GET again — should be revoked
+        let router = super::all_routes(Arc::clone(&app_state));
+        let resp = router
+            .oneshot(
+                Request::builder()
+                    .uri(format!("/mandates/{}", mandate_id))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let resp_body = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+        let revoked: serde_json::Value = serde_json::from_slice(&resp_body).unwrap();
+        assert_eq!(revoked["status"], "revoked");
+    }
+
+    #[tokio::test]
+    async fn mandate_stats_endpoint() {
+        let app_state = app_state_with_mandate();
+        let pid = std::process::id();
+
+        // Create two mandates
+        let router = super::all_routes(Arc::clone(&app_state));
+        let body = serde_json::json!({"pid": pid, "args": ["/bin/ls"], "ttl_ms": 5000});
+        let resp = router
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/mandates")
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::CREATED);
+
+        let router = super::all_routes(Arc::clone(&app_state));
+        let body = serde_json::json!({"pid": pid, "args": ["/bin/cat"], "ttl_ms": 5000});
+        let resp = router
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/mandates")
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::CREATED);
+
+        // GET /mandates/stats
+        let router = super::all_routes(Arc::clone(&app_state));
+        let resp = router
+            .oneshot(
+                Request::builder()
+                    .uri("/mandates/stats")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let resp_body = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+        let stats: serde_json::Value = serde_json::from_slice(&resp_body).unwrap();
+        assert_eq!(stats["total_created"], 2);
+        assert_eq!(stats["active_count"], 2);
+        assert_eq!(stats["backpressure_active"], false);
+    }
+
+    #[tokio::test]
+    async fn mandate_list_with_filter() {
+        let app_state = app_state_with_mandate();
+        let pid = std::process::id();
+
+        // Create two mandates
+        let router = super::all_routes(Arc::clone(&app_state));
+        let body = serde_json::json!({"pid": pid, "args": ["/bin/a"], "ttl_ms": 60000});
+        let resp = router
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/mandates")
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::CREATED);
+        let resp_body = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+        let created: serde_json::Value = serde_json::from_slice(&resp_body).unwrap();
+        let id1 = created["id"].as_str().unwrap().to_string();
+
+        let router = super::all_routes(Arc::clone(&app_state));
+        let body = serde_json::json!({"pid": pid, "args": ["/bin/b"], "ttl_ms": 60000});
+        let resp = router
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/mandates")
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::CREATED);
+
+        // Revoke first
+        let router = super::all_routes(Arc::clone(&app_state));
+        let resp = router
+            .oneshot(
+                Request::builder()
+                    .method("DELETE")
+                    .uri(format!("/mandates/{}", id1))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+
+        // GET /mandates?status=active
+        let router = super::all_routes(Arc::clone(&app_state));
+        let resp = router
+            .oneshot(
+                Request::builder()
+                    .uri("/mandates?status=active")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let resp_body = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+        let list: Vec<serde_json::Value> = serde_json::from_slice(&resp_body).unwrap();
+        assert_eq!(list.len(), 1);
+        assert_eq!(list[0]["status"], "active");
+
+        // GET /mandates (no filter — both)
+        let router = super::all_routes(Arc::clone(&app_state));
+        let resp = router
+            .oneshot(
+                Request::builder()
+                    .uri("/mandates")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let resp_body = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+        let list: Vec<serde_json::Value> = serde_json::from_slice(&resp_body).unwrap();
+        assert_eq!(list.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn mandate_get_nonexistent_returns_404() {
+        let app_state = app_state_with_mandate();
+        let router = super::all_routes(app_state);
+        let resp = router
+            .oneshot(
+                Request::builder()
+                    .uri("/mandates/does-not-exist")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn mandate_delete_nonexistent_returns_404() {
+        let app_state = app_state_with_mandate();
+        let router = super::all_routes(app_state);
+        let resp = router
+            .oneshot(
+                Request::builder()
+                    .method("DELETE")
+                    .uri("/mandates/does-not-exist")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn mandate_create_invalid_pid_returns_400() {
+        let app_state = app_state_with_mandate();
+        let router = super::all_routes(app_state);
+        // PID 999999999 almost certainly doesn't exist
+        let body = serde_json::json!({"pid": 999999999, "args": ["/bin/ls"], "ttl_ms": 5000});
+        let resp = router
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/mandates")
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        let resp_body = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+        let err: serde_json::Value = serde_json::from_slice(&resp_body).unwrap();
+        assert!(err["error"].as_str().unwrap().contains("999999999"));
     }
 }

--- a/cognitod/src/bpf_config.rs
+++ b/cognitod/src/bpf_config.rs
@@ -3,6 +3,7 @@ use btf::btf::{Array, Btf, Struct, Type};
 use linnix_ai_ebpf_common::{TelemetryConfig, rss_source};
 use std::convert::TryFrom;
 use std::env;
+use std::io::Read;
 use sysinfo::System;
 
 const KERNEL_BTF_PATH: &str = "/sys/kernel/btf/vmlinux";
@@ -32,6 +33,15 @@ pub fn derive_telemetry_config() -> Result<TelemetryConfigResult> {
     let (pid_bits, _) = member_offset(task_struct, "pid")?;
     let (comm_bits, _) = member_offset(task_struct, "comm")?;
     let (se_bits, se_type) = member_offset(task_struct, "se")?;
+
+    // `start_boottime` (or legacy `real_start_time`) stores the task start
+    // time in boot-monotonic nanoseconds.  This is the same value the
+    // MandateKey.start_time_ns field must contain for kernel/userspace
+    // to refer to the same process without PID confusion.
+    let start_boottime_bits = member_offset(task_struct, "start_boottime")
+        .or_else(|_| member_offset(task_struct, "real_start_time"))
+        .map(|(bits, _)| bits)
+        .unwrap_or(0); // 0 disables start_time check in LSM if field not found
 
     let signal_candidate = rss_layout_for_field(&btf, task_struct, "signal")?;
     let mm_candidate = rss_layout_for_field(&btf, task_struct, "mm")?;
@@ -96,6 +106,11 @@ pub fn derive_telemetry_config() -> Result<TelemetryConfigResult> {
     telemetry.rss_anon_index = anon_index;
     telemetry.page_size = page_size;
     telemetry.total_memory_bytes = total_memory_bytes;
+    telemetry.task_start_boottime_offset = if start_boottime_bits > 0 {
+        to_bytes(start_boottime_bits).unwrap_or(0)
+    } else {
+        0
+    };
 
     if let Some(bits) = signal_bits {
         telemetry.task_signal_offset = to_bytes(bits)?;
@@ -427,6 +442,49 @@ fn to_bytes(bits: u32) -> Result<u32> {
     }
 }
 
+// =============================================================================
+// BPF LSM CAPABILITY DETECTION
+// =============================================================================
+//
+// Linnix-Claw requires CONFIG_BPF_LSM=y and the "bpf" entry in the kernel's
+// active LSM list. Without it, cognitod runs in observability-only mode —
+// mandates are tracked via the API but the kernel doesn't enforce them.
+//
+// This mirrors the existing BTF degradation pattern: try to load, warn if
+// unavailable, continue with reduced functionality.
+
+const LSM_PATH: &str = "/sys/kernel/security/lsm";
+
+/// Check whether the running kernel has BPF LSM support enabled.
+///
+/// Reads `/sys/kernel/security/lsm` and looks for the "bpf" entry in the
+/// comma-separated list. This file is always readable (mode 0444).
+///
+/// Returns `true` if "bpf" is found, `false` otherwise.
+pub fn is_bpf_lsm_available() -> bool {
+    let Ok(content) = std::fs::read_to_string(LSM_PATH) else {
+        return false;
+    };
+
+    content.trim().split(',').any(|entry| entry.trim() == "bpf")
+}
+
+/// Generate a 128-bit SipHash key from /dev/urandom.
+///
+/// This key is injected into the eBPF SIPHASH_KEY map at load time.
+/// It MUST match what the userspace MandateManager uses.
+pub fn generate_siphash_key() -> Result<[u64; 2]> {
+    let mut buf = [0u8; 16];
+    let mut f = std::fs::File::open("/dev/urandom").context("failed to open /dev/urandom")?;
+    f.read_exact(&mut buf)
+        .context("failed to read 16 bytes from /dev/urandom")?;
+
+    let k0 = u64::from_le_bytes(buf[0..8].try_into().unwrap());
+    let k1 = u64::from_le_bytes(buf[8..16].try_into().unwrap());
+
+    Ok([k0, k1])
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -436,5 +494,15 @@ mod tests {
         assert_eq!(to_bytes(0).unwrap(), 0);
         assert_eq!(to_bytes(8).unwrap(), 1);
         assert!(to_bytes(3).is_err());
+    }
+
+    #[test]
+    fn lsm_detection_returns_result() {
+        // This test just verifies the function doesn't panic.
+        // On most CI systems CONFIG_BPF_LSM may not be set.
+        let available = is_bpf_lsm_available();
+        // We can't assert true/false since it depends on kernel config,
+        // but we can assert it runs without error.
+        let _ = available;
     }
 }

--- a/cognitod/src/claw_metrics.rs
+++ b/cognitod/src/claw_metrics.rs
@@ -1,0 +1,488 @@
+// cognitod/src/claw_metrics.rs — Linnix-Claw Prometheus SLO metrics (§10.5)
+//
+// Tracks mandate lifecycle, receipt signing, settlement finality, and
+// reconciliation runs. All fields are lock-free atomics suitable for the
+// hot path.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Linnix-Commercial
+
+use std::fmt::Write;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+// ── Histogram bucket boundaries (nanoseconds for latency, seconds for finality) ──
+
+/// Mandate creation latency histogram buckets (nanoseconds).
+/// Covers 50µs → 500ms in exponential-ish steps.
+const MANDATE_LATENCY_BUCKETS_NS: &[u64] = &[
+    50_000,      // 50µs
+    100_000,     // 100µs
+    250_000,     // 250µs
+    500_000,     // 500µs
+    1_000_000,   // 1ms
+    2_500_000,   // 2.5ms
+    5_000_000,   // 5ms
+    10_000_000,  // 10ms
+    25_000_000,  // 25ms
+    50_000_000,  // 50ms
+    100_000_000, // 100ms
+    500_000_000, // 500ms
+];
+
+/// Receipt signing latency histogram buckets (nanoseconds).
+/// Covers 10µs → 100ms — signing should be fast (Ed25519 + secp256k1).
+const RECEIPT_SIGN_LATENCY_BUCKETS_NS: &[u64] = &[
+    10_000,      // 10µs
+    25_000,      // 25µs
+    50_000,      // 50µs
+    100_000,     // 100µs
+    250_000,     // 250µs
+    500_000,     // 500µs
+    1_000_000,   // 1ms
+    5_000_000,   // 5ms
+    10_000_000,  // 10ms
+    50_000_000,  // 50ms
+    100_000_000, // 100ms
+];
+
+/// Settlement finality histogram buckets (seconds).
+/// From 1s to 1h — covers L2 fast finality through L1 confirmation.
+const SETTLEMENT_FINALITY_BUCKETS_S: &[u64] = &[
+    1,    // 1s
+    2,    // 2s
+    5,    // 5s
+    10,   // 10s
+    30,   // 30s
+    60,   // 1min
+    120,  // 2min
+    300,  // 5min
+    600,  // 10min
+    1800, // 30min
+    3600, // 1h
+];
+
+// ── Lock-free histogram ─────────────────────────────────────────────────────
+
+/// A fixed-bucket histogram using atomic counters.
+///
+/// Each bucket counts observations ≤ the bucket boundary. An extra `+Inf`
+/// bucket captures all observations. Thread-safe via `AtomicU64`.
+pub struct AtomicHistogram {
+    /// Upper-bound of each bucket (exclusive of next).
+    boundaries: &'static [u64],
+    /// One counter per boundary, plus a +Inf counter at the end.
+    buckets: Vec<AtomicU64>,
+    /// Running sum of all observed values.
+    sum: AtomicU64,
+    /// Total observation count.
+    count: AtomicU64,
+}
+
+impl AtomicHistogram {
+    pub fn new(boundaries: &'static [u64]) -> Self {
+        let mut buckets = Vec::with_capacity(boundaries.len() + 1);
+        for _ in 0..=boundaries.len() {
+            buckets.push(AtomicU64::new(0));
+        }
+        Self {
+            boundaries,
+            buckets,
+            sum: AtomicU64::new(0),
+            count: AtomicU64::new(0),
+        }
+    }
+
+    /// Record a single observation.
+    pub fn observe(&self, value: u64) {
+        self.sum.fetch_add(value, Ordering::Relaxed);
+        self.count.fetch_add(1, Ordering::Relaxed);
+
+        // Increment all buckets whose boundary ≥ value (cumulative).
+        for (i, &bound) in self.boundaries.iter().enumerate() {
+            if value <= bound {
+                self.buckets[i].fetch_add(1, Ordering::Relaxed);
+            }
+        }
+        // Always increment +Inf bucket.
+        self.buckets[self.boundaries.len()].fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Render as Prometheus exposition format lines into `buf`.
+    pub fn render(&self, buf: &mut String, name: &str, help: &str, unit: &str) {
+        let _ = writeln!(buf, "# HELP {} {}", name, help);
+        let _ = writeln!(buf, "# TYPE {} histogram", name);
+
+        for (i, &bound) in self.boundaries.iter().enumerate() {
+            let count = self.buckets[i].load(Ordering::Relaxed);
+            let _ = writeln!(buf, "{}_bucket{{le=\"{}{}\"}} {}", name, bound, unit, count);
+        }
+        let inf_count = self.buckets[self.boundaries.len()].load(Ordering::Relaxed);
+        let _ = writeln!(buf, "{}_bucket{{le=\"+Inf\"}} {}", name, inf_count);
+
+        let sum = self.sum.load(Ordering::Relaxed);
+        let count = self.count.load(Ordering::Relaxed);
+        let _ = writeln!(buf, "{}_sum {}", name, sum);
+        let _ = writeln!(buf, "{}_count {}", name, count);
+    }
+
+    /// Total observations.
+    pub fn count(&self) -> u64 {
+        self.count.load(Ordering::Relaxed)
+    }
+
+    /// Sum of all observations.
+    pub fn sum(&self) -> u64 {
+        self.sum.load(Ordering::Relaxed)
+    }
+
+    /// Snapshot bucket cumulative counts. Length = boundaries.len() + 1 (+Inf).
+    pub fn bucket_counts(&self) -> Vec<u64> {
+        self.buckets
+            .iter()
+            .map(|b| b.load(Ordering::Relaxed))
+            .collect()
+    }
+}
+
+// ── Claw SLO Metrics ────────────────────────────────────────────────────────
+
+/// Linnix-Claw SLO metrics (§10.5).
+///
+/// Exposed at `/metrics/prometheus` alongside existing linnix_* gauges.
+pub struct ClawMetrics {
+    // Counters — mandate lifecycle
+    pub mandates_created: AtomicU64,
+    pub mandates_rejected: AtomicU64,
+    pub mandates_revoked: AtomicU64,
+    pub mandates_expired: AtomicU64,
+    pub mandates_executed: AtomicU64,
+
+    // Gauge — current active mandates
+    pub mandates_active: AtomicU64,
+
+    // Histograms
+    pub mandate_latency: AtomicHistogram,
+    pub receipt_sign_latency: AtomicHistogram,
+    pub settlement_finality: AtomicHistogram,
+
+    // Counter — reconciliation runs
+    pub reconciliation_runs: AtomicU64,
+
+    // Commerce policy rejections
+    pub commerce_rejections: AtomicU64,
+}
+
+impl ClawMetrics {
+    pub fn new() -> Self {
+        Self {
+            mandates_created: AtomicU64::new(0),
+            mandates_rejected: AtomicU64::new(0),
+            mandates_revoked: AtomicU64::new(0),
+            mandates_expired: AtomicU64::new(0),
+            mandates_executed: AtomicU64::new(0),
+            mandates_active: AtomicU64::new(0),
+            mandate_latency: AtomicHistogram::new(MANDATE_LATENCY_BUCKETS_NS),
+            receipt_sign_latency: AtomicHistogram::new(RECEIPT_SIGN_LATENCY_BUCKETS_NS),
+            settlement_finality: AtomicHistogram::new(SETTLEMENT_FINALITY_BUCKETS_S),
+            reconciliation_runs: AtomicU64::new(0),
+            commerce_rejections: AtomicU64::new(0),
+        }
+    }
+
+    // ── Counter helpers ──────────────────────────────────────────────────
+
+    pub fn inc_created(&self) {
+        self.mandates_created.fetch_add(1, Ordering::Relaxed);
+        self.mandates_active.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn inc_rejected(&self) {
+        self.mandates_rejected.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn inc_revoked(&self) {
+        self.mandates_revoked.fetch_add(1, Ordering::Relaxed);
+        self.mandates_active.fetch_sub(1, Ordering::Relaxed);
+    }
+
+    pub fn inc_expired(&self) {
+        self.mandates_expired.fetch_add(1, Ordering::Relaxed);
+        self.mandates_active.fetch_sub(1, Ordering::Relaxed);
+    }
+
+    pub fn inc_executed(&self) {
+        self.mandates_executed.fetch_add(1, Ordering::Relaxed);
+        self.mandates_active.fetch_sub(1, Ordering::Relaxed);
+    }
+
+    pub fn inc_reconciliation(&self) {
+        self.reconciliation_runs.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn inc_commerce_rejection(&self) {
+        self.commerce_rejections.fetch_add(1, Ordering::Relaxed);
+    }
+
+    // ── Histogram observation helpers ────────────────────────────────────
+
+    /// Record mandate creation latency in nanoseconds.
+    pub fn observe_mandate_latency_ns(&self, ns: u64) {
+        self.mandate_latency.observe(ns);
+    }
+
+    /// Record receipt signing latency in nanoseconds.
+    pub fn observe_receipt_sign_latency_ns(&self, ns: u64) {
+        self.receipt_sign_latency.observe(ns);
+    }
+
+    /// Record settlement finality in seconds.
+    pub fn observe_settlement_finality_s(&self, seconds: u64) {
+        self.settlement_finality.observe(seconds);
+    }
+
+    // ── Prometheus rendering ─────────────────────────────────────────────
+
+    /// Render all Claw SLO metrics in Prometheus exposition format.
+    pub fn render_prometheus(&self) -> String {
+        let mut buf = String::with_capacity(4096);
+
+        // Counters: linnix_mandates_total{result="..."}
+        let _ = writeln!(
+            buf,
+            "# HELP linnix_mandates_total Total mandate operations by result."
+        );
+        let _ = writeln!(buf, "# TYPE linnix_mandates_total counter");
+        let _ = writeln!(
+            buf,
+            "linnix_mandates_total{{result=\"created\"}} {}",
+            self.mandates_created.load(Ordering::Relaxed)
+        );
+        let _ = writeln!(
+            buf,
+            "linnix_mandates_total{{result=\"rejected\"}} {}",
+            self.mandates_rejected.load(Ordering::Relaxed)
+        );
+        let _ = writeln!(
+            buf,
+            "linnix_mandates_total{{result=\"revoked\"}} {}",
+            self.mandates_revoked.load(Ordering::Relaxed)
+        );
+        let _ = writeln!(
+            buf,
+            "linnix_mandates_total{{result=\"expired\"}} {}",
+            self.mandates_expired.load(Ordering::Relaxed)
+        );
+        let _ = writeln!(
+            buf,
+            "linnix_mandates_total{{result=\"executed\"}} {}",
+            self.mandates_executed.load(Ordering::Relaxed)
+        );
+
+        // Gauge: linnix_mandates_active
+        let _ = writeln!(
+            buf,
+            "# HELP linnix_mandates_active Currently active mandates."
+        );
+        let _ = writeln!(buf, "# TYPE linnix_mandates_active gauge");
+        let _ = writeln!(
+            buf,
+            "linnix_mandates_active {}",
+            self.mandates_active.load(Ordering::Relaxed)
+        );
+
+        // Histogram: linnix_mandate_latency_ns
+        self.mandate_latency.render(
+            &mut buf,
+            "linnix_mandate_latency_ns",
+            "Mandate creation latency in nanoseconds.",
+            "",
+        );
+
+        // Histogram: linnix_receipt_sign_latency_ns
+        self.receipt_sign_latency.render(
+            &mut buf,
+            "linnix_receipt_sign_latency_ns",
+            "Receipt signing latency in nanoseconds.",
+            "",
+        );
+
+        // Histogram: linnix_settlement_finality_seconds
+        self.settlement_finality.render(
+            &mut buf,
+            "linnix_settlement_finality_seconds",
+            "Time to settlement finality in seconds.",
+            "",
+        );
+
+        // Counter: linnix_mandate_reconciliation_runs_total
+        let _ = writeln!(
+            buf,
+            "# HELP linnix_mandate_reconciliation_runs_total Total mandate reconciliation sweeps."
+        );
+        let _ = writeln!(
+            buf,
+            "# TYPE linnix_mandate_reconciliation_runs_total counter"
+        );
+        let _ = writeln!(
+            buf,
+            "linnix_mandate_reconciliation_runs_total {}",
+            self.reconciliation_runs.load(Ordering::Relaxed)
+        );
+
+        // Counter: linnix_commerce_rejections_total
+        let _ = writeln!(
+            buf,
+            "# HELP linnix_commerce_rejections_total Commerce requests rejected by policy."
+        );
+        let _ = writeln!(buf, "# TYPE linnix_commerce_rejections_total counter");
+        let _ = writeln!(
+            buf,
+            "linnix_commerce_rejections_total {}",
+            self.commerce_rejections.load(Ordering::Relaxed)
+        );
+
+        buf
+    }
+}
+
+impl Default for ClawMetrics {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn histogram_observe_and_cumulative_buckets() {
+        let h = AtomicHistogram::new(&[10, 50, 100]);
+        h.observe(5); // fits in bucket 10, 50, 100, +Inf
+        h.observe(25); // fits in bucket 50, 100, +Inf
+        h.observe(75); // fits in bucket 100, +Inf
+        h.observe(200); // fits only in +Inf
+
+        let counts = h.bucket_counts();
+        assert_eq!(counts.len(), 4); // 3 boundaries + Inf
+        assert_eq!(counts[0], 1); // le=10: only value 5
+        assert_eq!(counts[1], 2); // le=50: values 5, 25
+        assert_eq!(counts[2], 3); // le=100: values 5, 25, 75
+        assert_eq!(counts[3], 4); // +Inf: all 4
+
+        assert_eq!(h.count(), 4);
+        assert_eq!(h.sum(), 5 + 25 + 75 + 200);
+    }
+
+    #[test]
+    fn histogram_render_prometheus_format() {
+        let h = AtomicHistogram::new(&[100, 500]);
+        h.observe(50);
+        h.observe(300);
+        h.observe(1000);
+
+        let mut buf = String::new();
+        h.render(&mut buf, "test_metric", "A test histogram.", "");
+
+        assert!(buf.contains("# HELP test_metric A test histogram."));
+        assert!(buf.contains("# TYPE test_metric histogram"));
+        assert!(buf.contains("test_metric_bucket{le=\"100\"} 1"));
+        assert!(buf.contains("test_metric_bucket{le=\"500\"} 2"));
+        assert!(buf.contains("test_metric_bucket{le=\"+Inf\"} 3"));
+        assert!(buf.contains("test_metric_sum 1350"));
+        assert!(buf.contains("test_metric_count 3"));
+    }
+
+    #[test]
+    fn claw_metrics_mandate_counters() {
+        let m = ClawMetrics::new();
+
+        m.inc_created();
+        m.inc_created();
+        m.inc_created();
+        assert_eq!(m.mandates_created.load(Ordering::Relaxed), 3);
+        assert_eq!(m.mandates_active.load(Ordering::Relaxed), 3);
+
+        m.inc_revoked();
+        assert_eq!(m.mandates_revoked.load(Ordering::Relaxed), 1);
+        assert_eq!(m.mandates_active.load(Ordering::Relaxed), 2);
+
+        m.inc_executed();
+        assert_eq!(m.mandates_executed.load(Ordering::Relaxed), 1);
+        assert_eq!(m.mandates_active.load(Ordering::Relaxed), 1);
+
+        m.inc_expired();
+        assert_eq!(m.mandates_expired.load(Ordering::Relaxed), 1);
+        assert_eq!(m.mandates_active.load(Ordering::Relaxed), 0);
+    }
+
+    #[test]
+    fn claw_metrics_rejected_counter() {
+        let m = ClawMetrics::new();
+        m.inc_rejected();
+        m.inc_rejected();
+        assert_eq!(m.mandates_rejected.load(Ordering::Relaxed), 2);
+        // Rejections don't affect active gauge
+        assert_eq!(m.mandates_active.load(Ordering::Relaxed), 0);
+    }
+
+    #[test]
+    fn claw_metrics_histograms() {
+        let m = ClawMetrics::new();
+
+        m.observe_mandate_latency_ns(500_000); // 0.5ms
+        m.observe_mandate_latency_ns(2_000_000); // 2ms
+        assert_eq!(m.mandate_latency.count(), 2);
+
+        m.observe_receipt_sign_latency_ns(100_000); // 100µs
+        assert_eq!(m.receipt_sign_latency.count(), 1);
+
+        m.observe_settlement_finality_s(15);
+        assert_eq!(m.settlement_finality.count(), 1);
+    }
+
+    #[test]
+    fn claw_metrics_reconciliation_and_commerce() {
+        let m = ClawMetrics::new();
+
+        m.inc_reconciliation();
+        m.inc_reconciliation();
+        assert_eq!(m.reconciliation_runs.load(Ordering::Relaxed), 2);
+
+        m.inc_commerce_rejection();
+        assert_eq!(m.commerce_rejections.load(Ordering::Relaxed), 1);
+    }
+
+    #[test]
+    fn full_prometheus_render_contains_all_families() {
+        let m = ClawMetrics::new();
+        m.inc_created();
+        m.observe_mandate_latency_ns(1_000_000);
+        m.observe_receipt_sign_latency_ns(50_000);
+        m.observe_settlement_finality_s(10);
+        m.inc_reconciliation();
+        m.inc_commerce_rejection();
+
+        let output = m.render_prometheus();
+
+        // Verify all metric families are present
+        assert!(output.contains("linnix_mandates_total{result=\"created\"} 1"));
+        assert!(output.contains("linnix_mandates_active 1"));
+        assert!(output.contains("linnix_mandate_latency_ns_bucket"));
+        assert!(output.contains("linnix_mandate_latency_ns_count 1"));
+        assert!(output.contains("linnix_receipt_sign_latency_ns_bucket"));
+        assert!(output.contains("linnix_receipt_sign_latency_ns_count 1"));
+        assert!(output.contains("linnix_settlement_finality_seconds_bucket"));
+        assert!(output.contains("linnix_settlement_finality_seconds_count 1"));
+        assert!(output.contains("linnix_mandate_reconciliation_runs_total 1"));
+        assert!(output.contains("linnix_commerce_rejections_total 1"));
+    }
+
+    #[test]
+    fn default_trait() {
+        let m = ClawMetrics::default();
+        assert_eq!(m.mandates_created.load(Ordering::Relaxed), 0);
+        assert_eq!(m.mandate_latency.count(), 0);
+    }
+}

--- a/cognitod/src/commerce.rs
+++ b/cognitod/src/commerce.rs
@@ -1,0 +1,208 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// cognitod/src/commerce.rs — Commerce policy enforcement (§11.1)
+//
+// Determines whether commerce operations (mandates with settlement fields)
+// are allowed based on kernel enforcement availability.
+//
+// Default policy: refuse commerce without BPF LSM unless operator explicitly
+// opts in via `allow_commerce_without_lsm = true`.
+
+use serde::Serialize;
+
+// =============================================================================
+// DEPLOYMENT MODE
+// =============================================================================
+
+/// The three deployment modes per §11.1 commerce policy table.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DeploymentMode {
+    /// BPF LSM loaded and mandate mode = "enforce".
+    /// Commerce: allowed. Receipts: kernel-attested. Risk: lowest.
+    FullEnforcement,
+
+    /// BPF LSM loaded but mandate mode = "monitor".
+    /// Commerce: allowed with `degraded=true` in receipts. Risk: medium.
+    MonitorOnly,
+
+    /// BPF LSM not available (observability-only).
+    /// Commerce: only if `allow_commerce_without_lsm = true`. Risk: high.
+    ObservabilityOnly,
+}
+
+impl DeploymentMode {
+    /// Human-readable enforcement mode string for receipts and API responses.
+    pub fn enforcement_mode_str(&self) -> &'static str {
+        match self {
+            Self::FullEnforcement => "enforce",
+            Self::MonitorOnly => "monitor",
+            Self::ObservabilityOnly => "none",
+        }
+    }
+
+    /// Whether receipts from this mode carry kernel attestation.
+    pub fn is_kernel_attested(&self) -> bool {
+        matches!(self, Self::FullEnforcement)
+    }
+
+    /// Whether receipts should be tagged as degraded.
+    pub fn is_degraded(&self) -> bool {
+        !matches!(self, Self::FullEnforcement)
+    }
+}
+
+// =============================================================================
+// COMMERCE POLICY
+// =============================================================================
+
+/// Encapsulates the commerce policy decision logic.
+///
+/// The policy answers: "Should we allow this mandate to proceed?"
+///
+/// Key invariant from §11.1:
+///   If BPF LSM is unavailable AND `allow_commerce_without_lsm = false`,
+///   commerce mandates (those with `task_id` or `max_spend_cents`) are
+///   rejected with 503.
+#[derive(Debug, Clone)]
+pub struct CommercePolicy {
+    /// Current deployment mode (detected at startup).
+    pub mode: DeploymentMode,
+
+    /// Whether the operator has opted in to degraded commerce.
+    pub allow_commerce_without_lsm: bool,
+}
+
+impl CommercePolicy {
+    /// Create a commerce policy from runtime state.
+    pub fn new(bpf_lsm_available: bool, mandate_mode: &str, allow_without_lsm: bool) -> Self {
+        let mode = if bpf_lsm_available {
+            if mandate_mode == "enforce" {
+                DeploymentMode::FullEnforcement
+            } else {
+                DeploymentMode::MonitorOnly
+            }
+        } else {
+            DeploymentMode::ObservabilityOnly
+        };
+
+        Self {
+            mode,
+            allow_commerce_without_lsm: allow_without_lsm,
+        }
+    }
+
+    /// Check whether a mandate with settlement fields should be allowed.
+    ///
+    /// Returns `Ok(())` if allowed, or `Err(CommerceRejection)` if the
+    /// policy blocks it.
+    pub fn check_commerce(&self, is_commerce_request: bool) -> Result<(), CommerceRejection> {
+        // Non-commerce mandates (pure observability) are always allowed
+        if !is_commerce_request {
+            return Ok(());
+        }
+
+        // In observability-only mode, commerce requires explicit opt-in
+        if self.mode == DeploymentMode::ObservabilityOnly && !self.allow_commerce_without_lsm {
+            return Err(CommerceRejection {
+                enforcement_mode: self.mode.enforcement_mode_str().to_string(),
+                message: "BPF LSM not available. Set mandate.allow_commerce_without_lsm=true to enable degraded commerce.".to_string(),
+            });
+        }
+
+        Ok(())
+    }
+
+    /// Whether mandates created under this policy are kernel-enforced.
+    pub fn is_enforced(&self) -> bool {
+        self.mode == DeploymentMode::FullEnforcement
+    }
+}
+
+/// Error returned when commerce policy blocks a mandate.
+#[derive(Debug, Clone, Serialize)]
+pub struct CommerceRejection {
+    pub enforcement_mode: String,
+    pub message: String,
+}
+
+// =============================================================================
+// TESTS
+// =============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn full_enforcement_allows_commerce() {
+        let policy = CommercePolicy::new(true, "enforce", false);
+        assert_eq!(policy.mode, DeploymentMode::FullEnforcement);
+        assert!(policy.check_commerce(true).is_ok());
+        assert!(policy.is_enforced());
+    }
+
+    #[test]
+    fn monitor_mode_allows_commerce() {
+        let policy = CommercePolicy::new(true, "monitor", false);
+        assert_eq!(policy.mode, DeploymentMode::MonitorOnly);
+        assert!(policy.check_commerce(true).is_ok());
+        assert!(!policy.is_enforced());
+    }
+
+    #[test]
+    fn observability_only_blocks_commerce_by_default() {
+        let policy = CommercePolicy::new(false, "monitor", false);
+        assert_eq!(policy.mode, DeploymentMode::ObservabilityOnly);
+        let result = policy.check_commerce(true);
+        assert!(result.is_err());
+        let rejection = result.unwrap_err();
+        assert_eq!(rejection.enforcement_mode, "none");
+        assert!(rejection.message.contains("allow_commerce_without_lsm"));
+    }
+
+    #[test]
+    fn observability_only_allows_commerce_with_opt_in() {
+        let policy = CommercePolicy::new(false, "monitor", true);
+        assert_eq!(policy.mode, DeploymentMode::ObservabilityOnly);
+        assert!(policy.check_commerce(true).is_ok());
+        assert!(!policy.is_enforced());
+    }
+
+    #[test]
+    fn non_commerce_mandates_always_allowed() {
+        // Even in the most restrictive mode
+        let policy = CommercePolicy::new(false, "monitor", false);
+        assert!(policy.check_commerce(false).is_ok());
+    }
+
+    #[test]
+    fn deployment_mode_strings() {
+        assert_eq!(
+            DeploymentMode::FullEnforcement.enforcement_mode_str(),
+            "enforce"
+        );
+        assert_eq!(
+            DeploymentMode::MonitorOnly.enforcement_mode_str(),
+            "monitor"
+        );
+        assert_eq!(
+            DeploymentMode::ObservabilityOnly.enforcement_mode_str(),
+            "none"
+        );
+    }
+
+    #[test]
+    fn degraded_flag() {
+        assert!(!DeploymentMode::FullEnforcement.is_degraded());
+        assert!(DeploymentMode::MonitorOnly.is_degraded());
+        assert!(DeploymentMode::ObservabilityOnly.is_degraded());
+    }
+
+    #[test]
+    fn kernel_attested_flag() {
+        assert!(DeploymentMode::FullEnforcement.is_kernel_attested());
+        assert!(!DeploymentMode::MonitorOnly.is_kernel_attested());
+        assert!(!DeploymentMode::ObservabilityOnly.is_kernel_attested());
+    }
+}

--- a/cognitod/src/compliance.rs
+++ b/cognitod/src/compliance.rs
@@ -1,0 +1,666 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// cognitod/src/compliance.rs — Linnix-Claw compliance controls (§10.3)
+//
+// Implements OFAC SDN screening, KYT (Know Your Transaction) threshold
+// enforcement, Travel Rule metadata, and geographic restrictions.
+//
+// This module is feature-gated: compile with `--features compliance`.
+// Without the feature, all checks are no-ops that always pass.
+//
+// See docs/linnix-claw/specs.md §10.3.
+
+use anyhow::Result;
+use log::{debug, info, warn};
+use serde::{Deserialize, Serialize};
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+use tokio::sync::RwLock;
+
+use crate::config::ComplianceConfig;
+
+// =============================================================================
+// SCREENING RESULT
+// =============================================================================
+
+/// Outcome of a compliance screening check.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum ScreeningResult {
+    /// Entity passed all checks.
+    Clear,
+    /// Entity matched a sanctions list.
+    Sanctioned {
+        list: String,
+        match_type: String,
+        details: String,
+    },
+    /// Entity is in a blocked jurisdiction.
+    BlockedJurisdiction { jurisdiction: String },
+    /// KYT threshold exceeded — enhanced due diligence required.
+    KytRequired {
+        amount_cents: u64,
+        threshold_cents: u64,
+    },
+    /// Screening unavailable (API down, etc.). Policy decides whether to proceed.
+    Unavailable { reason: String },
+}
+
+impl ScreeningResult {
+    pub fn is_blocked(&self) -> bool {
+        matches!(
+            self,
+            Self::Sanctioned { .. } | Self::BlockedJurisdiction { .. }
+        )
+    }
+
+    pub fn requires_enhanced_dd(&self) -> bool {
+        matches!(self, Self::KytRequired { .. })
+    }
+}
+
+impl std::fmt::Display for ScreeningResult {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Clear => write!(f, "CLEAR"),
+            Self::Sanctioned {
+                list,
+                match_type,
+                details,
+            } => {
+                write!(f, "SANCTIONED ({} via {}: {})", list, match_type, details)
+            }
+            Self::BlockedJurisdiction { jurisdiction } => {
+                write!(f, "BLOCKED_JURISDICTION ({})", jurisdiction)
+            }
+            Self::KytRequired {
+                amount_cents,
+                threshold_cents,
+            } => {
+                write!(
+                    f,
+                    "KYT_REQUIRED (${:.2} >= ${:.2})",
+                    *amount_cents as f64 / 100.0,
+                    *threshold_cents as f64 / 100.0,
+                )
+            }
+            Self::Unavailable { reason } => {
+                write!(f, "UNAVAILABLE ({})", reason)
+            }
+        }
+    }
+}
+
+// =============================================================================
+// COMPLIANCE AUDIT LOG
+// =============================================================================
+
+/// A single compliance decision for the audit trail.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ComplianceAuditEntry {
+    pub timestamp: String,
+    pub counterparty_did: String,
+    pub wallet_address: Option<String>,
+    pub check_type: String,
+    pub result: ScreeningResult,
+    /// Chained hash for tamper evidence (SHA-256 of previous entry + this entry).
+    pub chain_hash: String,
+}
+
+// =============================================================================
+// TRAVEL RULE METADATA (§10.3)
+// =============================================================================
+
+/// Travel Rule data for transactions above $3,000 (FATF threshold).
+/// Attached to the off-chain receipt, never included in on-chain calldata.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TravelRuleData {
+    /// Originator legal name.
+    pub originator_name: String,
+    /// Originator account / wallet address.
+    pub originator_account: String,
+    /// Originator jurisdiction (ISO 3166 alpha-2).
+    pub originator_jurisdiction: String,
+    /// Beneficiary legal name.
+    pub beneficiary_name: String,
+    /// Beneficiary account / wallet address.
+    pub beneficiary_account: String,
+    /// Beneficiary jurisdiction (ISO 3166 alpha-2).
+    pub beneficiary_jurisdiction: String,
+    /// Purpose of transaction.
+    pub purpose: Option<String>,
+}
+
+// =============================================================================
+// SCREENING PROVIDER TRAIT
+// =============================================================================
+
+/// Provider for sanctions screening.
+///
+/// Implementations can be:
+/// - `OfacSdnProvider` — downloads and checks against OFAC SDN list
+/// - `ChainalysisProvider` — calls Chainalysis KYT API
+/// - `StubProvider` — always returns Clear (for testing)
+#[async_trait::async_trait]
+pub trait ScreeningProvider: Send + Sync {
+    fn name(&self) -> &str;
+    async fn screen_did(&self, did: &str) -> Result<ScreeningResult>;
+    async fn screen_wallet(&self, address: &str) -> Result<ScreeningResult>;
+}
+
+// =============================================================================
+// STUB SCREENING PROVIDER (always-clear)
+// =============================================================================
+
+/// Testing/development provider that always returns Clear.
+pub struct StubScreeningProvider;
+
+#[async_trait::async_trait]
+impl ScreeningProvider for StubScreeningProvider {
+    fn name(&self) -> &str {
+        "stub"
+    }
+    async fn screen_did(&self, _did: &str) -> Result<ScreeningResult> {
+        Ok(ScreeningResult::Clear)
+    }
+    async fn screen_wallet(&self, _address: &str) -> Result<ScreeningResult> {
+        Ok(ScreeningResult::Clear)
+    }
+}
+
+// =============================================================================
+// OFAC SDN LIST PROVIDER
+// =============================================================================
+
+/// In-memory OFAC SDN list checker.
+///
+/// Downloads the Specially Designated Nationals list and checks
+/// counterparty DIDs/wallet addresses against it.
+pub struct OfacSdnProvider {
+    /// Set of blocked identifiers (lowercased wallet addresses + DID fragments).
+    blocked: Arc<RwLock<HashSet<String>>>,
+    /// When the list was last refreshed.
+    last_refresh: Arc<RwLock<Option<Instant>>>,
+}
+
+impl Default for OfacSdnProvider {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl OfacSdnProvider {
+    pub fn new() -> Self {
+        Self {
+            blocked: Arc::new(RwLock::new(HashSet::new())),
+            last_refresh: Arc::new(RwLock::new(None)),
+        }
+    }
+
+    /// Load a set of blocked identifiers (for testing or static loading).
+    pub async fn load_blocklist(&self, entries: Vec<String>) {
+        let mut blocked = self.blocked.write().await;
+        blocked.clear();
+        for entry in entries {
+            blocked.insert(entry.to_lowercase());
+        }
+        *self.last_refresh.write().await = Some(Instant::now());
+        info!("OFAC SDN: loaded {} blocked entries", blocked.len());
+    }
+}
+
+#[async_trait::async_trait]
+impl ScreeningProvider for OfacSdnProvider {
+    fn name(&self) -> &str {
+        "ofac_sdn"
+    }
+
+    async fn screen_did(&self, did: &str) -> Result<ScreeningResult> {
+        let blocked = self.blocked.read().await;
+        let normalized = did.to_lowercase();
+        if blocked.contains(&normalized) {
+            Ok(ScreeningResult::Sanctioned {
+                list: "OFAC_SDN".to_string(),
+                match_type: "did_match".to_string(),
+                details: format!("DID {} matched OFAC SDN list", did),
+            })
+        } else {
+            Ok(ScreeningResult::Clear)
+        }
+    }
+
+    async fn screen_wallet(&self, address: &str) -> Result<ScreeningResult> {
+        let blocked = self.blocked.read().await;
+        let normalized = address.to_lowercase();
+        if blocked.contains(&normalized) {
+            Ok(ScreeningResult::Sanctioned {
+                list: "OFAC_SDN".to_string(),
+                match_type: "wallet_match".to_string(),
+                details: format!("Wallet {} matched OFAC SDN list", address),
+            })
+        } else {
+            Ok(ScreeningResult::Clear)
+        }
+    }
+}
+
+// =============================================================================
+// SCREENING CACHE
+// =============================================================================
+
+struct CachedScreening {
+    result: ScreeningResult,
+    expires: Instant,
+}
+
+/// TTL-based cache for screening results.
+struct ScreeningCache {
+    entries: HashMap<String, CachedScreening>,
+    ttl: Duration,
+}
+
+impl ScreeningCache {
+    fn new(ttl_hours: u64) -> Self {
+        Self {
+            entries: HashMap::new(),
+            ttl: Duration::from_secs(ttl_hours * 3600),
+        }
+    }
+
+    fn get(&self, key: &str) -> Option<&ScreeningResult> {
+        self.entries.get(key).and_then(|cached| {
+            if Instant::now() < cached.expires {
+                Some(&cached.result)
+            } else {
+                None
+            }
+        })
+    }
+
+    fn insert(&mut self, key: String, result: ScreeningResult) {
+        self.entries.insert(
+            key,
+            CachedScreening {
+                result,
+                expires: Instant::now() + self.ttl,
+            },
+        );
+    }
+
+    fn gc(&mut self) {
+        let now = Instant::now();
+        self.entries.retain(|_, v| now < v.expires);
+    }
+}
+
+// =============================================================================
+// COMPLIANCE ENGINE
+// =============================================================================
+
+/// Main compliance engine that coordinates screening, KYT, and jurisdiction checks.
+pub struct ComplianceEngine {
+    config: ComplianceConfig,
+    provider: Box<dyn ScreeningProvider>,
+    cache: Arc<RwLock<ScreeningCache>>,
+    blocked_jurisdictions: HashSet<String>,
+}
+
+impl std::fmt::Debug for ComplianceEngine {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ComplianceEngine")
+            .field("config", &self.config)
+            .field("blocked_jurisdictions", &self.blocked_jurisdictions)
+            .finish_non_exhaustive()
+    }
+}
+
+impl ComplianceEngine {
+    /// Create a new compliance engine from config.
+    pub fn new(config: ComplianceConfig, provider: Box<dyn ScreeningProvider>) -> Self {
+        let cache_ttl = config.screening_cache_ttl_hours;
+        let blocked: HashSet<String> = config
+            .blocked_jurisdictions
+            .iter()
+            .map(|j| j.to_uppercase())
+            .collect();
+
+        info!(
+            "compliance engine initialized: provider={}, kyt_threshold=${:.2}, blocked_jurisdictions={:?}, cache_ttl={}h",
+            provider.name(),
+            config.kyt_threshold_cents as f64 / 100.0,
+            blocked,
+            cache_ttl,
+        );
+
+        Self {
+            config,
+            provider,
+            cache: Arc::new(RwLock::new(ScreeningCache::new(cache_ttl))),
+            blocked_jurisdictions: blocked,
+        }
+    }
+
+    /// Create a permissive engine that skips all checks (for non-compliance builds).
+    pub fn permissive() -> Self {
+        Self {
+            config: ComplianceConfig::default(),
+            provider: Box::new(StubScreeningProvider),
+            cache: Arc::new(RwLock::new(ScreeningCache::new(24))),
+            blocked_jurisdictions: HashSet::new(),
+        }
+    }
+
+    /// Run all pre-task compliance checks.
+    ///
+    /// Returns a list of results — any blocked result should abort the task.
+    pub async fn pre_task_screen(
+        &self,
+        counterparty_did: &str,
+        wallet_address: Option<&str>,
+        jurisdiction: Option<&str>,
+        amount_cents: u64,
+    ) -> Vec<ScreeningResult> {
+        let mut results = Vec::new();
+
+        if !self.config.enabled {
+            debug!("compliance disabled, skipping all checks");
+            results.push(ScreeningResult::Clear);
+            return results;
+        }
+
+        // (1) Jurisdiction check
+        if let Some(j) = jurisdiction {
+            let j_upper = j.to_uppercase();
+            if self.blocked_jurisdictions.contains(&j_upper) {
+                warn!("blocked jurisdiction: {}", j_upper);
+                results.push(ScreeningResult::BlockedJurisdiction {
+                    jurisdiction: j_upper,
+                });
+                return results; // Immediate block
+            }
+        }
+
+        // (2) DID screening (with cache)
+        {
+            let cache = self.cache.read().await;
+            if let Some(cached) = cache.get(counterparty_did) {
+                debug!("screening cache hit for {}", counterparty_did);
+                results.push(cached.clone());
+            } else {
+                drop(cache); // Release read lock
+                match self.provider.screen_did(counterparty_did).await {
+                    Ok(result) => {
+                        self.cache
+                            .write()
+                            .await
+                            .insert(counterparty_did.to_string(), result.clone());
+                        results.push(result);
+                    }
+                    Err(e) => {
+                        results.push(ScreeningResult::Unavailable {
+                            reason: e.to_string(),
+                        });
+                    }
+                }
+            }
+        }
+
+        // (3) Wallet screening (if provided)
+        if let Some(addr) = wallet_address {
+            let cache = self.cache.read().await;
+            if let Some(cached) = cache.get(addr) {
+                results.push(cached.clone());
+            } else {
+                drop(cache);
+                match self.provider.screen_wallet(addr).await {
+                    Ok(result) => {
+                        self.cache
+                            .write()
+                            .await
+                            .insert(addr.to_string(), result.clone());
+                        results.push(result);
+                    }
+                    Err(e) => {
+                        results.push(ScreeningResult::Unavailable {
+                            reason: e.to_string(),
+                        });
+                    }
+                }
+            }
+        }
+
+        // (4) KYT threshold check
+        if amount_cents >= self.config.kyt_threshold_cents {
+            results.push(ScreeningResult::KytRequired {
+                amount_cents,
+                threshold_cents: self.config.kyt_threshold_cents,
+            });
+        }
+
+        // If nothing was pushed, mark clear
+        if results.is_empty() {
+            results.push(ScreeningResult::Clear);
+        }
+
+        results
+    }
+
+    /// Check if any screening result is a hard block.
+    pub fn has_hard_block(results: &[ScreeningResult]) -> bool {
+        results.iter().any(|r| r.is_blocked())
+    }
+
+    /// Check if Travel Rule data is required for this amount.
+    pub fn requires_travel_rule(&self, amount_cents: u64) -> bool {
+        // FATF Travel Rule threshold: $3,000
+        amount_cents >= self.config.kyt_threshold_cents
+    }
+
+    /// Flush expired cache entries.
+    pub async fn gc(&self) {
+        self.cache.write().await.gc();
+    }
+}
+
+// =============================================================================
+// TESTS
+// =============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_config() -> ComplianceConfig {
+        ComplianceConfig {
+            enabled: true,
+            screening_provider: "ofac_sdn".to_string(),
+            screening_api_key_env: String::new(),
+            screening_cache_ttl_hours: 24,
+            kyt_threshold_cents: 300_000, // $3,000
+            blocked_jurisdictions: vec![
+                "KP".to_string(),
+                "IR".to_string(),
+                "CU".to_string(),
+                "SY".to_string(),
+            ],
+        }
+    }
+
+    #[tokio::test]
+    async fn clear_screening_on_good_actor() {
+        let engine = ComplianceEngine::new(test_config(), Box::new(StubScreeningProvider));
+        let results = engine
+            .pre_task_screen("did:web:good.com", None, Some("US"), 5000)
+            .await;
+        assert!(results.iter().all(|r| !r.is_blocked()));
+    }
+
+    #[tokio::test]
+    async fn block_sanctioned_jurisdiction() {
+        let engine = ComplianceEngine::new(test_config(), Box::new(StubScreeningProvider));
+        let results = engine
+            .pre_task_screen("did:web:example.kp", None, Some("KP"), 100)
+            .await;
+        assert!(ComplianceEngine::has_hard_block(&results));
+        assert!(matches!(
+            results[0],
+            ScreeningResult::BlockedJurisdiction { .. }
+        ));
+    }
+
+    #[tokio::test]
+    async fn block_sanctioned_jurisdiction_case_insensitive() {
+        let engine = ComplianceEngine::new(test_config(), Box::new(StubScreeningProvider));
+        let results = engine
+            .pre_task_screen("did:web:example.ir", None, Some("ir"), 100)
+            .await;
+        assert!(ComplianceEngine::has_hard_block(&results));
+    }
+
+    #[tokio::test]
+    async fn kyt_threshold_triggers() {
+        let engine = ComplianceEngine::new(test_config(), Box::new(StubScreeningProvider));
+        let results = engine
+            .pre_task_screen("did:web:bigcorp.com", None, Some("US"), 300_000)
+            .await;
+        let has_kyt = results.iter().any(|r| r.requires_enhanced_dd());
+        assert!(has_kyt, "KYT should be required for $3,000+");
+    }
+
+    #[tokio::test]
+    async fn kyt_below_threshold_no_trigger() {
+        let engine = ComplianceEngine::new(test_config(), Box::new(StubScreeningProvider));
+        let results = engine
+            .pre_task_screen("did:web:smallbiz.com", None, Some("US"), 299_999)
+            .await;
+        let has_kyt = results.iter().any(|r| r.requires_enhanced_dd());
+        assert!(!has_kyt, "KYT should NOT trigger below $3,000");
+    }
+
+    #[tokio::test]
+    async fn ofac_sdn_blocks_listed_did() {
+        let provider = OfacSdnProvider::new();
+        provider
+            .load_blocklist(vec!["did:web:evil-corp.kp".to_string()])
+            .await;
+        let engine = ComplianceEngine::new(test_config(), Box::new(provider));
+
+        let results = engine
+            .pre_task_screen("did:web:evil-corp.kp", None, Some("US"), 100)
+            .await;
+        assert!(ComplianceEngine::has_hard_block(&results));
+    }
+
+    #[tokio::test]
+    async fn ofac_sdn_blocks_listed_wallet() {
+        let provider = OfacSdnProvider::new();
+        provider
+            .load_blocklist(vec!["0xdeadbeef".to_string()])
+            .await;
+        let engine = ComplianceEngine::new(test_config(), Box::new(provider));
+
+        let results = engine
+            .pre_task_screen("did:web:ok.com", Some("0xDeadBeef"), Some("US"), 100)
+            .await;
+        assert!(ComplianceEngine::has_hard_block(&results));
+    }
+
+    #[tokio::test]
+    async fn screening_cache_works() {
+        let engine = ComplianceEngine::new(test_config(), Box::new(StubScreeningProvider));
+
+        // First call: populates cache
+        let r1 = engine
+            .pre_task_screen("did:web:cached.com", None, Some("US"), 100)
+            .await;
+        // Second call: should hit cache
+        let r2 = engine
+            .pre_task_screen("did:web:cached.com", None, Some("US"), 200)
+            .await;
+
+        assert!(!ComplianceEngine::has_hard_block(&r1));
+        assert!(!ComplianceEngine::has_hard_block(&r2));
+    }
+
+    #[tokio::test]
+    async fn disabled_compliance_always_clears() {
+        let mut config = test_config();
+        config.enabled = false;
+        let engine = ComplianceEngine::new(config, Box::new(StubScreeningProvider));
+
+        let results = engine
+            .pre_task_screen("did:web:evil.kp", None, Some("KP"), 1_000_000)
+            .await;
+        assert!(!ComplianceEngine::has_hard_block(&results));
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0], ScreeningResult::Clear);
+    }
+
+    #[tokio::test]
+    async fn permissive_engine_clears_all() {
+        let engine = ComplianceEngine::permissive();
+        let results = engine
+            .pre_task_screen("did:web:anyone", None, Some("KP"), 999_999)
+            .await;
+        // Permissive engine has enabled=false (from ComplianceConfig::default())
+        assert!(!ComplianceEngine::has_hard_block(&results));
+    }
+
+    #[tokio::test]
+    async fn travel_rule_required_above_threshold() {
+        let engine = ComplianceEngine::new(test_config(), Box::new(StubScreeningProvider));
+        assert!(engine.requires_travel_rule(300_000));
+        assert!(engine.requires_travel_rule(500_000));
+        assert!(!engine.requires_travel_rule(299_999));
+        assert!(!engine.requires_travel_rule(0));
+    }
+
+    #[test]
+    fn screening_result_display() {
+        let clear = ScreeningResult::Clear;
+        assert_eq!(clear.to_string(), "CLEAR");
+
+        let blocked = ScreeningResult::BlockedJurisdiction {
+            jurisdiction: "KP".to_string(),
+        };
+        assert!(blocked.to_string().contains("KP"));
+
+        let kyt = ScreeningResult::KytRequired {
+            amount_cents: 500_000,
+            threshold_cents: 300_000,
+        };
+        assert!(kyt.to_string().contains("$5000.00"));
+    }
+
+    #[test]
+    fn screening_result_is_blocked() {
+        assert!(!ScreeningResult::Clear.is_blocked());
+        assert!(
+            ScreeningResult::Sanctioned {
+                list: "OFAC".to_string(),
+                match_type: "did".to_string(),
+                details: "test".to_string(),
+            }
+            .is_blocked()
+        );
+        assert!(
+            ScreeningResult::BlockedJurisdiction {
+                jurisdiction: "KP".to_string(),
+            }
+            .is_blocked()
+        );
+        assert!(
+            !ScreeningResult::KytRequired {
+                amount_cents: 500_000,
+                threshold_cents: 300_000,
+            }
+            .is_blocked()
+        );
+        assert!(
+            !ScreeningResult::Unavailable {
+                reason: "error".to_string(),
+            }
+            .is_blocked()
+        );
+    }
+}

--- a/cognitod/src/config.rs
+++ b/cognitod/src/config.rs
@@ -12,6 +12,11 @@ pub struct ApiConfig {
     pub listen_addr: String,
     #[serde(default)]
     pub auth_token: Option<String>,
+    /// Optional Unix domain socket path for local-only connections.
+    /// UDS connections bypass token auth (local identity verified by socket credentials).
+    /// Default: None (UDS disabled). Set to e.g. "/var/run/linnix/cognitod.sock" to enable.
+    #[serde(default)]
+    pub unix_socket: Option<String>,
 }
 
 impl Default for ApiConfig {
@@ -19,6 +24,7 @@ impl Default for ApiConfig {
         Self {
             listen_addr: default_listen_addr(),
             auth_token: None,
+            unix_socket: None,
         }
     }
 }
@@ -83,6 +89,14 @@ pub struct Config {
     pub privacy: PrivacyConfig,
     #[serde(default)]
     pub psi: PsiConfig,
+    #[serde(default)]
+    pub mandate: MandateConfig,
+    #[serde(default)]
+    pub spend_limits: SpendLimitsConfig,
+    #[serde(default)]
+    pub compliance: ComplianceConfig,
+    #[serde(default)]
+    pub receipt_privacy: ReceiptPrivacyConfig,
 }
 
 #[derive(Debug, Deserialize, Clone)]
@@ -333,6 +347,68 @@ fn default_psi_sustained_pressure_seconds() -> u64 {
     15
 }
 
+// =============================================================================
+// LINNIX-CLAW: MANDATE CONFIGURATION
+// =============================================================================
+
+/// Configuration for the Linnix-Claw mandate enforcement subsystem.
+///
+/// Added via `[mandate]` section in linnix.toml.
+///
+/// Example:
+/// ```toml
+/// [mandate]
+/// mode = "monitor"          # "monitor" or "enforce"
+/// map_capacity = 65536      # max entries in BPF LRU map
+/// allow_commerce_without_lsm = false
+/// ```
+#[derive(Debug, Deserialize, Clone)]
+pub struct MandateConfig {
+    /// Enforcement mode: "monitor" (log only) or "enforce" (block unauthorized).
+    /// Default: "monitor" — safe default that doesn't break existing workflows.
+    #[serde(default = "default_mandate_mode")]
+    pub mode: String,
+
+    /// Maximum entries in the MANDATE_MAP BPF LRU hash.
+    /// Must match the compiled eBPF program's map definition.
+    #[serde(default = "default_mandate_map_capacity")]
+    pub map_capacity: u32,
+
+    /// If true, mandate API is available even without BPF LSM support.
+    /// Mandates are tracked but not kernel-enforced.
+    /// Default: false — commerce features require kernel enforcement.
+    #[serde(default)]
+    pub allow_commerce_without_lsm: bool,
+
+    /// Path to the agent identity key file (Ed25519 + secp256k1 seed).
+    /// Default: /var/lib/linnix/identity.key
+    #[serde(default = "default_identity_path")]
+    pub identity_path: String,
+}
+
+impl Default for MandateConfig {
+    fn default() -> Self {
+        Self {
+            mode: default_mandate_mode(),
+            map_capacity: default_mandate_map_capacity(),
+            allow_commerce_without_lsm: false,
+            identity_path: default_identity_path(),
+        }
+    }
+}
+
+fn default_mandate_mode() -> String {
+    "monitor".to_string()
+}
+
+fn default_mandate_map_capacity() -> u32 {
+    65_536
+}
+
+fn default_identity_path() -> String {
+    "/var/lib/linnix/identity.key".to_string()
+}
+
 #[derive(Debug, Deserialize, Clone, Default)]
 pub struct ProbesConfig {
     // Configuration for probe settings (reserved for future use)
@@ -437,6 +513,209 @@ fn default_circuit_breaker_mode() -> String {
     "monitor".to_string() // Default to safe mode
 }
 
+// =============================================================================
+// LINNIX-CLAW PHASE 4: SPEND LIMITS (§9.1)
+// =============================================================================
+
+/// Per-agent spending limit override.
+///
+/// Example TOML:
+/// ```toml
+/// [mandate.spend_limits.per_agent."did:web:untrusted-agent.io"]
+/// daily_cents = 1000
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PerAgentLimit {
+    pub daily_cents: u64,
+}
+
+/// Spend control limits applied by cognitod's `SpendTracker`.
+///
+/// All amounts in USD cents (§8.5).
+///
+/// Example TOML:
+/// ```toml
+/// [spend_limits]
+/// per_mandate_cents = 5000
+/// daily_cents = 50000
+/// monthly_cents = 500000
+///
+/// [spend_limits.per_agent."did:web:untrusted.io"]
+/// daily_cents = 1000
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SpendLimitsConfig {
+    /// Max USD cents per individual mandate. Default: $50.
+    #[serde(default = "default_per_mandate_cents")]
+    pub per_mandate_cents: u64,
+
+    /// Max aggregate USD cents per hour (rolling). Optional — None = no hourly limit.
+    #[serde(default)]
+    pub hourly_cents: Option<u64>,
+
+    /// Max aggregate USD cents per day (rolling 24h). Default: $500.
+    #[serde(default = "default_daily_cents")]
+    pub daily_cents: u64,
+
+    /// Max aggregate USD cents per month (rolling 30d). Default: $5,000.
+    #[serde(default = "default_monthly_cents")]
+    pub monthly_cents: u64,
+
+    /// Per-agent daily limit overrides. Key is agent DID.
+    #[serde(default)]
+    pub per_agent: std::collections::HashMap<String, PerAgentLimit>,
+}
+
+impl Default for SpendLimitsConfig {
+    fn default() -> Self {
+        Self {
+            per_mandate_cents: default_per_mandate_cents(),
+            hourly_cents: None,
+            daily_cents: default_daily_cents(),
+            monthly_cents: default_monthly_cents(),
+            per_agent: std::collections::HashMap::new(),
+        }
+    }
+}
+
+fn default_per_mandate_cents() -> u64 {
+    5000 // $50
+}
+fn default_daily_cents() -> u64 {
+    50_000 // $500
+}
+fn default_monthly_cents() -> u64 {
+    500_000 // $5,000
+}
+
+// =============================================================================
+// LINNIX-CLAW PHASE 4: COMPLIANCE CONTROLS (§10.3)
+// =============================================================================
+
+/// Compliance configuration for sanctions screening, KYT, and jurisdiction blocks.
+///
+/// Feature-gated: compile with `--features compliance` to enable runtime checks.
+/// Without the feature, the `ComplianceEngine` operates in permissive mode.
+///
+/// Example TOML:
+/// ```toml
+/// [compliance]
+/// enabled = true
+/// screening_provider = "ofac_sdn"
+/// kyt_threshold_cents = 300000
+/// blocked_jurisdictions = ["KP", "IR", "CU", "SY"]
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ComplianceConfig {
+    /// Master switch. Default: false (opt-in).
+    #[serde(default)]
+    pub enabled: bool,
+
+    /// Screening provider: "ofac_sdn", "chainalysis", "elliptic", or "none".
+    #[serde(default = "default_screening_provider")]
+    pub screening_provider: String,
+
+    /// Env var name holding the screening API key.
+    #[serde(default)]
+    pub screening_api_key_env: String,
+
+    /// Cache TTL for screening results, in hours. Default: 24.
+    #[serde(default = "default_screening_cache_ttl")]
+    pub screening_cache_ttl_hours: u64,
+
+    /// KYT threshold in USD cents. Default: $3,000 (FATF Travel Rule).
+    #[serde(default = "default_kyt_threshold")]
+    pub kyt_threshold_cents: u64,
+
+    /// Blocked jurisdictions (ISO 3166 alpha-2).
+    #[serde(default = "default_blocked_jurisdictions")]
+    pub blocked_jurisdictions: Vec<String>,
+}
+
+impl Default for ComplianceConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            screening_provider: default_screening_provider(),
+            screening_api_key_env: String::new(),
+            screening_cache_ttl_hours: default_screening_cache_ttl(),
+            kyt_threshold_cents: default_kyt_threshold(),
+            blocked_jurisdictions: default_blocked_jurisdictions(),
+        }
+    }
+}
+
+fn default_screening_provider() -> String {
+    "none".to_string()
+}
+fn default_screening_cache_ttl() -> u64 {
+    24
+}
+fn default_kyt_threshold() -> u64 {
+    300_000 // $3,000
+}
+fn default_blocked_jurisdictions() -> Vec<String> {
+    vec![
+        "KP".to_string(),
+        "IR".to_string(),
+        "CU".to_string(),
+        "SY".to_string(),
+    ]
+}
+
+// =============================================================================
+// LINNIX-CLAW PHASE 4: RECEIPT PRIVACY (§10.4)
+// =============================================================================
+
+/// Receipt privacy and redaction configuration.
+///
+/// Example TOML:
+/// ```toml
+/// [receipt_privacy]
+/// redaction_level = "external"
+/// retention_days = 90
+/// encrypt_db = false
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ReceiptPrivacyConfig {
+    /// Redaction level: "none", "external" (default), or "full".
+    #[serde(default = "default_redaction_level")]
+    pub redaction_level: String,
+
+    /// Days to retain receipts in local SQLite. Default: 90.
+    #[serde(default = "default_retention_days")]
+    pub retention_days: u64,
+
+    /// Enable SQLCipher encryption for receipt DB.
+    #[serde(default)]
+    pub encrypt_db: bool,
+
+    /// Path to the database encryption key.
+    #[serde(default = "default_db_key_path")]
+    pub db_key_path: String,
+}
+
+impl Default for ReceiptPrivacyConfig {
+    fn default() -> Self {
+        Self {
+            redaction_level: default_redaction_level(),
+            retention_days: default_retention_days(),
+            encrypt_db: false,
+            db_key_path: default_db_key_path(),
+        }
+    }
+}
+
+fn default_redaction_level() -> String {
+    "external".to_string()
+}
+fn default_retention_days() -> u64 {
+    90
+}
+fn default_db_key_path() -> String {
+    "/var/lib/linnix/receipt_db.key".to_string()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -477,5 +756,89 @@ auth_token = "secret123"
         unsafe {
             std::env::remove_var(ENV_CONFIG_PATH);
         }
+    }
+
+    #[test]
+    fn parse_spend_limits() {
+        let toml = r#"
+[spend_limits]
+per_mandate_cents = 10000
+hourly_cents = 25000
+daily_cents = 100000
+monthly_cents = 1000000
+
+[spend_limits.per_agent."did:web:untrusted.io"]
+daily_cents = 500
+"#;
+        let cfg: Config = toml::from_str(toml).unwrap();
+        assert_eq!(cfg.spend_limits.per_mandate_cents, 10000);
+        assert_eq!(cfg.spend_limits.hourly_cents, Some(25000));
+        assert_eq!(cfg.spend_limits.daily_cents, 100000);
+        assert_eq!(cfg.spend_limits.monthly_cents, 1000000);
+        assert_eq!(
+            cfg.spend_limits
+                .per_agent
+                .get("did:web:untrusted.io")
+                .unwrap()
+                .daily_cents,
+            500
+        );
+    }
+
+    #[test]
+    fn parse_compliance_config() {
+        let toml = r#"
+[compliance]
+enabled = true
+screening_provider = "ofac_sdn"
+kyt_threshold_cents = 500000
+blocked_jurisdictions = ["KP", "IR"]
+"#;
+        let cfg: Config = toml::from_str(toml).unwrap();
+        assert!(cfg.compliance.enabled);
+        assert_eq!(cfg.compliance.screening_provider, "ofac_sdn");
+        assert_eq!(cfg.compliance.kyt_threshold_cents, 500000);
+        assert_eq!(cfg.compliance.blocked_jurisdictions, vec!["KP", "IR"]);
+    }
+
+    #[test]
+    fn parse_receipt_privacy_config() {
+        let toml = r#"
+[receipt_privacy]
+redaction_level = "full"
+retention_days = 30
+encrypt_db = true
+"#;
+        let cfg: Config = toml::from_str(toml).unwrap();
+        assert_eq!(cfg.receipt_privacy.redaction_level, "full");
+        assert_eq!(cfg.receipt_privacy.retention_days, 30);
+        assert!(cfg.receipt_privacy.encrypt_db);
+    }
+
+    #[test]
+    fn spend_limits_defaults() {
+        let cfg = SpendLimitsConfig::default();
+        assert_eq!(cfg.per_mandate_cents, 5000);
+        assert_eq!(cfg.hourly_cents, None);
+        assert_eq!(cfg.daily_cents, 50000);
+        assert_eq!(cfg.monthly_cents, 500000);
+        assert!(cfg.per_agent.is_empty());
+    }
+
+    #[test]
+    fn compliance_defaults() {
+        let cfg = ComplianceConfig::default();
+        assert!(!cfg.enabled);
+        assert_eq!(cfg.screening_provider, "none");
+        assert_eq!(cfg.kyt_threshold_cents, 300000);
+        assert_eq!(cfg.blocked_jurisdictions.len(), 4);
+    }
+
+    #[test]
+    fn receipt_privacy_defaults() {
+        let cfg = ReceiptPrivacyConfig::default();
+        assert_eq!(cfg.redaction_level, "external");
+        assert_eq!(cfg.retention_days, 90);
+        assert!(!cfg.encrypt_db);
     }
 }

--- a/cognitod/src/enforcement.rs
+++ b/cognitod/src/enforcement.rs
@@ -9,7 +9,15 @@ mod safety;
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case", tag = "type")]
 pub enum ActionType {
-    KillProcess { pid: u32, signal: i32 },
+    KillProcess {
+        pid: u32,
+        signal: i32,
+    },
+    AuthorizeExec {
+        pid: u32,
+        cmd_hash: u64,
+        expires_at: u64,
+    },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -93,6 +101,9 @@ impl EnforcementQueue {
         match &action {
             ActionType::KillProcess { pid, .. } => {
                 safety::SafetyGuard::is_safe_to_kill(*pid)?;
+            }
+            ActionType::AuthorizeExec { .. } => {
+                // Mandate authorizations don't need kill-safety checks.
             }
         }
 

--- a/cognitod/src/handler/mod.rs
+++ b/cognitod/src/handler/mod.rs
@@ -7,6 +7,8 @@ use tokio::fs::OpenOptions;
 use tokio::io::AsyncWriteExt;
 use tokio::sync::Mutex;
 
+use linnix_ai_ebpf_common::EventType;
+
 #[async_trait]
 pub trait Handler: Send + Sync {
     #[allow(dead_code)]
@@ -86,6 +88,127 @@ impl Handler for JsonlHandler {
             let _ = f.write_all(json.as_bytes()).await;
             let _ = f.write_all(b"\n").await;
         }
+    }
+}
+
+// =============================================================================
+// MANDATE RECEIPT HANDLER
+// =============================================================================
+//
+// Listens for MandateAllow events from the kernel LSM hook, builds a signed
+// execution receipt, and attaches it to the mandate via mark_executed().
+//
+// Event fields (from lsm.rs push_mandate_receipt):
+//   event_type = MandateAllow (8)
+//   pid        = process TID that triggered the check
+//   data       = cmd_hash of the checked operation
+//   data2      = mandate_seq (0 if no mandate matched)
+//   aux        = enforcement mode (0=monitor, 1=enforce)
+
+pub struct MandateReceiptHandler {
+    mandate: Arc<crate::mandate::MandateManager>,
+    identity: Arc<crate::identity::AgentIdentity>,
+}
+
+impl MandateReceiptHandler {
+    pub fn new(
+        mandate: Arc<crate::mandate::MandateManager>,
+        identity: Arc<crate::identity::AgentIdentity>,
+    ) -> Self {
+        Self { mandate, identity }
+    }
+}
+
+#[async_trait]
+impl Handler for MandateReceiptHandler {
+    fn name(&self) -> &'static str {
+        "mandate-receipt"
+    }
+
+    async fn on_event(&self, event: &ProcessEvent) {
+        // Only process MandateAllow events (event_type = 8)
+        if event.event_type != EventType::MandateAllow as u32 {
+            return;
+        }
+
+        let mandate_seq = event.data2;
+        if mandate_seq == 0 {
+            return; // No mandate matched (shouldn't happen for MandateAllow)
+        }
+
+        // Resolve mandate_seq → mandate_id via reverse index
+        let mandate_id = match self.mandate.find_id_by_seq(mandate_seq).await {
+            Some(id) => id,
+            None => {
+                log::debug!(
+                    "[mandate-receipt] no mandate found for seq={} (may have expired)",
+                    mandate_seq
+                );
+                return;
+            }
+        };
+
+        // Get execution data for receipt building
+        let (args, seq) = match self.mandate.get_execution_data(&mandate_id).await {
+            Some(data) => data,
+            None => {
+                log::debug!(
+                    "[mandate-receipt] mandate {} no longer active for receipt",
+                    mandate_id
+                );
+                return;
+            }
+        };
+
+        let cmd_hash = event.data;
+        let enforcement_mode = if event.aux == 1 { "enforce" } else { "monitor" };
+
+        // Build execution details for the receipt
+        let execution = crate::receipt::ExecutionDetails {
+            pid: event.pid,
+            ppid: None,
+            binary: args.first().cloned().unwrap_or_default(),
+            args_hash: format!("{:#018x}", cmd_hash),
+            exit_code: 0, // MandateAllow = authorized, not yet exited
+            started_at_ns: Some(event.ts_ns),
+            finished_at_ns: None,
+            duration_ms: 0,
+            cpu_pct: None,
+            mem_pct: None,
+        };
+
+        // Build and sign the receipt
+        let receipt = crate::receipt::ReceiptBuilder::new(mandate_id.clone(), execution)
+            .kernel_seq(seq)
+            .enforcement_mode(enforcement_mode)
+            .sign(&self.identity);
+
+        match receipt {
+            Ok(signed_receipt) => {
+                if let Err(e) = self
+                    .mandate
+                    .mark_executed(&mandate_id, signed_receipt)
+                    .await
+                {
+                    log::warn!(
+                        "[mandate-receipt] failed to mark mandate {} as executed: {}",
+                        mandate_id,
+                        e
+                    );
+                }
+            }
+            Err(e) => {
+                log::warn!(
+                    "[mandate-receipt] failed to sign receipt for mandate {}: {}",
+                    mandate_id,
+                    e
+                );
+            }
+        }
+    }
+
+    async fn on_snapshot(&self, _snapshot: &SystemSnapshot) {
+        // No-op: MandateReceiptHandler only processes events.
     }
 }
 

--- a/cognitod/src/identity.rs
+++ b/cognitod/src/identity.rs
@@ -1,0 +1,412 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// cognitod/src/identity.rs — Linnix-Claw dual-key identity management (§5.4)
+//
+// Derives Ed25519 + secp256k1 keypairs from a single 32-byte seed via HKDF-SHA256.
+// Ed25519: off-chain receipt verification (RFC 8032).
+// secp256k1: on-chain verification via Solidity's ecrecover (EIP-712).
+
+use anyhow::{Context, Result};
+use base64::{Engine, engine::general_purpose::STANDARD as BASE64};
+use ed25519_dalek::{SigningKey as Ed25519SigningKey, VerifyingKey as Ed25519VerifyingKey};
+use hkdf::Hkdf;
+use k256::ecdsa::{SigningKey as Secp256k1SigningKey, VerifyingKey as Secp256k1VerifyingKey};
+use serde::{Deserialize, Serialize};
+use sha2::Sha256;
+use std::path::Path;
+
+/// HKDF info strings — domain-separate the two derived keys.
+const ED25519_INFO: &[u8] = b"linnix-claw-ed25519";
+const SECP256K1_INFO: &[u8] = b"linnix-claw-secp256k1";
+
+/// Identity file version.
+const IDENTITY_VERSION: u32 = 1;
+
+// =============================================================================
+// IDENTITY FILE FORMAT (§5.4)
+// =============================================================================
+
+/// Persisted identity file stored at `config.mandate.identity_path`.
+///
+/// ```json
+/// {
+///   "version": 1,
+///   "did": "did:web:agent.example.com",
+///   "seed": "<base64-encoded-32-bytes>",
+///   "ed25519_pubkey": "<base64>",
+///   "secp256k1_address": "0x1234...abcd",
+///   "created_at": "2026-02-16T00:00:00Z",
+///   "rotated_from": null
+/// }
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct IdentityFile {
+    pub version: u32,
+    pub did: String,
+    pub seed: String, // base64-encoded 32-byte seed
+    pub ed25519_pubkey: String,
+    pub secp256k1_address: String,
+    pub created_at: String,
+    pub rotated_from: Option<String>,
+}
+
+// =============================================================================
+// AGENT IDENTITY (in-memory)
+// =============================================================================
+
+/// In-memory agent identity holding both keypairs.
+///
+/// Created from a 32-byte seed via HKDF-SHA256 derivation.
+pub struct AgentIdentity {
+    /// The raw seed (32 bytes). Stored to enable serialization.
+    seed: [u8; 32],
+
+    /// Ed25519 signing key for off-chain receipt signatures.
+    ed25519_signing: Ed25519SigningKey,
+
+    /// secp256k1 signing key for on-chain EIP-712 receipt signatures.
+    secp256k1_signing: Secp256k1SigningKey,
+
+    /// Agent's DID (e.g., "did:web:agent.example.com").
+    did: String,
+
+    /// Timestamp when this identity was created (ISO 8601).
+    created_at: String,
+}
+
+impl AgentIdentity {
+    /// Derive both keypairs from a 32-byte seed via HKDF-SHA256 (§5.4).
+    ///
+    /// - Ed25519: `HKDF(seed, info="linnix-claw-ed25519")` → 32-byte signing key
+    /// - secp256k1: `HKDF(seed, info="linnix-claw-secp256k1")` → 32-byte private key
+    pub fn from_seed(seed: [u8; 32], did: String) -> Result<Self> {
+        let ed25519_signing = derive_ed25519(&seed)?;
+        let secp256k1_signing = derive_secp256k1(&seed)?;
+        let created_at = chrono::Utc::now().to_rfc3339();
+
+        Ok(Self {
+            seed,
+            ed25519_signing,
+            secp256k1_signing,
+            did,
+            created_at,
+        })
+    }
+
+    /// Generate a new identity with a random 32-byte seed.
+    pub fn generate(did: String) -> Result<Self> {
+        let mut seed = [0u8; 32];
+        getrandom(&mut seed)?;
+        Self::from_seed(seed, did)
+    }
+
+    /// Load identity from a file path. If the file doesn't exist, generate
+    /// a new identity and save it.
+    pub fn load_or_generate(path: &Path, default_did: &str) -> Result<Self> {
+        if path.exists() {
+            Self::load(path)
+        } else {
+            let identity = Self::generate(default_did.to_string())?;
+            identity.save(path)?;
+            Ok(identity)
+        }
+    }
+
+    /// Load identity from an existing file.
+    pub fn load(path: &Path) -> Result<Self> {
+        let content = std::fs::read_to_string(path)
+            .with_context(|| format!("failed to read identity file: {}", path.display()))?;
+        let file: IdentityFile = serde_json::from_str(&content)
+            .with_context(|| format!("failed to parse identity file: {}", path.display()))?;
+
+        if file.version != IDENTITY_VERSION {
+            anyhow::bail!(
+                "unsupported identity file version: {} (expected {})",
+                file.version,
+                IDENTITY_VERSION
+            );
+        }
+
+        let seed_bytes = BASE64
+            .decode(&file.seed)
+            .context("failed to decode seed from base64")?;
+        if seed_bytes.len() != 32 {
+            anyhow::bail!("seed must be 32 bytes, got {}", seed_bytes.len());
+        }
+
+        let mut seed = [0u8; 32];
+        seed.copy_from_slice(&seed_bytes);
+
+        let mut identity = Self::from_seed(seed, file.did)?;
+        identity.created_at = file.created_at;
+        Ok(identity)
+    }
+
+    /// Save identity to a file (mode 0600).
+    pub fn save(&self, path: &Path) -> Result<()> {
+        // Ensure parent directory exists
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("failed to create directory: {}", parent.display()))?;
+        }
+
+        let file = self.to_identity_file();
+        let content =
+            serde_json::to_string_pretty(&file).context("failed to serialize identity file")?;
+
+        std::fs::write(path, &content)
+            .with_context(|| format!("failed to write identity file: {}", path.display()))?;
+
+        // Set file permissions to 0600 (owner read/write only)
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let perms = std::fs::Permissions::from_mode(0o600);
+            std::fs::set_permissions(path, perms)
+                .with_context(|| format!("failed to set permissions on {}", path.display()))?;
+        }
+
+        Ok(())
+    }
+
+    /// Convert to the serializable identity file format.
+    pub fn to_identity_file(&self) -> IdentityFile {
+        IdentityFile {
+            version: IDENTITY_VERSION,
+            did: self.did.clone(),
+            seed: BASE64.encode(self.seed),
+            ed25519_pubkey: BASE64.encode(self.ed25519_verifying_key().as_bytes()),
+            secp256k1_address: format!("0x{}", hex::encode(self.ethereum_address())),
+            created_at: self.created_at.clone(),
+            rotated_from: None,
+        }
+    }
+
+    // ── Accessors ────────────────────────────────────────────────────────
+
+    /// Ed25519 signing key reference (for receipt signing).
+    pub fn ed25519_signing_key(&self) -> &Ed25519SigningKey {
+        &self.ed25519_signing
+    }
+
+    /// Ed25519 public/verifying key.
+    pub fn ed25519_verifying_key(&self) -> Ed25519VerifyingKey {
+        self.ed25519_signing.verifying_key()
+    }
+
+    /// secp256k1 signing key reference (for EIP-712 receipt signing).
+    pub fn secp256k1_signing_key(&self) -> &Secp256k1SigningKey {
+        &self.secp256k1_signing
+    }
+
+    /// secp256k1 public/verifying key.
+    pub fn secp256k1_verifying_key(&self) -> Secp256k1VerifyingKey {
+        *self.secp256k1_signing.verifying_key()
+    }
+
+    /// Derive Ethereum-style address from secp256k1 public key.
+    ///
+    /// `keccak256(uncompressed_pubkey_bytes[1..])[12..]` → 20-byte address
+    pub fn ethereum_address(&self) -> [u8; 20] {
+        use tiny_keccak::{Hasher, Keccak};
+
+        let pubkey = self.secp256k1_verifying_key();
+        let point = pubkey.to_encoded_point(false); // uncompressed: 65 bytes
+        let pubkey_bytes = &point.as_bytes()[1..]; // skip 0x04 prefix
+
+        let mut keccak = Keccak::v256();
+        let mut hash = [0u8; 32];
+        keccak.update(pubkey_bytes);
+        keccak.finalize(&mut hash);
+
+        let mut addr = [0u8; 20];
+        addr.copy_from_slice(&hash[12..]);
+        addr
+    }
+
+    /// Agent DID string.
+    pub fn did(&self) -> &str {
+        &self.did
+    }
+
+    /// Raw 32-byte seed (for tests / backup).
+    pub fn seed(&self) -> &[u8; 32] {
+        &self.seed
+    }
+}
+
+// =============================================================================
+// KEY DERIVATION
+// =============================================================================
+
+/// Derive Ed25519 signing key from seed via HKDF-SHA256.
+///
+/// `HKDF-SHA256(ikm=seed, salt=None, info="linnix-claw-ed25519")` → 32 bytes
+fn derive_ed25519(seed: &[u8; 32]) -> Result<Ed25519SigningKey> {
+    let hk = Hkdf::<Sha256>::new(None, seed);
+    let mut okm = [0u8; 32];
+    hk.expand(ED25519_INFO, &mut okm)
+        .map_err(|e| anyhow::anyhow!("HKDF expand failed for Ed25519: {e}"))?;
+    Ok(Ed25519SigningKey::from_bytes(&okm))
+}
+
+/// Derive secp256k1 signing key from seed via HKDF-SHA256.
+///
+/// `HKDF-SHA256(ikm=seed, salt=None, info="linnix-claw-secp256k1")` → 32 bytes
+fn derive_secp256k1(seed: &[u8; 32]) -> Result<Secp256k1SigningKey> {
+    let hk = Hkdf::<Sha256>::new(None, seed);
+    let mut okm = [0u8; 32];
+    hk.expand(SECP256K1_INFO, &mut okm)
+        .map_err(|e| anyhow::anyhow!("HKDF expand failed for secp256k1: {e}"))?;
+    Secp256k1SigningKey::from_bytes((&okm).into())
+        .map_err(|e| anyhow::anyhow!("invalid secp256k1 key material: {e}"))
+}
+
+/// Read 32 bytes from /dev/urandom.
+fn getrandom(buf: &mut [u8; 32]) -> Result<()> {
+    use std::io::Read;
+    let mut f = std::fs::File::open("/dev/urandom").context("failed to open /dev/urandom")?;
+    f.read_exact(buf)
+        .context("failed to read 32 bytes from /dev/urandom")?;
+    Ok(())
+}
+
+// =============================================================================
+// TESTS
+// =============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ed25519_dalek::Verifier;
+    use tempfile::TempDir;
+
+    /// Fixed test seed for reproducibility.
+    fn test_seed() -> [u8; 32] {
+        let mut s = [0u8; 32];
+        for (i, b) in s.iter_mut().enumerate() {
+            *b = i as u8;
+        }
+        s
+    }
+
+    #[test]
+    fn derive_keys_from_seed_is_deterministic() {
+        let seed = test_seed();
+        let id1 = AgentIdentity::from_seed(seed, "did:web:test.example".into()).unwrap();
+        let id2 = AgentIdentity::from_seed(seed, "did:web:test.example".into()).unwrap();
+
+        assert_eq!(
+            id1.ed25519_verifying_key().as_bytes(),
+            id2.ed25519_verifying_key().as_bytes(),
+            "Ed25519 keys must be deterministic from same seed"
+        );
+
+        assert_eq!(
+            id1.ethereum_address(),
+            id2.ethereum_address(),
+            "Ethereum addresses must be deterministic from same seed"
+        );
+    }
+
+    #[test]
+    fn ed25519_sign_verify_roundtrip() {
+        let id = AgentIdentity::from_seed(test_seed(), "did:web:test".into()).unwrap();
+        let message = b"hello world receipt";
+
+        use ed25519_dalek::Signer;
+        let sig = id.ed25519_signing_key().sign(message);
+        let vk = id.ed25519_verifying_key();
+        assert!(vk.verify(message, &sig).is_ok());
+    }
+
+    #[test]
+    fn secp256k1_sign_verify_roundtrip() {
+        let id = AgentIdentity::from_seed(test_seed(), "did:web:test".into()).unwrap();
+        let message = b"hello world receipt";
+
+        use k256::ecdsa::{Signature, signature::Signer};
+        let sig: Signature = id.secp256k1_signing_key().sign(message);
+        let vk = id.secp256k1_verifying_key();
+        assert!(vk.verify(message, &sig).is_ok());
+    }
+
+    #[test]
+    fn different_seeds_produce_different_keys() {
+        let id1 = AgentIdentity::from_seed([0xAA; 32], "did:web:a".into()).unwrap();
+        let id2 = AgentIdentity::from_seed([0xBB; 32], "did:web:b".into()).unwrap();
+
+        assert_ne!(
+            id1.ed25519_verifying_key().as_bytes(),
+            id2.ed25519_verifying_key().as_bytes()
+        );
+        assert_ne!(id1.ethereum_address(), id2.ethereum_address());
+    }
+
+    #[test]
+    fn ethereum_address_is_20_bytes() {
+        let id = AgentIdentity::from_seed(test_seed(), "did:web:test".into()).unwrap();
+        let addr = id.ethereum_address();
+        assert_eq!(addr.len(), 20);
+        // Address should not be all zeros (highly unlikely from real key)
+        assert!(addr.iter().any(|&b| b != 0));
+    }
+
+    #[test]
+    fn save_and_load_roundtrip() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("identity.json");
+
+        let id1 = AgentIdentity::from_seed(test_seed(), "did:web:roundtrip".into()).unwrap();
+        id1.save(&path).unwrap();
+
+        let id2 = AgentIdentity::load(&path).unwrap();
+
+        assert_eq!(id1.did(), id2.did());
+        assert_eq!(
+            id1.ed25519_verifying_key().as_bytes(),
+            id2.ed25519_verifying_key().as_bytes()
+        );
+        assert_eq!(id1.ethereum_address(), id2.ethereum_address());
+    }
+
+    #[test]
+    fn load_or_generate_creates_new_if_missing() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("subdir/identity.json");
+
+        // File doesn't exist — should generate and save
+        let id = AgentIdentity::load_or_generate(&path, "did:web:auto-generated").unwrap();
+        assert!(path.exists());
+        assert_eq!(id.did(), "did:web:auto-generated");
+
+        // Load again — should get same keys
+        let id2 = AgentIdentity::load(&path).unwrap();
+        assert_eq!(
+            id.ed25519_verifying_key().as_bytes(),
+            id2.ed25519_verifying_key().as_bytes()
+        );
+    }
+
+    #[test]
+    fn identity_file_has_correct_version() {
+        let id = AgentIdentity::from_seed(test_seed(), "did:web:v".into()).unwrap();
+        let file = id.to_identity_file();
+        assert_eq!(file.version, 1);
+    }
+
+    #[test]
+    fn identity_file_permissions_are_0600() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("identity.json");
+        let id = AgentIdentity::from_seed(test_seed(), "did:web:perms".into()).unwrap();
+        id.save(&path).unwrap();
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let perms = std::fs::metadata(&path).unwrap().permissions();
+            assert_eq!(perms.mode() & 0o777, 0o600);
+        }
+    }
+}

--- a/cognitod/src/lib.rs
+++ b/cognitod/src/lib.rs
@@ -1,20 +1,30 @@
 // let_chains stabilized in Rust 1.82 (Jan 2025)
 // Both local stable and Docker stable support it without feature flags
 
+pub mod agent_card;
 pub mod alerts;
 pub mod bpf_config;
+pub mod claw_metrics;
 pub mod collectors;
+pub mod commerce;
+pub mod compliance;
 pub mod config;
 pub mod context;
 pub mod enforcement;
 pub mod handler;
+pub mod identity;
 pub mod incidents;
 pub mod insights;
 pub mod k8s;
+pub mod mandate;
 pub mod metrics;
 pub mod notifications;
+pub mod payment;
+pub mod privacy;
+pub mod receipt;
 pub mod runtime;
 pub mod schema;
+pub mod spend;
 pub mod types;
 pub mod ui;
 pub mod utils;

--- a/cognitod/src/main.rs
+++ b/cognitod/src/main.rs
@@ -8,7 +8,7 @@ use aya::maps::{
     MapData,
     perf::{PerfEventArray, PerfEventArrayBuffer},
 };
-use aya::programs::{KProbe, TracePoint};
+use aya::programs::{KProbe, Lsm, TracePoint};
 use aya::util::online_cpus;
 use aya::{Ebpf, EbpfLoader};
 use aya_log::EbpfLogger;
@@ -88,6 +88,26 @@ fn attach_tracepoint_internal(
 fn attach_tracepoint_optional(bpf: &mut Ebpf, program: &str, category: &str, name: &str) {
     if let Err(err) = attach_tracepoint_internal(bpf, program, category, name) {
         warn!("[cognitod] optional tracepoint {category}:{name} ({program}) not attached: {err:?}");
+    }
+}
+
+fn attach_lsm_internal(bpf: &mut Ebpf, program: &str, hook: &str) -> anyhow::Result<()> {
+    let prog: &mut Lsm = bpf
+        .program_mut(program)
+        .ok_or_else(|| anyhow::anyhow!("{program} program not found"))?
+        .try_into()?;
+    let btf = aya::Btf::from_sys_fs()?;
+    prog.load(hook, &btf)?;
+    prog.attach()?;
+    Ok(())
+}
+
+fn attach_lsm_optional(bpf: &mut Ebpf, program: &str, hook: &str) {
+    if let Err(err) = attach_lsm_internal(bpf, program, hook) {
+        warn!(
+            "[cognitod] optional LSM hook {hook} ({program}) not attached: {err:?}. \
+             Requires CONFIG_BPF_LSM=y and lsm=...,bpf boot parameter."
+        );
     }
 }
 
@@ -221,7 +241,11 @@ fn read_rss_trace_bytes() -> anyhow::Result<(Vec<u8>, String)> {
 fn init_ebpf(
     bpf_bytes: &[u8],
     telemetry_cfg: TelemetryConfig,
-) -> anyhow::Result<(BpfRuntimeGuards, Vec<PerfEventArrayBuffer<MapData>>)> {
+) -> anyhow::Result<(
+    BpfRuntimeGuards,
+    Vec<PerfEventArrayBuffer<MapData>>,
+    Option<cognitod::mandate::BpfMandateMaps>,
+)> {
     let telemetry = TelemetryConfigPod(telemetry_cfg);
     let mut loader = EbpfLoader::new();
     loader.set_global("TELEMETRY_CONFIG", &telemetry, true);
@@ -274,6 +298,10 @@ fn init_ebpf(
         "block_rq_complete",
     );
 
+    // Attach LINNIX-CLAW LSM enforcement hooks (optional — need CONFIG_BPF_LSM=y).
+    attach_lsm_optional(&mut bpf, "mandate_execve_check", "bprm_check_security");
+    attach_lsm_optional(&mut bpf, "mandate_socket_connect", "socket_connect");
+
     info!("[cognitod] Program attached. Setting up perf buffers...");
 
     let events_map = bpf
@@ -285,12 +313,45 @@ fn init_ebpf(
         perf_buffers.push(perf_array.open(cpu, None)?);
     }
 
+    // Take LINNIX-CLAW BPF maps for mandate lifecycle management.
+    // These are taken (not borrowed) so they outlive the Ebpf loader and can be
+    // passed to MandateManager.  If any map is absent (older BPF object), we
+    // fall back gracefully to userspace-only tracking.
+    let mandate_maps = (|| -> anyhow::Result<cognitod::mandate::BpfMandateMaps> {
+        let mm_raw = bpf
+            .take_map("MANDATE_MAP")
+            .ok_or_else(|| anyhow::anyhow!("MANDATE_MAP not found"))?;
+        let mode_raw = bpf
+            .take_map("MANDATE_MODE")
+            .ok_or_else(|| anyhow::anyhow!("MANDATE_MODE not found"))?;
+        let siphash_raw = bpf
+            .take_map("SIPHASH_KEY")
+            .ok_or_else(|| anyhow::anyhow!("SIPHASH_KEY not found"))?;
+        cognitod::mandate::build_bpf_mandate_maps(mm_raw, mode_raw, siphash_raw)
+    })();
+
+    let bpf_mandate_maps = match mandate_maps {
+        Ok(maps) => {
+            info!(
+                "[cognitod] LINNIX-CLAW: BPF mandate maps acquired (MANDATE_MAP, MANDATE_MODE, SIPHASH_KEY)"
+            );
+            Some(maps)
+        }
+        Err(e) => {
+            warn!(
+                "[cognitod] LINNIX-CLAW: BPF mandate maps not available ({e}); mandate enforcement will be userspace-only"
+            );
+            None
+        }
+    };
+
     Ok((
         BpfRuntimeGuards {
             _bpf: bpf,
             _logger: logger,
         },
         perf_buffers,
+        bpf_mandate_maps,
     ))
 }
 
@@ -409,6 +470,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let mut transport: &'static str = "userspace";
     let mut _bpf_runtime: Option<BpfRuntimeGuards> = None;
     let mut probe_state = ProbeState::disabled();
+    let mut mandate_bpf_maps: Option<cognitod::mandate::BpfMandateMaps> = None;
 
     let btf_path = std::env::var("LINNIX_KERNEL_BTF")
         .unwrap_or_else(|_| "/sys/kernel/btf/vmlinux".to_string());
@@ -427,10 +489,11 @@ async fn main() -> Result<(), Box<dyn Error>> {
                 let (bpf_bytes, chosen_path) = read_bpf_bytes()?;
                 println!("[cognitod] Using BPF object: {chosen_path}");
                 match init_ebpf(&bpf_bytes, telemetry_cfg) {
-                    Ok((guards, buffers)) => {
+                    Ok((guards, buffers, maps)) => {
                         transport = "perf";
                         perf_buffers = buffers;
                         _bpf_runtime = Some(guards);
+                        mandate_bpf_maps = maps;
                         probe_state = ProbeState {
                             rss_probe: match result.mode {
                                 CoreRssMode::MmStruct => RssProbeMode::CoreMm,
@@ -1105,6 +1168,18 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                 }
                                 let _ = queue_clone.complete(&action.id).await;
                             }
+                            cognitod::enforcement::ActionType::AuthorizeExec {
+                                pid,
+                                cmd_hash,
+                                expires_at,
+                            } => {
+                                info!(
+                                    "[enforcement] AUTHORIZE EXEC pid={} cmd_hash={:#x} expires_at={}",
+                                    pid, cmd_hash, expires_at
+                                );
+                                // Phase 0: mandate authorization handled via MandateManager API
+                                let _ = queue_clone.complete(&action.id).await;
+                            }
                         }
                     }
                 }
@@ -1135,6 +1210,92 @@ async fn main() -> Result<(), Box<dyn Error>> {
         .ok()
         .or(config.api.auth_token.clone());
 
+    // ── Linnix-Claw: initialize MandateManager ──────────────────────────
+    let mandate_manager: Option<Arc<cognitod::mandate::MandateManager>> = {
+        let lsm_available = bpf_config::is_bpf_lsm_available();
+        let allow_without_lsm = config.mandate.allow_commerce_without_lsm;
+
+        if lsm_available || allow_without_lsm {
+            match bpf_config::generate_siphash_key() {
+                Ok(key) => {
+                    let mode = if config.mandate.mode == "enforce" {
+                        linnix_ai_ebpf_common::MandateMode::Enforce
+                    } else {
+                        linnix_ai_ebpf_common::MandateMode::Monitor
+                    };
+                    let mgr = cognitod::mandate::MandateManager::new(key, lsm_available, mode);
+                    info!(
+                        "[claw] MandateManager initialized (lsm={}, mode={}, capacity={})",
+                        lsm_available, config.mandate.mode, config.mandate.map_capacity
+                    );
+                    let mgr = Arc::new(mgr);
+
+                    // Connect BPF maps if available (writes siphash key + mode to kernel).
+                    if let Some(maps) = mandate_bpf_maps.take() {
+                        mgr.connect_bpf_maps(maps).await;
+                    }
+
+                    Some(mgr)
+                }
+                Err(e) => {
+                    warn!("[claw] Failed to generate SipHash key: {e:#}. Mandate system disabled.");
+                    None
+                }
+            }
+        } else {
+            info!(
+                "[claw] BPF LSM not available and allow_commerce_without_lsm=false. Mandate system disabled."
+            );
+            None
+        }
+    };
+
+    // ── Linnix-Claw: commerce policy (§11.1) ───────────────────────────
+    let commerce_policy = {
+        let lsm_available = bpf_config::is_bpf_lsm_available();
+        let policy = cognitod::commerce::CommercePolicy::new(
+            lsm_available,
+            &config.mandate.mode,
+            config.mandate.allow_commerce_without_lsm,
+        );
+        info!(
+            "[claw] Commerce policy: mode={}, enforced={}, allow_without_lsm={}",
+            policy.mode.enforcement_mode_str(),
+            policy.is_enforced(),
+            policy.allow_commerce_without_lsm,
+        );
+        Some(policy)
+    };
+
+    // ── Linnix-Claw: initialize AgentIdentity (Phase 1) ─────────────────
+    let agent_identity: Option<Arc<cognitod::identity::AgentIdentity>> = if mandate_manager
+        .is_some()
+    {
+        let identity_path = std::path::Path::new(&config.mandate.identity_path);
+        let hostname = std::fs::read_to_string("/etc/hostname")
+            .map(|h| h.trim().to_string())
+            .unwrap_or_else(|_| "unknown".to_string());
+        let default_did = format!("did:linnix:{hostname}");
+        match cognitod::identity::AgentIdentity::load_or_generate(identity_path, &default_did) {
+            Ok(id) => {
+                info!(
+                    "[claw] AgentIdentity loaded (did={}, eth=0x{})",
+                    id.did(),
+                    hex::encode(id.ethereum_address())
+                );
+                Some(Arc::new(id))
+            }
+            Err(e) => {
+                warn!(
+                    "[claw] Failed to load/generate identity: {e:#}. Receipts will be unavailable."
+                );
+                None
+            }
+        }
+    } else {
+        None
+    };
+
     let app_state = Arc::new(AppState {
         context: Arc::clone(&context),
         metrics: Arc::clone(&metrics),
@@ -1150,6 +1311,10 @@ async fn main() -> Result<(), Box<dyn Error>> {
         enforcement: enforcement_queue.clone(),
         incident_store: incident_store.clone(),
         k8s: k8s_context.clone(),
+        mandate: mandate_manager,
+        identity: agent_identity,
+        commerce_policy,
+        claw_metrics: Arc::new(cognitod::claw_metrics::ClawMetrics::new()),
     });
 
     let api = all_routes(app_state.clone());
@@ -1170,6 +1335,52 @@ async fn main() -> Result<(), Box<dyn Error>> {
             eprintln!("server error: {e}");
         }
     });
+
+    // ── Unix domain socket listener (bypasses token auth) ──
+    let uds_path = std::env::var("LINNIX_UDS_PATH")
+        .ok()
+        .or_else(|| config.api.unix_socket.clone());
+
+    if let Some(ref socket_path) = uds_path {
+        use std::os::unix::fs::PermissionsExt;
+        use tokio::net::UnixListener;
+
+        // Remove stale socket file if it exists
+        let _ = std::fs::remove_file(socket_path);
+
+        // Ensure parent directory exists
+        if let Some(parent) = std::path::Path::new(socket_path).parent() {
+            let _ = std::fs::create_dir_all(parent);
+        }
+
+        match UnixListener::bind(socket_path) {
+            Ok(uds_listener) => {
+                // Set socket permissions: owner + group read/write (0o660)
+                if let Err(e) =
+                    std::fs::set_permissions(socket_path, std::fs::Permissions::from_mode(0o660))
+                {
+                    warn!("Failed to set UDS permissions: {}", e);
+                }
+
+                let uds_api = api::uds_routes(app_state.clone());
+                info!(
+                    "[cognitod] UDS server on {} (no auth — local connections only)",
+                    socket_path
+                );
+                tokio::spawn(async move {
+                    if let Err(e) = axum::serve(uds_listener, uds_api).await {
+                        eprintln!("UDS server error: {e}");
+                    }
+                });
+            }
+            Err(e) => {
+                warn!(
+                    "Failed to bind UDS at {}: {}. UDS disabled.",
+                    socket_path, e
+                );
+            }
+        }
+    }
 
     tokio::spawn(async {
         let mut sigterm = signal(SignalKind::terminate()).unwrap();

--- a/cognitod/src/main.rs
+++ b/cognitod/src/main.rs
@@ -896,6 +896,96 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     // LocalIlmHandlerRag removed (YAGNI cleanup)
 
+    // ── Linnix-Claw: initialize MandateManager ──────────────────────────
+    // Moved before handler_list finalization so MandateReceiptHandler can be
+    // registered in the handler pipeline.
+    let mandate_manager: Option<Arc<cognitod::mandate::MandateManager>> = {
+        let lsm_available = bpf_config::is_bpf_lsm_available();
+        let allow_without_lsm = config.mandate.allow_commerce_without_lsm;
+        // BPF enforcement is only truly active when capability checks pass
+        // AND the BPF mandate maps were successfully loaded from the eBPF
+        // object.  If eBPF init failed, mandate_bpf_maps is None and we
+        // must not claim enforcement is active.
+        let bpf_maps_connected = mandate_bpf_maps.is_some();
+        let enforcement_available = lsm_available && bpf_maps_connected;
+
+        if enforcement_available || allow_without_lsm {
+            match bpf_config::generate_siphash_key() {
+                Ok(key) => {
+                    let mode = if config.mandate.mode == "enforce" {
+                        linnix_ai_ebpf_common::MandateMode::Enforce
+                    } else {
+                        linnix_ai_ebpf_common::MandateMode::Monitor
+                    };
+                    let mgr =
+                        cognitod::mandate::MandateManager::new(key, enforcement_available, mode);
+                    info!(
+                        "[claw] MandateManager initialized (lsm={}, bpf_maps={}, mode={}, capacity={})",
+                        lsm_available,
+                        bpf_maps_connected,
+                        config.mandate.mode,
+                        config.mandate.map_capacity
+                    );
+                    let mgr = Arc::new(mgr);
+
+                    // Connect BPF maps if available (writes siphash key + mode to kernel).
+                    if let Some(maps) = mandate_bpf_maps.take() {
+                        mgr.connect_bpf_maps(maps).await;
+                    }
+
+                    Some(mgr)
+                }
+                Err(e) => {
+                    warn!("[claw] Failed to generate SipHash key: {e:#}. Mandate system disabled.");
+                    None
+                }
+            }
+        } else {
+            info!(
+                "[claw] BPF LSM not available and allow_commerce_without_lsm=false. Mandate system disabled."
+            );
+            None
+        }
+    };
+
+    // ── Linnix-Claw: initialize AgentIdentity (Phase 1) ─────────────────
+    let agent_identity: Option<Arc<cognitod::identity::AgentIdentity>> = if mandate_manager
+        .is_some()
+    {
+        let identity_path = std::path::Path::new(&config.mandate.identity_path);
+        let hostname = std::fs::read_to_string("/etc/hostname")
+            .map(|h| h.trim().to_string())
+            .unwrap_or_else(|_| "unknown".to_string());
+        let default_did = format!("did:linnix:{hostname}");
+        match cognitod::identity::AgentIdentity::load_or_generate(identity_path, &default_did) {
+            Ok(identity) => {
+                info!(
+                    "[claw] Agent identity: DID={}, ETH=0x{}",
+                    identity.did(),
+                    hex::encode(identity.ethereum_address())
+                );
+                Some(Arc::new(identity))
+            }
+            Err(e) => {
+                warn!(
+                    "[claw] Failed to load/generate identity: {e:#}. Receipts will be unavailable."
+                );
+                None
+            }
+        }
+    } else {
+        None
+    };
+
+    // ── Linnix-Claw: register MandateReceiptHandler ─────────────────────
+    if let (Some(mgr), Some(id)) = (&mandate_manager, &agent_identity) {
+        handler_list.register(cognitod::handler::MandateReceiptHandler::new(
+            Arc::clone(mgr),
+            Arc::clone(id),
+        ));
+        info!("[claw] MandateReceiptHandler registered in event pipeline");
+    }
+
     let handlers = Arc::new(handler_list);
     // Pass metrics to your listener
     if !perf_buffers.is_empty() {
@@ -1210,46 +1300,6 @@ async fn main() -> Result<(), Box<dyn Error>> {
         .ok()
         .or(config.api.auth_token.clone());
 
-    // ── Linnix-Claw: initialize MandateManager ──────────────────────────
-    let mandate_manager: Option<Arc<cognitod::mandate::MandateManager>> = {
-        let lsm_available = bpf_config::is_bpf_lsm_available();
-        let allow_without_lsm = config.mandate.allow_commerce_without_lsm;
-
-        if lsm_available || allow_without_lsm {
-            match bpf_config::generate_siphash_key() {
-                Ok(key) => {
-                    let mode = if config.mandate.mode == "enforce" {
-                        linnix_ai_ebpf_common::MandateMode::Enforce
-                    } else {
-                        linnix_ai_ebpf_common::MandateMode::Monitor
-                    };
-                    let mgr = cognitod::mandate::MandateManager::new(key, lsm_available, mode);
-                    info!(
-                        "[claw] MandateManager initialized (lsm={}, mode={}, capacity={})",
-                        lsm_available, config.mandate.mode, config.mandate.map_capacity
-                    );
-                    let mgr = Arc::new(mgr);
-
-                    // Connect BPF maps if available (writes siphash key + mode to kernel).
-                    if let Some(maps) = mandate_bpf_maps.take() {
-                        mgr.connect_bpf_maps(maps).await;
-                    }
-
-                    Some(mgr)
-                }
-                Err(e) => {
-                    warn!("[claw] Failed to generate SipHash key: {e:#}. Mandate system disabled.");
-                    None
-                }
-            }
-        } else {
-            info!(
-                "[claw] BPF LSM not available and allow_commerce_without_lsm=false. Mandate system disabled."
-            );
-            None
-        }
-    };
-
     // ── Linnix-Claw: commerce policy (§11.1) ───────────────────────────
     let commerce_policy = {
         let lsm_available = bpf_config::is_bpf_lsm_available();
@@ -1267,34 +1317,30 @@ async fn main() -> Result<(), Box<dyn Error>> {
         Some(policy)
     };
 
-    // ── Linnix-Claw: initialize AgentIdentity (Phase 1) ─────────────────
-    let agent_identity: Option<Arc<cognitod::identity::AgentIdentity>> = if mandate_manager
-        .is_some()
-    {
-        let identity_path = std::path::Path::new(&config.mandate.identity_path);
-        let hostname = std::fs::read_to_string("/etc/hostname")
-            .map(|h| h.trim().to_string())
-            .unwrap_or_else(|_| "unknown".to_string());
-        let default_did = format!("did:linnix:{hostname}");
-        match cognitod::identity::AgentIdentity::load_or_generate(identity_path, &default_did) {
-            Ok(id) => {
-                info!(
-                    "[claw] AgentIdentity loaded (did={}, eth=0x{})",
-                    id.did(),
-                    hex::encode(id.ethereum_address())
-                );
-                Some(Arc::new(id))
-            }
-            Err(e) => {
-                warn!(
-                    "[claw] Failed to load/generate identity: {e:#}. Receipts will be unavailable."
-                );
-                None
-            }
-        }
-    } else {
-        None
-    };
+    // ── Linnix-Claw: initialize SpendTracker (§8.5) ─────────────────────
+    let spend_tracker: Option<Arc<cognitod::spend::SpendTracker>> =
+        mandate_manager.as_ref().map(|_| {
+            Arc::new(cognitod::spend::SpendTracker::new(
+                config.spend_limits.clone(),
+            ))
+        });
+
+    // ── Linnix-Claw: initialize ComplianceEngine (§10.3) ────────────────
+    let compliance_engine: Option<Arc<cognitod::compliance::ComplianceEngine>> = mandate_manager
+        .as_ref()
+        .map(|_| Arc::new(cognitod::compliance::ComplianceEngine::permissive()));
+
+    // ── Linnix-Claw: initialize ReceiptRedactor (§10.4) ─────────────────
+    let receipt_redactor: Option<cognitod::privacy::ReceiptRedactor> =
+        mandate_manager.as_ref().map(|_| {
+            let level = config
+                .receipt_privacy
+                .redaction_level
+                .parse::<cognitod::privacy::RedactionLevel>()
+                .unwrap_or_default();
+            info!("[claw] Receipt redaction level: {}", level);
+            cognitod::privacy::ReceiptRedactor::new(level)
+        });
 
     let app_state = Arc::new(AppState {
         context: Arc::clone(&context),
@@ -1314,6 +1360,9 @@ async fn main() -> Result<(), Box<dyn Error>> {
         mandate: mandate_manager,
         identity: agent_identity,
         commerce_policy,
+        spend_tracker,
+        compliance_engine,
+        receipt_redactor,
         claw_metrics: Arc::new(cognitod::claw_metrics::ClawMetrics::new()),
     });
 

--- a/cognitod/src/main.rs
+++ b/cognitod/src/main.rs
@@ -1302,9 +1302,11 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     // ── Linnix-Claw: commerce policy (§11.1) ───────────────────────────
     let commerce_policy = {
-        let lsm_available = bpf_config::is_bpf_lsm_available();
+        // Use actual enforcement status: LSM available AND BPF maps connected.
+        // is_bpf_lsm_available() alone is insufficient — maps may have failed to load.
+        let enforcement_active = mandate_manager.as_ref().is_some_and(|m| m.bpf_available());
         let policy = cognitod::commerce::CommercePolicy::new(
-            lsm_available,
+            enforcement_active,
             &config.mandate.mode,
             config.mandate.allow_commerce_without_lsm,
         );

--- a/cognitod/src/mandate.rs
+++ b/cognitod/src/mandate.rs
@@ -865,8 +865,10 @@ impl MandateManager {
             &batch.mandates
         };
 
-        let total = mandates.len().min(MAX_BATCH_SIZE);
-        let mut results = Vec::with_capacity(total);
+        // Use the constant cap for allocation — `mandates` is already truncated
+        // to MAX_BATCH_SIZE above, so this is the true upper bound.
+        let total = mandates.len();
+        let mut results = Vec::with_capacity(MAX_BATCH_SIZE);
         let mut succeeded = 0usize;
         let mut failed = 0usize;
 

--- a/cognitod/src/mandate.rs
+++ b/cognitod/src/mandate.rs
@@ -91,7 +91,7 @@ pub fn build_bpf_mandate_maps(
 
 #[inline]
 fn rotl(x: u64, b: u32) -> u64 {
-    (x << b) | (x >> (64 - b))
+    x.rotate_left(b)
 }
 
 #[inline]
@@ -494,10 +494,12 @@ impl MandateManager {
         if pid == 0 {
             return Err(anyhow!("invalid PID 0"));
         }
-        // pid is u32 — format! produces only digits, so the path is safe.
-        let stat_path = format!("/proc/{}/stat", pid);
+        // Construct path from a u32 — only digits, no path traversal possible.
+        let mut stat_path = std::path::PathBuf::from("/proc");
+        stat_path.push(pid.to_string());
+        stat_path.push("stat");
         let stat_content = std::fs::read_to_string(&stat_path)
-            .with_context(|| format!("failed to read {}", stat_path))?;
+            .with_context(|| format!("failed to read {}", stat_path.display()))?;
 
         // /proc/<pid>/stat format: pid (comm) state ppid ... field22=starttime
         // The comm field can contain spaces and parens, so we find the last ')'
@@ -568,8 +570,10 @@ impl MandateManager {
                 continue;
             };
 
-            // Check cgroup for container ID
-            let cgroup_path = format!("/proc/{}/cgroup", host_pid);
+            // Check cgroup for container ID — host_pid is a parsed u32, safe.
+            let mut cgroup_path = std::path::PathBuf::from("/proc");
+            cgroup_path.push(host_pid.to_string());
+            cgroup_path.push("cgroup");
             let Ok(cgroup_content) = std::fs::read_to_string(&cgroup_path) else {
                 continue;
             };
@@ -580,7 +584,9 @@ impl MandateManager {
 
             // Found a process in this container. Now check NSpid to see if the
             // namespace PID matches the requested container_pid.
-            let status_path = format!("/proc/{}/status", host_pid);
+            let mut status_path = std::path::PathBuf::from("/proc");
+            status_path.push(host_pid.to_string());
+            status_path.push("status");
             let Ok(status_content) = std::fs::read_to_string(&status_path) else {
                 continue;
             };
@@ -859,7 +865,7 @@ impl MandateManager {
             &batch.mandates
         };
 
-        let total = mandates.len();
+        let total = mandates.len().min(MAX_BATCH_SIZE);
         let mut results = Vec::with_capacity(total);
         let mut succeeded = 0usize;
         let mut failed = 0usize;

--- a/cognitod/src/mandate.rs
+++ b/cognitod/src/mandate.rs
@@ -1,0 +1,1144 @@
+// =============================================================================
+// LINNIX-CLAW: MandateManager — Userspace BPF Map Controller
+// =============================================================================
+//
+// Owns the lifecycle of mandates: create, lookup, revoke, expire.
+// Writes MandateKey→MandateValue entries into the BPF LRU hash map.
+// Runs a periodic reconciliation loop (every 5s) to evict expired entries.
+//
+// See docs/linnix-claw/specs.md §3 for API specification.
+// See docs/linnix-claw/specs.md §1.3 for LRU eviction policy.
+
+use anyhow::{Context, Result, anyhow};
+use aya::maps::{Array as AyaArray, HashMap as AyaHashMap, MapData};
+use log::{debug, info, warn};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+use tokio::sync::{Mutex as TokioMutex, RwLock};
+
+use crate::receipt::ExecutionReceipt;
+
+use linnix_ai_ebpf_common::{
+    MANDATE_MAP_MAX_ENTRIES, MANDATE_MAP_WATERMARK, MANDATE_RECONCILE_INTERVAL_SECS, MandateKey,
+    MandateMode, MandateValue,
+};
+
+// =============================================================================
+// AYA POD WRAPPERS
+// =============================================================================
+//
+// aya::maps::HashMap requires key/value types to implement aya::Pod.
+// MandateKey and MandateValue are defined in linnix_ai_ebpf_common (a foreign
+// crate), so we cannot implement aya::Pod for them directly (orphan rule).
+// These transparent wrappers have identical memory layout and satisfy aya.
+
+#[repr(transparent)]
+#[derive(Copy, Clone)]
+pub(crate) struct BpfMandateKey(MandateKey);
+
+#[repr(transparent)]
+#[derive(Copy, Clone)]
+pub(crate) struct BpfMandateValue(MandateValue);
+
+// SAFETY: both MandateKey and MandateValue are #[repr(C)] POD structs with
+// no padding holes, and are safe to copy byte-for-byte to/from kernel memory.
+unsafe impl aya::Pod for BpfMandateKey {}
+unsafe impl aya::Pod for BpfMandateValue {}
+
+/// BPF map handles passed from init_ebpf() to connect_bpf_maps().
+///
+/// Construct via [`build_bpf_mandate_maps`] — the inner types are
+/// transparent-wrapper internals and not part of the public API.
+pub struct BpfMandateMaps {
+    mandate_map: AyaHashMap<MapData, BpfMandateKey, BpfMandateValue>,
+    mode_map: AyaArray<MapData, u32>,
+    siphash_map: AyaArray<MapData, u64>,
+}
+
+/// Build a [`BpfMandateMaps`] from three raw aya `Map` objects taken from the
+/// loaded BPF object.
+///
+/// Intended to be called in `main.rs` right after `init_ebpf()`:
+/// ```ignore
+/// let mandate_maps = build_bpf_mandate_maps(
+///     bpf.take_map("MANDATE_MAP").ok_or(...)?,
+///     bpf.take_map("MANDATE_MODE").ok_or(...)?,
+///     bpf.take_map("SIPHASH_KEY").ok_or(...)?,
+/// )?;
+/// ```
+pub fn build_bpf_mandate_maps(
+    mandate_map_raw: aya::maps::Map,
+    mode_map_raw: aya::maps::Map,
+    siphash_map_raw: aya::maps::Map,
+) -> anyhow::Result<BpfMandateMaps> {
+    use anyhow::Context as _;
+    Ok(BpfMandateMaps {
+        mandate_map: AyaHashMap::try_from(mandate_map_raw).context("MANDATE_MAP type mismatch")?,
+        mode_map: AyaArray::try_from(mode_map_raw).context("MANDATE_MODE type mismatch")?,
+        siphash_map: AyaArray::try_from(siphash_map_raw).context("SIPHASH_KEY type mismatch")?,
+    })
+}
+
+// =============================================================================
+// SipHash-2-4 (userspace implementation)
+// =============================================================================
+//
+// Mirrors the eBPF-side siphash.rs implementation exactly.
+// Both MUST produce identical output for the same inputs and key.
+
+#[inline]
+fn rotl(x: u64, b: u32) -> u64 {
+    (x << b) | (x >> (64 - b))
+}
+
+#[inline]
+fn sipround(v0: &mut u64, v1: &mut u64, v2: &mut u64, v3: &mut u64) {
+    *v0 = v0.wrapping_add(*v1);
+    *v1 = rotl(*v1, 13);
+    *v1 ^= *v0;
+    *v0 = rotl(*v0, 32);
+    *v2 = v2.wrapping_add(*v3);
+    *v3 = rotl(*v3, 16);
+    *v3 ^= *v2;
+    *v0 = v0.wrapping_add(*v3);
+    *v3 = rotl(*v3, 21);
+    *v3 ^= *v0;
+    *v2 = v2.wrapping_add(*v1);
+    *v1 = rotl(*v1, 17);
+    *v1 ^= *v2;
+    *v2 = rotl(*v2, 32);
+}
+
+pub struct SipHasher {
+    v0: u64,
+    v1: u64,
+    v2: u64,
+    v3: u64,
+    buf: u64,
+    count: usize,
+}
+
+impl SipHasher {
+    pub fn new(k0: u64, k1: u64) -> Self {
+        Self {
+            v0: k0 ^ 0x736f6d6570736575,
+            v1: k1 ^ 0x646f72616e646f6d,
+            v2: k0 ^ 0x6c7967656e657261,
+            v3: k1 ^ 0x7465646279746573,
+            buf: 0,
+            count: 0,
+        }
+    }
+
+    pub fn write_byte(&mut self, byte: u8) {
+        let shift = (self.count % 8) * 8;
+        self.buf |= (byte as u64) << shift;
+        self.count += 1;
+
+        if self.count.is_multiple_of(8) {
+            self.compress();
+        }
+    }
+
+    pub fn write(&mut self, data: &[u8]) {
+        for &b in data {
+            self.write_byte(b);
+        }
+    }
+
+    fn compress(&mut self) {
+        self.v3 ^= self.buf;
+        sipround(&mut self.v0, &mut self.v1, &mut self.v2, &mut self.v3);
+        sipround(&mut self.v0, &mut self.v1, &mut self.v2, &mut self.v3);
+        self.v0 ^= self.buf;
+        self.buf = 0;
+    }
+
+    pub fn finish(mut self) -> u64 {
+        let b = (self.count as u64) << 56;
+        self.buf |= b;
+
+        self.v3 ^= self.buf;
+        sipround(&mut self.v0, &mut self.v1, &mut self.v2, &mut self.v3);
+        sipround(&mut self.v0, &mut self.v1, &mut self.v2, &mut self.v3);
+        self.v0 ^= self.buf;
+
+        self.v2 ^= 0xff;
+        sipround(&mut self.v0, &mut self.v1, &mut self.v2, &mut self.v3);
+        sipround(&mut self.v0, &mut self.v1, &mut self.v2, &mut self.v3);
+        sipround(&mut self.v0, &mut self.v1, &mut self.v2, &mut self.v3);
+        sipround(&mut self.v0, &mut self.v1, &mut self.v2, &mut self.v3);
+
+        self.v0 ^ self.v1 ^ self.v2 ^ self.v3
+    }
+}
+
+/// Compute SipHash-2-4 of data with the given 128-bit key.
+pub fn siphash_2_4(key: [u64; 2], data: &[u8]) -> u64 {
+    let mut hasher = SipHasher::new(key[0], key[1]);
+    hasher.write(data);
+    hasher.finish()
+}
+
+// =============================================================================
+// MANDATE TYPES
+// =============================================================================
+
+/// Unique mandate identifier (UUID-based for API consumers).
+pub type MandateId = String;
+
+/// Request to create a new mandate.
+#[derive(Debug, Clone, Deserialize)]
+pub struct MandateRequest {
+    /// Target process ID.
+    pub pid: u32,
+    /// The command arguments to authorize (will be canonicalized and hashed).
+    pub args: Vec<String>,
+    /// Time-to-live in milliseconds (mandate expires after this duration).
+    pub ttl_ms: u64,
+    /// Optional container ID for PID namespace translation.
+    #[serde(default)]
+    pub container_id: Option<String>,
+    /// If true, mandate is in monitor-only mode (allow but tag receipts).
+    #[serde(default)]
+    pub monitor_only: bool,
+    /// Correlation ID for settlement. Not sent to kernel.
+    #[serde(default)]
+    pub task_id: Option<String>,
+    /// Spend cap for this mandate in USD cents (§8.5). Tracked by cognitod.
+    #[serde(default)]
+    pub max_spend_cents: Option<u64>,
+}
+
+impl MandateRequest {
+    /// Whether this mandate has settlement-related fields (commerce request).
+    /// Commerce requests are subject to the §11.1 commerce policy.
+    pub fn is_commerce_request(&self) -> bool {
+        self.task_id.is_some() || self.max_spend_cents.is_some()
+    }
+}
+
+/// Batch mandate creation request.
+#[derive(Debug, Clone, Deserialize)]
+pub struct BatchMandateRequest {
+    /// Up to 64 mandates to create atomically.
+    pub mandates: Vec<MandateRequest>,
+}
+
+/// Result for a single mandate in a batch operation.
+#[derive(Debug, Clone, Serialize)]
+pub struct BatchMandateResult {
+    /// Index of this item in the request array.
+    pub index: usize,
+    /// The mandate response if creation succeeded.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mandate: Option<MandateResponse>,
+    /// Error message if creation failed.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+/// Response for a batch mandate creation.
+#[derive(Debug, Clone, Serialize)]
+pub struct BatchMandateResponse {
+    /// Total mandates requested.
+    pub total: usize,
+    /// Number that succeeded.
+    pub succeeded: usize,
+    /// Number that failed.
+    pub failed: usize,
+    /// Individual results.
+    pub results: Vec<BatchMandateResult>,
+}
+
+/// Response after creating a mandate.
+#[derive(Debug, Clone, Serialize)]
+pub struct MandateResponse {
+    /// Unique mandate ID for tracking.
+    pub id: MandateId,
+    /// The BPF map key that was written.
+    pub key: MandateKeyInfo,
+    /// When the mandate expires (Unix timestamp ms).
+    pub expires_at_ms: u64,
+    /// Current mandate status.
+    pub status: MandateStatus,
+    /// Whether this mandate is kernel-enforced (BPF LSM active).
+    #[serde(default)]
+    pub enforced: bool,
+    /// Enforcement mode: "enforce", "monitor", or "none".
+    pub enforcement_mode: String,
+}
+
+/// Human-readable representation of a MandateKey.
+#[derive(Debug, Clone, Serialize)]
+pub struct MandateKeyInfo {
+    pub pid: u32,
+    pub start_time_ns: u64,
+    pub cmd_hash: u64,
+}
+
+/// Mandate lifecycle status.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub enum MandateStatus {
+    Active,
+    Expired,
+    Revoked,
+    Executed,
+}
+
+/// Internal mandate record tracked by the manager.
+#[derive(Debug, Clone)]
+#[allow(dead_code)] // Fields used in Phase 1 (BPF map writeback)
+struct MandateRecord {
+    id: MandateId,
+    key: MandateKey,
+    value: MandateValue,
+    args: Vec<String>,
+    status: MandateStatus,
+    created_at: Instant,
+    /// If the mandate has been written to the BPF map.
+    bpf_committed: bool,
+    /// Signed execution receipt (populated after mandate execution completes).
+    receipt: Option<ExecutionReceipt>,
+}
+
+/// Summary statistics for the mandate system.
+#[derive(Debug, Clone, Serialize)]
+pub struct MandateStats {
+    pub active_count: usize,
+    pub total_created: u64,
+    pub total_expired: u64,
+    pub total_revoked: u64,
+    pub total_executed: u64,
+    pub bpf_map_usage: u32,
+    pub bpf_map_capacity: u32,
+    pub backpressure_active: bool,
+}
+
+/// Health status for the mandate subsystem.
+#[derive(Debug, Clone, Serialize)]
+pub struct MandateHealth {
+    pub status: String,
+    pub bpf_lsm_loaded: bool,
+    pub enforcement_mode: String,
+    pub map_usage_percent: f32,
+    pub siphash_key_set: bool,
+    pub reconciliation_interval_secs: u64,
+}
+
+// =============================================================================
+// MANDATE MANAGER
+// =============================================================================
+
+pub struct MandateManager {
+    /// Active mandates indexed by their API-level ID.
+    mandates: RwLock<HashMap<MandateId, MandateRecord>>,
+
+    /// SipHash-2-4 key (128-bit: [k0, k1]).
+    siphash_key: [u64; 2],
+
+    /// Whether BPF LSM is loaded and functional.
+    bpf_available: bool,
+
+    /// Current enforcement mode.
+    mode: MandateMode,
+
+    /// Monotonic mandate sequence counter.
+    next_seq: AtomicU64,
+
+    /// Counters for stats.
+    total_created: AtomicU64,
+    total_expired: AtomicU64,
+    total_revoked: AtomicU64,
+    total_executed: AtomicU64,
+
+    /// Approximate count of entries in the BPF map (tracked locally since
+    /// BPF LRU maps don't expose count directly).
+    bpf_map_count: AtomicU64,
+
+    /// BPF MANDATE_MAP handle for kernel enforcement.
+    /// Populated by connect_bpf_maps() after eBPF load.
+    bpf_mandate_map: TokioMutex<Option<AyaHashMap<MapData, BpfMandateKey, BpfMandateValue>>>,
+}
+
+impl MandateManager {
+    /// Create a new MandateManager.
+    ///
+    /// `siphash_key` — 128-bit key matching what was loaded into eBPF .rodata.
+    /// `bpf_available` — whether BPF LSM programs were successfully loaded.
+    /// `mode` — initial enforcement mode (Monitor or Enforce).
+    pub fn new(siphash_key: [u64; 2], bpf_available: bool, mode: MandateMode) -> Self {
+        Self {
+            mandates: RwLock::new(HashMap::new()),
+            siphash_key,
+            bpf_available,
+            mode,
+            next_seq: AtomicU64::new(1),
+            total_created: AtomicU64::new(0),
+            total_expired: AtomicU64::new(0),
+            total_revoked: AtomicU64::new(0),
+            total_executed: AtomicU64::new(0),
+            bpf_map_count: AtomicU64::new(0),
+            bpf_mandate_map: TokioMutex::new(None),
+        }
+    }
+
+    /// Whether BPF LSM is available for kernel enforcement.
+    pub fn bpf_available(&self) -> bool {
+        self.bpf_available
+    }
+
+    /// Current enforcement mode.
+    pub fn mode(&self) -> &MandateMode {
+        &self.mode
+    }
+
+    /// Enforcement mode as a string for API responses.
+    pub fn enforcement_mode_str(&self) -> &'static str {
+        match self.mode {
+            MandateMode::Monitor => "monitor",
+            MandateMode::Enforce => "enforce",
+        }
+    }
+
+    /// Connect the BPF maps taken from the loaded eBPF object.
+    ///
+    /// Must be called after eBPF programs are loaded. Writes the SipHash key
+    /// and enforcement mode into the kernel maps so the LSM hooks can use them.
+    /// After this call, create/revoke/reconcile will maintain the MANDATE_MAP.
+    pub async fn connect_bpf_maps(&self, mut maps: BpfMandateMaps) {
+        // Write SipHash key into SIPHASH_KEY array map (indices 0 and 1).
+        if let Err(e) = maps.siphash_map.set(0, self.siphash_key[0], 0) {
+            warn!("[mandate] failed to write SIPHASH_KEY[0] to BPF map: {e}");
+        }
+        if let Err(e) = maps.siphash_map.set(1, self.siphash_key[1], 0) {
+            warn!("[mandate] failed to write SIPHASH_KEY[1] to BPF map: {e}");
+        }
+
+        // Write enforcement mode to MANDATE_MODE array map (index 0).
+        let mode_val = self.mode as u32;
+        if let Err(e) = maps.mode_map.set(0, mode_val, 0) {
+            warn!("[mandate] failed to write MANDATE_MODE to BPF map: {e}");
+        }
+
+        info!(
+            "[mandate] BPF maps connected: siphash_key=[{:#x}, {:#x}] mode={}",
+            self.siphash_key[0],
+            self.siphash_key[1],
+            self.enforcement_mode_str()
+        );
+
+        *self.bpf_mandate_map.lock().await = Some(maps.mandate_map);
+    }
+
+    /// Canonicalize command arguments and compute SipHash-2-4.
+    ///
+    /// Canonical form (per specs.md §1.1.1):
+    ///   arg0 \x00 arg1 \x00 arg2 \x00 ...
+    /// UTF-8 encoded, NUL-separated, no trailing NUL.
+    pub fn hash_args(&self, args: &[String]) -> u64 {
+        let mut hasher = SipHasher::new(self.siphash_key[0], self.siphash_key[1]);
+        for (i, arg) in args.iter().enumerate() {
+            if i > 0 {
+                hasher.write_byte(0x00); // NUL separator
+            }
+            hasher.write(arg.as_bytes());
+        }
+        hasher.finish()
+    }
+
+    /// Read the start_time_ns for a process from /proc/<pid>/stat.
+    ///
+    /// Field 22 is `starttime` in clock ticks since boot.
+    /// Converted to nanoseconds via `ticks * (1e9 / CLK_TCK)`.
+    fn read_start_time_ns(pid: u32) -> Result<u64> {
+        let stat_path = format!("/proc/{}/stat", pid);
+        let stat_content = std::fs::read_to_string(&stat_path)
+            .with_context(|| format!("failed to read {}", stat_path))?;
+
+        // /proc/<pid>/stat format: pid (comm) state ppid ... field22=starttime
+        // The comm field can contain spaces and parens, so we find the last ')'
+        // and work from there.
+        let last_paren = stat_content
+            .rfind(')')
+            .ok_or_else(|| anyhow!("malformed /proc/{}/stat: no closing paren", pid))?;
+
+        let fields_after_comm = &stat_content[last_paren + 2..]; // skip ") "
+        let fields: Vec<&str> = fields_after_comm.split_whitespace().collect();
+
+        // Field 22 in the full stat is starttime. After ")" and state, it's at
+        // index 19 (0-indexed) in the remaining fields.
+        // Fields after ')': state(0) ppid(1) pgrp(2) session(3) tty_nr(4) tpgid(5)
+        //   flags(6) minflt(7) cminflt(8) majflt(9) cmajflt(10) utime(11) stime(12)
+        //   cutime(13) cstime(14) priority(15) nice(16) num_threads(17) itrealvalue(18)
+        //   starttime(19)
+        const STARTTIME_INDEX: usize = 19;
+
+        if fields.len() <= STARTTIME_INDEX {
+            return Err(anyhow!(
+                "malformed /proc/{}/stat: not enough fields (got {})",
+                pid,
+                fields.len()
+            ));
+        }
+
+        let starttime_ticks: u64 = fields[STARTTIME_INDEX]
+            .parse()
+            .with_context(|| format!("failed to parse starttime from /proc/{}/stat", pid))?;
+
+        // Convert clock ticks to nanoseconds
+        let clk_tck = unsafe { libc::sysconf(libc::_SC_CLK_TCK) };
+        if clk_tck <= 0 {
+            return Err(anyhow!("sysconf(_SC_CLK_TCK) returned {}", clk_tck));
+        }
+
+        let ns_per_tick = 1_000_000_000u64 / (clk_tck as u64);
+        Ok(starttime_ticks.saturating_mul(ns_per_tick))
+    }
+
+    /// Resolve a container PID to a host PID using `/proc/*/cgroup` matching.
+    ///
+    /// See specs.md §2.5. When `container_id` is provided, we scan `/proc`
+    /// entries whose cgroup path contains the container ID prefix (12+ chars).
+    /// Returns the host-namespace PID.
+    pub fn resolve_container_pid(container_pid: u32, container_id: &str) -> Result<u32> {
+        if container_id.len() < 12 {
+            return Err(anyhow!("container_id must be at least 12 hex chars"));
+        }
+
+        let prefix = &container_id[..12];
+
+        // Scan /proc for processes whose cgroup contains this container ID
+        let proc_dir = std::fs::read_dir("/proc").context("failed to read /proc")?;
+
+        for entry in proc_dir.flatten() {
+            let name = entry.file_name();
+            let name_str = name.to_string_lossy();
+
+            // Only look at numeric (PID) directories
+            let Ok(host_pid) = name_str.parse::<u32>() else {
+                continue;
+            };
+
+            // Check cgroup for container ID
+            let cgroup_path = format!("/proc/{}/cgroup", host_pid);
+            let Ok(cgroup_content) = std::fs::read_to_string(&cgroup_path) else {
+                continue;
+            };
+
+            if !cgroup_content.contains(prefix) {
+                continue;
+            }
+
+            // Found a process in this container. Now check NSpid to see if the
+            // namespace PID matches the requested container_pid.
+            let status_path = format!("/proc/{}/status", host_pid);
+            let Ok(status_content) = std::fs::read_to_string(&status_path) else {
+                continue;
+            };
+
+            for line in status_content.lines() {
+                if let Some(nspid_str) = line.strip_prefix("NSpid:") {
+                    let pids: Vec<u32> = nspid_str
+                        .split_whitespace()
+                        .filter_map(|s| s.parse().ok())
+                        .collect();
+
+                    // NSpid lists PIDs from outermost to innermost namespace.
+                    // The last entry is the container-visible PID.
+                    if pids.last() == Some(&container_pid) {
+                        info!(
+                            "[mandate] resolved container PID {} (container={}) → host PID {}",
+                            container_pid,
+                            &container_id[..12],
+                            host_pid
+                        );
+                        return Ok(host_pid);
+                    }
+                }
+            }
+        }
+
+        Err(anyhow!(
+            "pid {} not found in container {} namespace",
+            container_pid,
+            &container_id[..12]
+        ))
+    }
+
+    /// Check if backpressure should be applied (map usage > 80%).
+    pub fn is_backpressure_active(&self) -> bool {
+        self.bpf_map_count.load(Ordering::Relaxed) as u32 >= MANDATE_MAP_WATERMARK
+    }
+
+    /// Create a new mandate.
+    ///
+    /// Returns `Err` with a descriptive message if:
+    /// - The PID doesn't exist
+    /// - Backpressure is active (map > 80% full)
+    /// - The process start time can't be read
+    pub async fn create(&self, req: MandateRequest) -> Result<MandateResponse> {
+        // Check backpressure
+        if self.is_backpressure_active() {
+            return Err(anyhow!(
+                "mandate map backpressure active ({}/{} entries). Retry later.",
+                self.bpf_map_count.load(Ordering::Relaxed),
+                MANDATE_MAP_MAX_ENTRIES
+            ));
+        }
+
+        // Resolve container PID → host PID if container_id is provided (§2.5)
+        let effective_pid = if let Some(ref cid) = req.container_id {
+            Self::resolve_container_pid(req.pid, cid).with_context(|| {
+                format!(
+                    "container PID {} in container {} could not be resolved",
+                    req.pid,
+                    &cid[..cid.len().min(12)]
+                )
+            })?
+        } else {
+            req.pid
+        };
+
+        // Validate the PID exists
+        let start_time_ns = Self::read_start_time_ns(effective_pid)
+            .with_context(|| format!("PID {} does not exist or is not readable", effective_pid))?;
+
+        // Hash the command args
+        let cmd_hash = self.hash_args(&req.args);
+
+        // Build the key
+        let key = MandateKey {
+            pid: effective_pid,
+            _pad: 0,
+            start_time_ns,
+            cmd_hash,
+        };
+
+        // Calculate expiry
+        let now_ns = nix::time::clock_gettime(nix::time::ClockId::CLOCK_BOOTTIME)
+            .map(|ts| ts.tv_sec() as u64 * 1_000_000_000 + ts.tv_nsec() as u64)
+            .unwrap_or(0);
+        let expires_ns = now_ns.saturating_add(req.ttl_ms.saturating_mul(1_000_000));
+
+        // Build the value
+        let seq = self.next_seq.fetch_add(1, Ordering::Relaxed);
+        let flags = if req.monitor_only {
+            MandateValue::FLAG_MONITOR
+        } else {
+            0
+        };
+
+        let value = MandateValue {
+            expires_ns,
+            flags,
+            _reserved: 0,
+            mandate_seq: seq,
+        };
+
+        // Generate mandate ID
+        let id = uuid::Uuid::new_v4().to_string();
+
+        // Calculate expires_at for the API response (wall-clock)
+        let expires_at_ms = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis() as u64
+            + req.ttl_ms;
+
+        // Store the record
+        let record = MandateRecord {
+            id: id.clone(),
+            key,
+            value,
+            args: req.args,
+            status: MandateStatus::Active,
+            created_at: Instant::now(),
+            bpf_committed: self.bpf_available, // mark as committed if BPF is available
+            receipt: None,
+        };
+
+        let response = MandateResponse {
+            id: id.clone(),
+            key: MandateKeyInfo {
+                pid: key.pid,
+                start_time_ns: key.start_time_ns,
+                cmd_hash: key.cmd_hash,
+            },
+            expires_at_ms,
+            status: MandateStatus::Active,
+            enforced: self.bpf_available && self.mode == MandateMode::Enforce,
+            enforcement_mode: self.enforcement_mode_str().to_string(),
+        };
+
+        {
+            let mut mandates = self.mandates.write().await;
+            mandates.insert(id.clone(), record);
+        }
+
+        // Write to BPF MANDATE_MAP so the LSM hook can enforce this mandate.
+        {
+            let mut bpf_guard = self.bpf_mandate_map.lock().await;
+            if let Some(ref mut bpf_map) = *bpf_guard {
+                if let Err(e) = bpf_map.insert(BpfMandateKey(key), BpfMandateValue(value), 0) {
+                    warn!("[mandate] BPF map insert failed for mandate {}: {}", id, e);
+                } else {
+                    debug!(
+                        "[mandate] BPF map: inserted mandate {} (pid={})",
+                        id, key.pid
+                    );
+                }
+            }
+        }
+
+        self.total_created.fetch_add(1, Ordering::Relaxed);
+        self.bpf_map_count.fetch_add(1, Ordering::Relaxed);
+
+        Ok(response)
+    }
+
+    /// Get a mandate by ID.
+    pub async fn get(&self, id: &str) -> Option<MandateResponse> {
+        let mandates = self.mandates.read().await;
+        let record = mandates.get(id)?;
+
+        let expires_at_ms = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis() as u64;
+
+        Some(MandateResponse {
+            id: record.id.clone(),
+            key: MandateKeyInfo {
+                pid: record.key.pid,
+                start_time_ns: record.key.start_time_ns,
+                cmd_hash: record.key.cmd_hash,
+            },
+            expires_at_ms,
+            status: record.status.clone(),
+            enforced: self.bpf_available && self.mode == MandateMode::Enforce,
+            enforcement_mode: self.enforcement_mode_str().to_string(),
+        })
+    }
+
+    /// Revoke (delete) a mandate by ID.
+    pub async fn revoke(&self, id: &str) -> Result<()> {
+        let revoked_key = {
+            let mut mandates = self.mandates.write().await;
+            let record = mandates
+                .get_mut(id)
+                .ok_or_else(|| anyhow!("mandate {} not found", id))?;
+
+            if record.status != MandateStatus::Active {
+                return Err(anyhow!(
+                    "mandate {} is not active (status: {:?})",
+                    id,
+                    record.status
+                ));
+            }
+
+            record.status = MandateStatus::Revoked;
+            record.key
+        };
+
+        // Remove from BPF MANDATE_MAP so the LSM hook stops enforcing it.
+        {
+            let mut bpf_guard = self.bpf_mandate_map.lock().await;
+            if let Some(ref mut bpf_map) = *bpf_guard {
+                if let Err(e) = bpf_map.remove(&BpfMandateKey(revoked_key)) {
+                    warn!("[mandate] BPF map remove failed for mandate {}: {}", id, e);
+                } else {
+                    debug!(
+                        "[mandate] BPF map: removed revoked mandate {} (pid={})",
+                        id, revoked_key.pid
+                    );
+                }
+            }
+        }
+
+        self.total_revoked.fetch_add(1, Ordering::Relaxed);
+        self.bpf_map_count
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |v| {
+                Some(v.saturating_sub(1))
+            })
+            .ok();
+
+        info!("[mandate] revoked mandate {}", id);
+        Ok(())
+    }
+
+    /// Create multiple mandates in a batch (up to 64).
+    ///
+    /// Each mandate is created independently — individual failures do not
+    /// prevent other mandates from being created. Returns per-item results.
+    pub async fn create_batch(&self, batch: BatchMandateRequest) -> BatchMandateResponse {
+        const MAX_BATCH_SIZE: usize = 64;
+
+        let mandates = if batch.mandates.len() > MAX_BATCH_SIZE {
+            warn!(
+                "[mandate] batch size {} exceeds max {}, truncating",
+                batch.mandates.len(),
+                MAX_BATCH_SIZE
+            );
+            &batch.mandates[..MAX_BATCH_SIZE]
+        } else {
+            &batch.mandates
+        };
+
+        let total = mandates.len();
+        let mut results = Vec::with_capacity(total);
+        let mut succeeded = 0usize;
+        let mut failed = 0usize;
+
+        for (index, req) in mandates.iter().enumerate() {
+            match self.create(req.clone()).await {
+                Ok(resp) => {
+                    results.push(BatchMandateResult {
+                        index,
+                        mandate: Some(resp),
+                        error: None,
+                    });
+                    succeeded += 1;
+                }
+                Err(e) => {
+                    results.push(BatchMandateResult {
+                        index,
+                        mandate: None,
+                        error: Some(e.to_string()),
+                    });
+                    failed += 1;
+                }
+            }
+        }
+
+        BatchMandateResponse {
+            total,
+            succeeded,
+            failed,
+            results,
+        }
+    }
+
+    /// Mark a mandate as executed and attach a signed receipt.
+    ///
+    /// Called when the mandated process completes (exit event received).
+    pub async fn mark_executed(&self, id: &str, receipt: ExecutionReceipt) -> Result<()> {
+        let mut mandates = self.mandates.write().await;
+        let record = mandates
+            .get_mut(id)
+            .ok_or_else(|| anyhow!("mandate {} not found", id))?;
+
+        if record.status != MandateStatus::Active {
+            return Err(anyhow!(
+                "mandate {} is not active (status: {:?})",
+                id,
+                record.status
+            ));
+        }
+
+        record.status = MandateStatus::Executed;
+        record.receipt = Some(receipt);
+
+        self.total_executed.fetch_add(1, Ordering::Relaxed);
+        self.bpf_map_count
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |v| {
+                Some(v.saturating_sub(1))
+            })
+            .ok();
+
+        info!("[mandate] mandate {} executed, receipt stored", id);
+        Ok(())
+    }
+
+    /// Get the execution receipt for a mandate.
+    ///
+    /// Returns `None` if the mandate doesn't exist or hasn't been executed yet.
+    pub async fn get_receipt(&self, id: &str) -> Option<ExecutionReceipt> {
+        let mandates = self.mandates.read().await;
+        mandates.get(id)?.receipt.clone()
+    }
+
+    /// Get the arguments for a mandate.
+    pub async fn get_args(&self, id: &str) -> Option<Vec<String>> {
+        let mandates = self.mandates.read().await;
+        mandates.get(id).map(|r| r.args.clone())
+    }
+
+    /// Get the mandate status.
+    pub async fn get_status(&self, id: &str) -> Option<MandateStatus> {
+        let mandates = self.mandates.read().await;
+        mandates.get(id).map(|r| r.status.clone())
+    }
+
+    /// Run the reconciliation loop — scans all mandates and evicts expired ones.
+    /// Called every MANDATE_RECONCILE_INTERVAL_SECS by a background task.
+    pub async fn reconcile(&self) -> usize {
+        // Current boot-monotonic time matches MandateValue.expires_ns (eBPF side).
+        let now_ns = nix::time::clock_gettime(nix::time::ClockId::CLOCK_BOOTTIME)
+            .map(|ts| ts.tv_sec() as u64 * 1_000_000_000 + ts.tv_nsec() as u64)
+            .unwrap_or(0);
+
+        let mut mandates = self.mandates.write().await;
+        let mut to_expire: Vec<(MandateId, MandateKey)> = Vec::new();
+
+        for (id, record) in mandates.iter() {
+            if record.status == MandateStatus::Active && now_ns >= record.value.expires_ns {
+                to_expire.push((id.clone(), record.key));
+            }
+        }
+
+        let expired_count = to_expire.len();
+
+        if expired_count > 0 {
+            // Remove from BPF map before updating userspace state.
+            {
+                let mut bpf_guard = self.bpf_mandate_map.lock().await;
+                if let Some(ref mut bpf_map) = *bpf_guard {
+                    for (id, key) in &to_expire {
+                        if let Err(e) = bpf_map.remove(&BpfMandateKey(*key)) {
+                            // Key may already have been evicted by LRU; not an error.
+                            debug!("[mandate] BPF map remove on expire (mandate={}): {}", id, e);
+                        }
+                    }
+                }
+            }
+
+            for (id, _key) in &to_expire {
+                if let Some(record) = mandates.get_mut(id) {
+                    record.status = MandateStatus::Expired;
+                }
+            }
+
+            self.total_expired
+                .fetch_add(expired_count as u64, Ordering::Relaxed);
+            self.bpf_map_count
+                .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |v| {
+                    Some(v.saturating_sub(expired_count as u64))
+                })
+                .ok();
+            debug!(
+                "[mandate] reconciliation: expired {} mandates",
+                expired_count
+            );
+        }
+
+        expired_count
+    }
+
+    /// Get current mandate statistics.
+    pub async fn stats(&self) -> MandateStats {
+        let mandates = self.mandates.read().await;
+        let active_count = mandates
+            .values()
+            .filter(|r| r.status == MandateStatus::Active)
+            .count();
+
+        MandateStats {
+            active_count,
+            total_created: self.total_created.load(Ordering::Relaxed),
+            total_expired: self.total_expired.load(Ordering::Relaxed),
+            total_revoked: self.total_revoked.load(Ordering::Relaxed),
+            total_executed: self.total_executed.load(Ordering::Relaxed),
+            bpf_map_usage: self.bpf_map_count.load(Ordering::Relaxed) as u32,
+            bpf_map_capacity: MANDATE_MAP_MAX_ENTRIES,
+            backpressure_active: self.is_backpressure_active(),
+        }
+    }
+
+    /// Get health status for the mandate subsystem.
+    pub fn health(&self) -> MandateHealth {
+        MandateHealth {
+            status: if self.bpf_available {
+                "healthy".into()
+            } else {
+                "degraded".into()
+            },
+            bpf_lsm_loaded: self.bpf_available,
+            enforcement_mode: match self.mode {
+                MandateMode::Monitor => "monitor".into(),
+                MandateMode::Enforce => "enforce".into(),
+            },
+            map_usage_percent: (self.bpf_map_count.load(Ordering::Relaxed) as f32
+                / MANDATE_MAP_MAX_ENTRIES as f32)
+                * 100.0,
+            siphash_key_set: self.siphash_key[0] != 0 || self.siphash_key[1] != 0,
+            reconciliation_interval_secs: MANDATE_RECONCILE_INTERVAL_SECS,
+        }
+    }
+
+    /// List all mandates (optionally filtered by status).
+    pub async fn list(&self, status_filter: Option<MandateStatus>) -> Vec<MandateResponse> {
+        let mandates = self.mandates.read().await;
+        let now_ms = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis() as u64;
+
+        mandates
+            .values()
+            .filter(|r| status_filter.as_ref().is_none_or(|s| &r.status == s))
+            .map(|r| MandateResponse {
+                id: r.id.clone(),
+                key: MandateKeyInfo {
+                    pid: r.key.pid,
+                    start_time_ns: r.key.start_time_ns,
+                    cmd_hash: r.key.cmd_hash,
+                },
+                expires_at_ms: now_ms,
+                status: r.status.clone(),
+                enforced: self.bpf_available && self.mode == MandateMode::Enforce,
+                enforcement_mode: self.enforcement_mode_str().to_string(),
+            })
+            .collect()
+    }
+
+    /// Spawn the background reconciliation loop.
+    pub fn spawn_reconciliation_loop(self: &Arc<Self>) {
+        let manager = Arc::clone(self);
+        tokio::spawn(async move {
+            let mut interval =
+                tokio::time::interval(Duration::from_secs(MANDATE_RECONCILE_INTERVAL_SECS));
+            loop {
+                interval.tick().await;
+                let expired = manager.reconcile().await;
+                if expired > 0 {
+                    debug!(
+                        "[mandate] reconciliation tick: expired {} mandates",
+                        expired
+                    );
+                }
+            }
+        });
+    }
+}
+
+// =============================================================================
+// SIPHASH TESTS
+// =============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_siphash_deterministic() {
+        let key = [0xdeadbeef_u64, 0xcafebabe_u64];
+        let data = b"curl https://example.com";
+        let h1 = siphash_2_4(key, data);
+        let h2 = siphash_2_4(key, data);
+        assert_eq!(h1, h2);
+    }
+
+    #[test]
+    fn test_siphash_reference_vector() {
+        // Same test vector as the eBPF-side implementation
+        let k0 = u64::from_le_bytes([0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07]);
+        let k1 = u64::from_le_bytes([0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f]);
+
+        let input: Vec<u8> = (0..15u8).collect();
+        let hash = siphash_2_4([k0, k1], &input);
+
+        assert_eq!(hash, 0xa129ca6149be45e5, "reference vector mismatch");
+    }
+
+    #[test]
+    fn test_canonicalize_args() {
+        let mgr = MandateManager::new([0xdeadbeef, 0xcafebabe], false, MandateMode::Monitor);
+
+        // Same args should produce same hash
+        let args1 = vec!["curl".to_string(), "https://example.com".to_string()];
+        let args2 = vec!["curl".to_string(), "https://example.com".to_string()];
+        assert_eq!(mgr.hash_args(&args1), mgr.hash_args(&args2));
+
+        // Different args should produce different hash
+        let args3 = vec!["wget".to_string(), "https://example.com".to_string()];
+        assert_ne!(mgr.hash_args(&args1), mgr.hash_args(&args3));
+    }
+
+    #[test]
+    fn test_backpressure() {
+        let mgr = MandateManager::new([1, 2], false, MandateMode::Monitor);
+        assert!(!mgr.is_backpressure_active());
+
+        // Simulate high map usage
+        mgr.bpf_map_count
+            .store(MANDATE_MAP_WATERMARK as u64, Ordering::Relaxed);
+        assert!(mgr.is_backpressure_active());
+    }
+
+    #[tokio::test]
+    async fn test_create_and_get_mandate() {
+        let mgr = MandateManager::new([1, 2], false, MandateMode::Monitor);
+
+        // Create a mandate for our own PID (which definitely exists)
+        let req = MandateRequest {
+            pid: std::process::id(),
+            args: vec!["test".to_string(), "command".to_string()],
+            ttl_ms: 5000,
+            container_id: None,
+            monitor_only: false,
+            task_id: None,
+            max_spend_cents: None,
+        };
+
+        let resp = mgr.create(req).await.expect("create should succeed");
+        assert_eq!(resp.status, MandateStatus::Active);
+        assert_eq!(resp.key.pid, std::process::id());
+
+        // Get it back
+        let fetched = mgr.get(&resp.id).await.expect("should find mandate");
+        assert_eq!(fetched.id, resp.id);
+    }
+
+    #[tokio::test]
+    async fn test_revoke_mandate() {
+        let mgr = MandateManager::new([1, 2], false, MandateMode::Monitor);
+
+        let req = MandateRequest {
+            pid: std::process::id(),
+            args: vec!["test".to_string()],
+            ttl_ms: 5000,
+            container_id: None,
+            monitor_only: false,
+            task_id: None,
+            max_spend_cents: None,
+        };
+
+        let resp = mgr.create(req).await.unwrap();
+        mgr.revoke(&resp.id).await.expect("revoke should succeed");
+
+        let fetched = mgr.get(&resp.id).await.unwrap();
+        assert_eq!(fetched.status, MandateStatus::Revoked);
+
+        // Double revoke should fail
+        assert!(mgr.revoke(&resp.id).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_stats() {
+        let mgr = MandateManager::new([1, 2], false, MandateMode::Monitor);
+
+        let stats = mgr.stats().await;
+        assert_eq!(stats.active_count, 0);
+        assert_eq!(stats.total_created, 0);
+
+        let req = MandateRequest {
+            pid: std::process::id(),
+            args: vec!["test".to_string()],
+            ttl_ms: 5000,
+            container_id: None,
+            monitor_only: false,
+            task_id: None,
+            max_spend_cents: None,
+        };
+
+        mgr.create(req).await.unwrap();
+        let stats = mgr.stats().await;
+        assert_eq!(stats.active_count, 1);
+        assert_eq!(stats.total_created, 1);
+    }
+}

--- a/cognitod/src/mandate.rs
+++ b/cognitod/src/mandate.rs
@@ -211,6 +211,15 @@ pub struct MandateRequest {
     /// Spend cap for this mandate in USD cents (§8.5). Tracked by cognitod.
     #[serde(default)]
     pub max_spend_cents: Option<u64>,
+    /// Counterparty DID for compliance screening (§10.3).
+    #[serde(default)]
+    pub counterparty_did: Option<String>,
+    /// Wallet address for KYT screening (§10.3).
+    #[serde(default)]
+    pub wallet_address: Option<String>,
+    /// Jurisdiction code for sanctions screening (§10.3).
+    #[serde(default)]
+    pub jurisdiction: Option<String>,
 }
 
 impl MandateRequest {
@@ -300,6 +309,8 @@ struct MandateRecord {
     args: Vec<String>,
     status: MandateStatus,
     created_at: Instant,
+    /// Wall-clock expiry time (Unix timestamp ms) for API responses.
+    expires_at_ms: u64,
     /// If the mandate has been written to the BPF map.
     bpf_committed: bool,
     /// Signed execution receipt (populated after mandate execution completes).
@@ -338,6 +349,11 @@ pub struct MandateManager {
     /// Active mandates indexed by their API-level ID.
     mandates: RwLock<HashMap<MandateId, MandateRecord>>,
 
+    /// Reverse index: mandate_seq → mandate_id.
+    /// Populated on create(), cleaned up on reconcile().
+    /// Allows the MandateReceiptHandler to look up mandates from kernel events.
+    seq_to_id: RwLock<HashMap<u64, MandateId>>,
+
     /// SipHash-2-4 key (128-bit: [k0, k1]).
     siphash_key: [u64; 2],
 
@@ -374,6 +390,7 @@ impl MandateManager {
     pub fn new(siphash_key: [u64; 2], bpf_available: bool, mode: MandateMode) -> Self {
         Self {
             mandates: RwLock::new(HashMap::new()),
+            seq_to_id: RwLock::new(HashMap::new()),
             siphash_key,
             bpf_available,
             mode,
@@ -440,6 +457,9 @@ impl MandateManager {
     /// Canonical form (per specs.md §1.1.1):
     ///   arg0 \x00 arg1 \x00 arg2 \x00 ...
     /// UTF-8 encoded, NUL-separated, no trailing NUL.
+    ///
+    /// NOTE: This hashes ALL args. For BPF map keys, use [`hash_filename`]
+    /// which matches the kernel LSM hook's hashing (filename only).
     pub fn hash_args(&self, args: &[String]) -> u64 {
         let mut hasher = SipHasher::new(self.siphash_key[0], self.siphash_key[1]);
         for (i, arg) in args.iter().enumerate() {
@@ -451,11 +471,30 @@ impl MandateManager {
         hasher.finish()
     }
 
+    /// Compute the BPF-map-compatible hash using only the first argument
+    /// (the binary filename / resolved path).
+    ///
+    /// The kernel LSM hook (`bprm_check_security`) hashes only
+    /// `linux_binprm->filename` — the resolved binary path — not the full
+    /// argv.  This method MUST produce the same hash so that mandate
+    /// lookups in the BPF map succeed.
+    pub fn hash_filename(&self, args: &[String]) -> u64 {
+        let mut hasher = SipHasher::new(self.siphash_key[0], self.siphash_key[1]);
+        if let Some(filename) = args.first() {
+            hasher.write(filename.as_bytes());
+        }
+        hasher.finish()
+    }
+
     /// Read the start_time_ns for a process from /proc/<pid>/stat.
     ///
     /// Field 22 is `starttime` in clock ticks since boot.
     /// Converted to nanoseconds via `ticks * (1e9 / CLK_TCK)`.
     fn read_start_time_ns(pid: u32) -> Result<u64> {
+        if pid == 0 {
+            return Err(anyhow!("invalid PID 0"));
+        }
+        // pid is u32 — format! produces only digits, so the path is safe.
         let stat_path = format!("/proc/{}/stat", pid);
         let stat_content = std::fs::read_to_string(&stat_path)
             .with_context(|| format!("failed to read {}", stat_path))?;
@@ -508,6 +547,11 @@ impl MandateManager {
     pub fn resolve_container_pid(container_pid: u32, container_id: &str) -> Result<u32> {
         if container_id.len() < 12 {
             return Err(anyhow!("container_id must be at least 12 hex chars"));
+        }
+        // Validate container_id contains only hex characters to prevent
+        // injection via cgroup path matching.
+        if !container_id.chars().all(|c| c.is_ascii_hexdigit()) {
+            return Err(anyhow!("container_id must contain only hex characters"));
         }
 
         let prefix = &container_id[..12];
@@ -581,7 +625,30 @@ impl MandateManager {
     /// - The PID doesn't exist
     /// - Backpressure is active (map > 80% full)
     /// - The process start time can't be read
+    /// - The args list is empty or exceeds size limits
     pub async fn create(&self, req: MandateRequest) -> Result<MandateResponse> {
+        // Validate args to prevent unbounded allocation from user input.
+        const MAX_ARGS: usize = 128;
+        const MAX_ARG_BYTES: usize = 4096;
+        if req.args.is_empty() {
+            return Err(anyhow!("args must not be empty"));
+        }
+        if req.args.len() > MAX_ARGS {
+            return Err(anyhow!(
+                "too many args ({}, max {})",
+                req.args.len(),
+                MAX_ARGS
+            ));
+        }
+        let total_bytes: usize = req.args.iter().map(|a| a.len()).sum();
+        if total_bytes > MAX_ARG_BYTES {
+            return Err(anyhow!(
+                "total args size {} bytes exceeds max {} bytes",
+                total_bytes,
+                MAX_ARG_BYTES
+            ));
+        }
+
         // Check backpressure
         if self.is_backpressure_active() {
             return Err(anyhow!(
@@ -608,8 +675,9 @@ impl MandateManager {
         let start_time_ns = Self::read_start_time_ns(effective_pid)
             .with_context(|| format!("PID {} does not exist or is not readable", effective_pid))?;
 
-        // Hash the command args
-        let cmd_hash = self.hash_args(&req.args);
+        // Hash only the filename (first arg) for the BPF map key.
+        // This matches the kernel LSM hook which hashes binprm->filename only.
+        let cmd_hash = self.hash_filename(&req.args);
 
         // Build the key
         let key = MandateKey {
@@ -658,6 +726,7 @@ impl MandateManager {
             args: req.args,
             status: MandateStatus::Active,
             created_at: Instant::now(),
+            expires_at_ms,
             bpf_committed: self.bpf_available, // mark as committed if BPF is available
             receipt: None,
         };
@@ -678,6 +747,12 @@ impl MandateManager {
         {
             let mut mandates = self.mandates.write().await;
             mandates.insert(id.clone(), record);
+        }
+
+        // Populate reverse index for kernel event → mandate ID lookups.
+        {
+            let mut seq_map = self.seq_to_id.write().await;
+            seq_map.insert(seq, id.clone());
         }
 
         // Write to BPF MANDATE_MAP so the LSM hook can enforce this mandate.
@@ -706,11 +781,6 @@ impl MandateManager {
         let mandates = self.mandates.read().await;
         let record = mandates.get(id)?;
 
-        let expires_at_ms = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_millis() as u64;
-
         Some(MandateResponse {
             id: record.id.clone(),
             key: MandateKeyInfo {
@@ -718,7 +788,7 @@ impl MandateManager {
                 start_time_ns: record.key.start_time_ns,
                 cmd_hash: record.key.cmd_hash,
             },
-            expires_at_ms,
+            expires_at_ms: record.expires_at_ms,
             status: record.status.clone(),
             enforced: self.bpf_available && self.mode == MandateMode::Enforce,
             enforcement_mode: self.enforcement_mode_str().to_string(),
@@ -874,6 +944,27 @@ impl MandateManager {
         mandates.get(id).map(|r| r.status.clone())
     }
 
+    /// Look up a mandate ID by its kernel sequence number.
+    ///
+    /// Used by MandateReceiptHandler to resolve kernel MandateAllow events
+    /// (which carry mandate_seq) back to the API-level mandate ID.
+    pub async fn find_id_by_seq(&self, seq: u64) -> Option<MandateId> {
+        let seq_map = self.seq_to_id.read().await;
+        seq_map.get(&seq).cloned()
+    }
+
+    /// Get the execution data needed to build a receipt for a mandate.
+    ///
+    /// Returns `(args, mandate_seq)` if the mandate exists and is active.
+    pub async fn get_execution_data(&self, id: &str) -> Option<(Vec<String>, u64)> {
+        let mandates = self.mandates.read().await;
+        let record = mandates.get(id)?;
+        if record.status != MandateStatus::Active {
+            return None;
+        }
+        Some((record.args.clone(), record.value.mandate_seq))
+    }
+
     /// Run the reconciliation loop — scans all mandates and evicts expired ones.
     /// Called every MANDATE_RECONCILE_INTERVAL_SECS by a background task.
     pub async fn reconcile(&self) -> usize {
@@ -883,11 +974,11 @@ impl MandateManager {
             .unwrap_or(0);
 
         let mut mandates = self.mandates.write().await;
-        let mut to_expire: Vec<(MandateId, MandateKey)> = Vec::new();
+        let mut to_expire: Vec<(MandateId, MandateKey, u64)> = Vec::new();
 
         for (id, record) in mandates.iter() {
             if record.status == MandateStatus::Active && now_ns >= record.value.expires_ns {
-                to_expire.push((id.clone(), record.key));
+                to_expire.push((id.clone(), record.key, record.value.mandate_seq));
             }
         }
 
@@ -898,7 +989,7 @@ impl MandateManager {
             {
                 let mut bpf_guard = self.bpf_mandate_map.lock().await;
                 if let Some(ref mut bpf_map) = *bpf_guard {
-                    for (id, key) in &to_expire {
+                    for (id, key, _seq) in &to_expire {
                         if let Err(e) = bpf_map.remove(&BpfMandateKey(*key)) {
                             // Key may already have been evicted by LRU; not an error.
                             debug!("[mandate] BPF map remove on expire (mandate={}): {}", id, e);
@@ -907,7 +998,15 @@ impl MandateManager {
                 }
             }
 
-            for (id, _key) in &to_expire {
+            // Clean up seq_to_id reverse index for expired mandates.
+            {
+                let mut seq_map = self.seq_to_id.write().await;
+                for (_id, _key, seq) in &to_expire {
+                    seq_map.remove(seq);
+                }
+            }
+
+            for (id, _key, _seq) in &to_expire {
                 if let Some(record) = mandates.get_mut(id) {
                     record.status = MandateStatus::Expired;
                 }
@@ -973,10 +1072,6 @@ impl MandateManager {
     /// List all mandates (optionally filtered by status).
     pub async fn list(&self, status_filter: Option<MandateStatus>) -> Vec<MandateResponse> {
         let mandates = self.mandates.read().await;
-        let now_ms = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_millis() as u64;
 
         mandates
             .values()
@@ -988,7 +1083,7 @@ impl MandateManager {
                     start_time_ns: r.key.start_time_ns,
                     cmd_hash: r.key.cmd_hash,
                 },
-                expires_at_ms: now_ms,
+                expires_at_ms: r.expires_at_ms,
                 status: r.status.clone(),
                 enforced: self.bpf_available && self.mode == MandateMode::Enforce,
                 enforcement_mode: self.enforcement_mode_str().to_string(),
@@ -1060,6 +1155,101 @@ mod tests {
     }
 
     #[test]
+    fn test_hash_filename_matches_first_arg_only() {
+        let mgr = MandateManager::new([0xdeadbeef, 0xcafebabe], false, MandateMode::Monitor);
+
+        // hash_filename should only use the first arg
+        let args_full = vec![
+            "/usr/bin/curl".to_string(),
+            "https://example.com".to_string(),
+        ];
+        let args_cmd_only = vec!["/usr/bin/curl".to_string()];
+        assert_eq!(
+            mgr.hash_filename(&args_full),
+            mgr.hash_filename(&args_cmd_only),
+            "hash_filename should ignore args beyond the first"
+        );
+
+        // hash_filename should differ from hash_args for multi-arg inputs
+        assert_ne!(
+            mgr.hash_filename(&args_full),
+            mgr.hash_args(&args_full),
+            "hash_filename and hash_args should differ for multi-arg inputs"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_get_returns_stored_expiry() {
+        let mgr = MandateManager::new([1, 2], false, MandateMode::Monitor);
+        let ttl_ms = 60_000u64;
+
+        let req = MandateRequest {
+            pid: std::process::id(),
+            args: vec!["test".to_string()],
+            ttl_ms,
+            container_id: None,
+            monitor_only: false,
+            task_id: None,
+            max_spend_cents: None,
+            counterparty_did: None,
+            wallet_address: None,
+            jurisdiction: None,
+        };
+
+        let resp = mgr.create(req).await.unwrap();
+        let fetched = mgr.get(&resp.id).await.unwrap();
+
+        // expires_at_ms from get() should match create() response
+        assert_eq!(fetched.expires_at_ms, resp.expires_at_ms);
+        // And should be in the future (not just current time)
+        let now_ms = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_millis() as u64;
+        assert!(
+            fetched.expires_at_ms > now_ms,
+            "expires_at_ms should be in the future"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_create_rejects_empty_args() {
+        let mgr = MandateManager::new([1, 2], false, MandateMode::Monitor);
+        let req = MandateRequest {
+            pid: std::process::id(),
+            args: vec![],
+            ttl_ms: 5000,
+            container_id: None,
+            monitor_only: false,
+            task_id: None,
+            max_spend_cents: None,
+            counterparty_did: None,
+            wallet_address: None,
+            jurisdiction: None,
+        };
+        assert!(mgr.create(req).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_create_rejects_too_many_args() {
+        let mgr = MandateManager::new([1, 2], false, MandateMode::Monitor);
+        let args: Vec<String> = (0..200).map(|i| format!("arg{}", i)).collect();
+        let req = MandateRequest {
+            pid: std::process::id(),
+            args,
+            ttl_ms: 5000,
+            container_id: None,
+            monitor_only: false,
+            task_id: None,
+            max_spend_cents: None,
+            counterparty_did: None,
+            wallet_address: None,
+            jurisdiction: None,
+        };
+        assert!(mgr.create(req).await.is_err());
+    }
+
+    #[test]
     fn test_backpressure() {
         let mgr = MandateManager::new([1, 2], false, MandateMode::Monitor);
         assert!(!mgr.is_backpressure_active());
@@ -1083,6 +1273,9 @@ mod tests {
             monitor_only: false,
             task_id: None,
             max_spend_cents: None,
+            counterparty_did: None,
+            wallet_address: None,
+            jurisdiction: None,
         };
 
         let resp = mgr.create(req).await.expect("create should succeed");
@@ -1106,6 +1299,9 @@ mod tests {
             monitor_only: false,
             task_id: None,
             max_spend_cents: None,
+            counterparty_did: None,
+            wallet_address: None,
+            jurisdiction: None,
         };
 
         let resp = mgr.create(req).await.unwrap();
@@ -1134,6 +1330,9 @@ mod tests {
             monitor_only: false,
             task_id: None,
             max_spend_cents: None,
+            counterparty_did: None,
+            wallet_address: None,
+            jurisdiction: None,
         };
 
         mgr.create(req).await.unwrap();

--- a/cognitod/src/payment.rs
+++ b/cognitod/src/payment.rs
@@ -1,0 +1,379 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// cognitod/src/payment.rs — Linnix-Claw fiat gateway adapter (§8)
+//
+// Defines the `PaymentAdapter` trait for fiat ↔ stablecoin operations
+// and provides a Stripe stub implementation. The adapter handles:
+// - Converting cents (API/Config units) to token base units (contract units)
+// - Off-chain settlement via webhooks (§8.3)
+// - Invoice/billing artifact generation (§8.4)
+//
+// All amounts in cognitod are USD cents (integer). Convert on the boundary.
+
+use anyhow::Result;
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+
+// =============================================================================
+// AMOUNT CONVERSION (§8.5)
+// =============================================================================
+
+/// Token metadata for cent ↔ base-unit conversion.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TokenInfo {
+    /// Human-readable name (e.g., "USD Coin").
+    pub name: String,
+    /// Symbol (e.g., "USDC").
+    pub symbol: String,
+    /// Number of decimal places (6 for USDC, 18 for DAI).
+    pub decimals: u8,
+    /// Contract address (hex, EIP-55 checksummed).
+    pub address: String,
+    /// Chain ID (e.g., 8453 for Base).
+    pub chain_id: u64,
+}
+
+impl TokenInfo {
+    /// Convert USD cents to token base units.
+    ///
+    /// Formula: `base_units = cents × 10^(decimals - 2)`
+    ///
+    /// # Examples
+    /// - USDC (6 dec): 15 cents → 150_000 base units
+    /// - DAI (18 dec): 15 cents → 150_000_000_000_000_000 base units
+    pub fn cents_to_base_units(&self, cents: u64) -> u128 {
+        if self.decimals < 2 {
+            // Tokens with < 2 decimals: integer math rounds down
+            cents as u128 / 10u128.pow(2 - self.decimals as u32)
+        } else {
+            cents as u128 * 10u128.pow(self.decimals as u32 - 2)
+        }
+    }
+
+    /// Convert token base units to USD cents.
+    ///
+    /// Formula: `cents = base_units / 10^(decimals - 2)`
+    pub fn base_units_to_cents(&self, base_units: u128) -> u64 {
+        if self.decimals < 2 {
+            (base_units * 10u128.pow(2 - self.decimals as u32)) as u64
+        } else {
+            (base_units / 10u128.pow(self.decimals as u32 - 2)) as u64
+        }
+    }
+
+    /// Well-known USDC on Base (chain 8453).
+    pub fn usdc_base() -> Self {
+        Self {
+            name: "USD Coin".to_string(),
+            symbol: "USDC".to_string(),
+            decimals: 6,
+            address: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913".to_string(),
+            chain_id: 8453,
+        }
+    }
+
+    /// Well-known USDC on Base Sepolia (testnet).
+    pub fn usdc_base_sepolia() -> Self {
+        Self {
+            name: "USD Coin".to_string(),
+            symbol: "USDC".to_string(),
+            decimals: 6,
+            address: "0x036CbD53842c5426634e7929541eC2318f3dCF7e".to_string(),
+            chain_id: 84532,
+        }
+    }
+
+    /// Well-known DAI on Ethereum mainnet.
+    pub fn dai_mainnet() -> Self {
+        Self {
+            name: "Dai Stablecoin".to_string(),
+            symbol: "DAI".to_string(),
+            decimals: 18,
+            address: "0x6B175474E89094C44Da98b954EedeAC495271d0F".to_string(),
+            chain_id: 1,
+        }
+    }
+}
+
+// =============================================================================
+// PAYMENT ADAPTER TRAIT (§8.1–§8.3)
+// =============================================================================
+
+/// The settlement path chosen for a given task.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum SettlementPath {
+    /// On-chain ERC-20 transfer via TaskSettlement contract.
+    OnChain { chain_id: u64, token: String },
+    /// Off-chain webhook (Stripe, SAP, etc.).
+    Webhook { endpoint: String },
+    /// Manual / out-of-band settlement.
+    Manual,
+}
+
+/// Result of a payment operation.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PaymentResult {
+    /// Whether the payment was successful.
+    pub success: bool,
+    /// Transaction reference (tx hash, invoice ID, etc.).
+    pub reference: Option<String>,
+    /// Human-readable status message.
+    pub message: String,
+    /// Amount in USD cents that was settled.
+    pub settled_cents: u64,
+}
+
+/// Trait for fiat / stablecoin settlement adapters.
+///
+/// Implementations handle the boundary between cognitod's cents-based
+/// accounting and external payment rails. The trait is object-safe
+/// for dynamic dispatch.
+#[async_trait]
+pub trait PaymentAdapter: Send + Sync {
+    /// Human-readable name of the adapter (e.g., "stripe", "on-chain-base").
+    fn name(&self) -> &str;
+
+    /// Determine the settlement path for a counterparty.
+    ///
+    /// Inspects the counterparty's agent card to decide: on-chain, webhook, or manual.
+    async fn resolve_settlement_path(&self, counterparty_did: &str) -> Result<SettlementPath>;
+
+    /// Submit a receipt for settlement.
+    ///
+    /// The adapter converts `amount_cents` to the appropriate units and
+    /// submits to the chosen payment rail.
+    async fn settle(
+        &self,
+        receipt_json: &str,
+        amount_cents: u64,
+        path: &SettlementPath,
+    ) -> Result<PaymentResult>;
+
+    /// Check the status of a previously submitted settlement.
+    async fn check_status(&self, reference: &str) -> Result<PaymentResult>;
+}
+
+// =============================================================================
+// STRIPE STUB ADAPTER
+// =============================================================================
+
+/// Stub adapter for off-chain Stripe settlement.
+///
+/// In production, this would call the Stripe API to create payment intents
+/// or invoices. For Phase 4 (MVP), it validates the flow without real API calls.
+pub struct StripeStubAdapter {
+    /// Stripe API key (from env or config). Empty in stub mode.
+    #[allow(dead_code)]
+    api_key: String,
+    /// Whether to actually call Stripe (false = stub).
+    live: bool,
+}
+
+impl StripeStubAdapter {
+    /// Create a new stub adapter (no real API calls).
+    pub fn new_stub() -> Self {
+        Self {
+            api_key: String::new(),
+            live: false,
+        }
+    }
+
+    /// Create a live adapter with a Stripe API key.
+    #[allow(dead_code)]
+    pub fn new_live(api_key: String) -> Self {
+        Self {
+            api_key,
+            live: true,
+        }
+    }
+}
+
+#[async_trait]
+impl PaymentAdapter for StripeStubAdapter {
+    fn name(&self) -> &str {
+        if self.live {
+            "stripe-live"
+        } else {
+            "stripe-stub"
+        }
+    }
+
+    async fn resolve_settlement_path(&self, _counterparty_did: &str) -> Result<SettlementPath> {
+        // Stub: always returns webhook path
+        Ok(SettlementPath::Webhook {
+            endpoint: "https://api.stripe.com/v1/payment_intents".to_string(),
+        })
+    }
+
+    async fn settle(
+        &self,
+        _receipt_json: &str,
+        amount_cents: u64,
+        path: &SettlementPath,
+    ) -> Result<PaymentResult> {
+        if !self.live {
+            log::info!(
+                "stripe-stub: would settle ${:.2} via {:?}",
+                amount_cents as f64 / 100.0,
+                path
+            );
+            return Ok(PaymentResult {
+                success: true,
+                reference: Some(format!("stub_pi_{}", uuid::Uuid::new_v4())),
+                message: "stub settlement recorded".to_string(),
+                settled_cents: amount_cents,
+            });
+        }
+
+        // Live mode would call Stripe here.
+        // For now, return an error indicating live mode is not yet implemented.
+        anyhow::bail!("Stripe live mode not yet implemented")
+    }
+
+    async fn check_status(&self, reference: &str) -> Result<PaymentResult> {
+        if !self.live {
+            return Ok(PaymentResult {
+                success: true,
+                reference: Some(reference.to_string()),
+                message: "stub: payment confirmed".to_string(),
+                settled_cents: 0,
+            });
+        }
+        anyhow::bail!("Stripe live mode not yet implemented")
+    }
+}
+
+// =============================================================================
+// NO-OP ADAPTER (for testing / offline mode)
+// =============================================================================
+
+/// No-op adapter that always succeeds. Used in offline/test mode.
+pub struct NoopAdapter;
+
+#[async_trait]
+impl PaymentAdapter for NoopAdapter {
+    fn name(&self) -> &str {
+        "noop"
+    }
+
+    async fn resolve_settlement_path(&self, _counterparty_did: &str) -> Result<SettlementPath> {
+        Ok(SettlementPath::Manual)
+    }
+
+    async fn settle(
+        &self,
+        _receipt_json: &str,
+        amount_cents: u64,
+        _path: &SettlementPath,
+    ) -> Result<PaymentResult> {
+        Ok(PaymentResult {
+            success: true,
+            reference: None,
+            message: "noop: no settlement performed".to_string(),
+            settled_cents: amount_cents,
+        })
+    }
+
+    async fn check_status(&self, _reference: &str) -> Result<PaymentResult> {
+        Ok(PaymentResult {
+            success: true,
+            reference: None,
+            message: "noop".to_string(),
+            settled_cents: 0,
+        })
+    }
+}
+
+// =============================================================================
+// TESTS
+// =============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── Amount conversion tests ──
+
+    #[test]
+    fn usdc_cents_to_base_units() {
+        let usdc = TokenInfo::usdc_base();
+        assert_eq!(usdc.cents_to_base_units(1), 10_000); // 1 cent = 10,000
+        assert_eq!(usdc.cents_to_base_units(15), 150_000); // $0.15
+        assert_eq!(usdc.cents_to_base_units(100), 1_000_000); // $1.00
+        assert_eq!(usdc.cents_to_base_units(5000), 50_000_000); // $50.00
+    }
+
+    #[test]
+    fn dai_cents_to_base_units() {
+        let dai = TokenInfo::dai_mainnet();
+        assert_eq!(dai.cents_to_base_units(1), 10_000_000_000_000_000);
+        assert_eq!(dai.cents_to_base_units(100), 1_000_000_000_000_000_000); // 1 DAI
+    }
+
+    #[test]
+    fn usdc_base_units_to_cents() {
+        let usdc = TokenInfo::usdc_base();
+        assert_eq!(usdc.base_units_to_cents(10_000), 1);
+        assert_eq!(usdc.base_units_to_cents(150_000), 15);
+        assert_eq!(usdc.base_units_to_cents(1_000_000), 100);
+    }
+
+    #[test]
+    fn round_trip_conversion() {
+        let usdc = TokenInfo::usdc_base();
+        for cents in [0, 1, 15, 100, 999, 5000, 100_000] {
+            let base = usdc.cents_to_base_units(cents);
+            let back = usdc.base_units_to_cents(base);
+            assert_eq!(back, cents, "round-trip failed for {} cents", cents);
+        }
+    }
+
+    #[test]
+    fn zero_conversion() {
+        let usdc = TokenInfo::usdc_base();
+        assert_eq!(usdc.cents_to_base_units(0), 0);
+        assert_eq!(usdc.base_units_to_cents(0), 0);
+    }
+
+    // ── Stripe stub tests ──
+
+    #[tokio::test]
+    async fn stripe_stub_settle() {
+        let adapter = StripeStubAdapter::new_stub();
+        assert_eq!(adapter.name(), "stripe-stub");
+
+        let path = adapter
+            .resolve_settlement_path("did:web:example.com")
+            .await
+            .unwrap();
+        assert!(matches!(path, SettlementPath::Webhook { .. }));
+
+        let result = adapter.settle("{}", 1500, &path).await.unwrap();
+        assert!(result.success);
+        assert_eq!(result.settled_cents, 1500);
+        assert!(result.reference.unwrap().starts_with("stub_pi_"));
+    }
+
+    #[tokio::test]
+    async fn noop_adapter_settle() {
+        let adapter = NoopAdapter;
+        assert_eq!(adapter.name(), "noop");
+
+        let path = adapter
+            .resolve_settlement_path("did:web:example.com")
+            .await
+            .unwrap();
+        assert_eq!(path, SettlementPath::Manual);
+
+        let result = adapter.settle("{}", 500, &path).await.unwrap();
+        assert!(result.success);
+        assert_eq!(result.settled_cents, 500);
+    }
+
+    #[tokio::test]
+    async fn stripe_stub_check_status() {
+        let adapter = StripeStubAdapter::new_stub();
+        let result = adapter.check_status("stub_pi_12345").await.unwrap();
+        assert!(result.success);
+    }
+}

--- a/cognitod/src/privacy.rs
+++ b/cognitod/src/privacy.rs
@@ -17,21 +17,16 @@ use std::path::Path;
 // =============================================================================
 
 /// Receipt redaction level (§10.4).
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum RedactionLevel {
     /// Full binary path exposed. For internal/dev environments.
     None,
     /// Basename only (e.g., `/usr/bin/curl` → `curl`). Default.
+    #[default]
     External,
     /// Generic category label (e.g., `tool_execution`). Maximum privacy.
     Full,
-}
-
-impl Default for RedactionLevel {
-    fn default() -> Self {
-        Self::External
-    }
 }
 
 impl std::fmt::Display for RedactionLevel {

--- a/cognitod/src/privacy.rs
+++ b/cognitod/src/privacy.rs
@@ -1,0 +1,334 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// cognitod/src/privacy.rs — Linnix-Claw receipt privacy & redaction (§10.4)
+//
+// Three redaction levels for receipts before sending to counterparties:
+//   - `none`     — full binary path, hash only for args (dev/internal)
+//   - `external` — basename only (e.g., "curl"), hash only for args (default)
+//   - `full`     — category label (e.g., "tool_execution"), hash only for args
+//
+// See docs/linnix-claw/specs.md §10.4.
+
+use serde::{Deserialize, Serialize};
+use std::path::Path;
+
+// =============================================================================
+// REDACTION LEVEL
+// =============================================================================
+
+/// Receipt redaction level (§10.4).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum RedactionLevel {
+    /// Full binary path exposed. For internal/dev environments.
+    None,
+    /// Basename only (e.g., `/usr/bin/curl` → `curl`). Default.
+    External,
+    /// Generic category label (e.g., `tool_execution`). Maximum privacy.
+    Full,
+}
+
+impl Default for RedactionLevel {
+    fn default() -> Self {
+        Self::External
+    }
+}
+
+impl std::fmt::Display for RedactionLevel {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::None => write!(f, "none"),
+            Self::External => write!(f, "external"),
+            Self::Full => write!(f, "full"),
+        }
+    }
+}
+
+impl std::str::FromStr for RedactionLevel {
+    type Err = String;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "none" => Ok(Self::None),
+            "external" => Ok(Self::External),
+            "full" => Ok(Self::Full),
+            other => Err(format!(
+                "invalid redaction level '{}': expected none, external, or full",
+                other
+            )),
+        }
+    }
+}
+
+// =============================================================================
+// BINARY CLASSIFICATION (for "full" redaction)
+// =============================================================================
+
+/// Classify a binary path into a generic category.
+///
+/// Used when `redaction_level = "full"` to replace the binary field
+/// with a non-revealing label.
+fn classify_binary(binary_path: &str) -> &'static str {
+    let basename = Path::new(binary_path)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or(binary_path);
+
+    match basename {
+        // Network tools
+        "curl" | "wget" | "fetch" | "httpie" | "aria2c" => "network_transfer",
+        // Data processing
+        "jq" | "yq" | "csvtool" | "awk" | "sed" | "grep" | "sort" | "uniq" | "cut" | "tr" => {
+            "data_processing"
+        }
+        // Shells
+        "bash" | "sh" | "zsh" | "fish" | "dash" => "shell_execution",
+        // Python / interpreters
+        "python" | "python3" | "python3.11" | "python3.12" | "node" | "ruby" | "perl" => {
+            "interpreter_execution"
+        }
+        // Compilers / build tools
+        "gcc" | "g++" | "clang" | "rustc" | "cargo" | "make" | "cmake" | "ninja" => "build_tool",
+        // Container / orchestration
+        "docker" | "podman" | "kubectl" | "helm" | "crictl" => "container_tool",
+        // Package managers
+        "apt" | "apt-get" | "yum" | "dnf" | "pip" | "pip3" | "npm" | "yarn" | "pnpm" => {
+            "package_manager"
+        }
+        // File operations
+        "cp" | "mv" | "rm" | "mkdir" | "chmod" | "chown" | "tar" | "zip" | "unzip" | "gzip" => {
+            "file_operation"
+        }
+        // System inspection
+        "ps" | "top" | "htop" | "lsof" | "strace" | "ltrace" | "perf" | "vmstat" | "iostat" => {
+            "system_inspection"
+        }
+        // Default
+        _ => "tool_execution",
+    }
+}
+
+// =============================================================================
+// RECEIPT REDACTOR
+// =============================================================================
+
+/// Redacts receipt fields based on the configured level.
+pub struct ReceiptRedactor {
+    level: RedactionLevel,
+}
+
+impl ReceiptRedactor {
+    pub fn new(level: RedactionLevel) -> Self {
+        Self { level }
+    }
+
+    /// Redact a binary path according to the configured level.
+    ///
+    /// - `none` → `/usr/bin/curl` (unchanged)
+    /// - `external` → `curl` (basename only)
+    /// - `full` → `network_transfer` (category)
+    pub fn redact_binary(&self, binary_path: &str) -> String {
+        match self.level {
+            RedactionLevel::None => binary_path.to_string(),
+            RedactionLevel::External => Path::new(binary_path)
+                .file_name()
+                .and_then(|n| n.to_str())
+                .unwrap_or(binary_path)
+                .to_string(),
+            RedactionLevel::Full => classify_binary(binary_path).to_string(),
+        }
+    }
+
+    /// Determine if args should be included as-is or hash-only.
+    /// Args are ALWAYS hash-only at all levels per §10.4.
+    pub fn should_redact_args(&self) -> bool {
+        true // Always true — args are always hash-only
+    }
+
+    /// Redact an optional task context / URL field.
+    ///
+    /// - `none` → unchanged
+    /// - `external` → domain only (strip path/query)
+    /// - `full` → "[redacted]"
+    pub fn redact_url(&self, url: &str) -> String {
+        match self.level {
+            RedactionLevel::None => url.to_string(),
+            RedactionLevel::External => {
+                // Extract domain: "https://api.example.com/v1/data?key=secret"
+                //                → "api.example.com"
+                if let Some(start) = url.find("://") {
+                    let after_scheme = &url[start + 3..];
+                    let end = after_scheme.find('/').unwrap_or(after_scheme.len());
+                    after_scheme[..end].to_string()
+                } else {
+                    url.split('/').next().unwrap_or(url).to_string()
+                }
+            }
+            RedactionLevel::Full => "[redacted]".to_string(),
+        }
+    }
+
+    /// Get current redaction level.
+    pub fn level(&self) -> RedactionLevel {
+        self.level
+    }
+}
+
+// =============================================================================
+// TESTS
+// =============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── RedactionLevel parsing ──
+
+    #[test]
+    fn parse_redaction_levels() {
+        assert_eq!(
+            "none".parse::<RedactionLevel>().unwrap(),
+            RedactionLevel::None
+        );
+        assert_eq!(
+            "external".parse::<RedactionLevel>().unwrap(),
+            RedactionLevel::External
+        );
+        assert_eq!(
+            "full".parse::<RedactionLevel>().unwrap(),
+            RedactionLevel::Full
+        );
+        assert_eq!(
+            "EXTERNAL".parse::<RedactionLevel>().unwrap(),
+            RedactionLevel::External
+        );
+        assert!("invalid".parse::<RedactionLevel>().is_err());
+    }
+
+    #[test]
+    fn display_redaction_level() {
+        assert_eq!(RedactionLevel::None.to_string(), "none");
+        assert_eq!(RedactionLevel::External.to_string(), "external");
+        assert_eq!(RedactionLevel::Full.to_string(), "full");
+    }
+
+    #[test]
+    fn default_redaction_level() {
+        assert_eq!(RedactionLevel::default(), RedactionLevel::External);
+    }
+
+    // ── Binary redaction ──
+
+    #[test]
+    fn redact_binary_none() {
+        let r = ReceiptRedactor::new(RedactionLevel::None);
+        assert_eq!(r.redact_binary("/usr/bin/curl"), "/usr/bin/curl");
+        assert_eq!(
+            r.redact_binary("/usr/local/bin/python3"),
+            "/usr/local/bin/python3"
+        );
+    }
+
+    #[test]
+    fn redact_binary_external() {
+        let r = ReceiptRedactor::new(RedactionLevel::External);
+        assert_eq!(r.redact_binary("/usr/bin/curl"), "curl");
+        assert_eq!(r.redact_binary("/usr/local/bin/python3"), "python3");
+        assert_eq!(r.redact_binary("docker"), "docker"); // already basename
+    }
+
+    #[test]
+    fn redact_binary_full() {
+        let r = ReceiptRedactor::new(RedactionLevel::Full);
+        assert_eq!(r.redact_binary("/usr/bin/curl"), "network_transfer");
+        assert_eq!(r.redact_binary("/usr/bin/jq"), "data_processing");
+        assert_eq!(r.redact_binary("/usr/bin/bash"), "shell_execution");
+        assert_eq!(r.redact_binary("/usr/bin/python3"), "interpreter_execution");
+        assert_eq!(r.redact_binary("/usr/bin/gcc"), "build_tool");
+        assert_eq!(r.redact_binary("/usr/bin/docker"), "container_tool");
+        assert_eq!(r.redact_binary("/usr/bin/npm"), "package_manager");
+        assert_eq!(r.redact_binary("/usr/bin/cp"), "file_operation");
+        assert_eq!(r.redact_binary("/usr/bin/lsof"), "system_inspection");
+        assert_eq!(r.redact_binary("/opt/custom/my-tool"), "tool_execution");
+    }
+
+    // ── URL redaction ──
+
+    #[test]
+    fn redact_url_none() {
+        let r = ReceiptRedactor::new(RedactionLevel::None);
+        assert_eq!(
+            r.redact_url("https://api.example.com/v1/data?key=secret"),
+            "https://api.example.com/v1/data?key=secret"
+        );
+    }
+
+    #[test]
+    fn redact_url_external() {
+        let r = ReceiptRedactor::new(RedactionLevel::External);
+        assert_eq!(
+            r.redact_url("https://api.example.com/v1/data?key=secret"),
+            "api.example.com"
+        );
+        assert_eq!(
+            r.redact_url("http://internal:8080/metrics"),
+            "internal:8080"
+        );
+    }
+
+    #[test]
+    fn redact_url_full() {
+        let r = ReceiptRedactor::new(RedactionLevel::Full);
+        assert_eq!(
+            r.redact_url("https://api.example.com/v1/data"),
+            "[redacted]"
+        );
+    }
+
+    // ── Args always redacted ──
+
+    #[test]
+    fn args_always_hash_only() {
+        for level in [
+            RedactionLevel::None,
+            RedactionLevel::External,
+            RedactionLevel::Full,
+        ] {
+            let r = ReceiptRedactor::new(level);
+            assert!(
+                r.should_redact_args(),
+                "args must be hash-only at {:?}",
+                level
+            );
+        }
+    }
+
+    // ── Binary classification ──
+
+    #[test]
+    fn classify_known_binaries() {
+        assert_eq!(classify_binary("/usr/bin/curl"), "network_transfer");
+        assert_eq!(classify_binary("wget"), "network_transfer");
+        assert_eq!(classify_binary("awk"), "data_processing");
+        assert_eq!(classify_binary("bash"), "shell_execution");
+        assert_eq!(classify_binary("node"), "interpreter_execution");
+        assert_eq!(classify_binary("cargo"), "build_tool");
+        assert_eq!(classify_binary("kubectl"), "container_tool");
+        assert_eq!(classify_binary("pip3"), "package_manager");
+        assert_eq!(classify_binary("tar"), "file_operation");
+        assert_eq!(classify_binary("vmstat"), "system_inspection");
+    }
+
+    #[test]
+    fn classify_unknown_binary() {
+        assert_eq!(classify_binary("my-custom-agent"), "tool_execution");
+        assert_eq!(classify_binary("/opt/unknown"), "tool_execution");
+    }
+
+    // ── Retention config test ──
+
+    #[test]
+    fn redactor_reports_level() {
+        let r = ReceiptRedactor::new(RedactionLevel::Full);
+        assert_eq!(r.level(), RedactionLevel::Full);
+    }
+}

--- a/cognitod/src/receipt.rs
+++ b/cognitod/src/receipt.rs
@@ -1,0 +1,802 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// cognitod/src/receipt.rs — Linnix-Claw execution receipt builder (§5.1, §5.2)
+//
+// Constructs and signs receipts proving mandated command execution.
+// Dual signatures: Ed25519 (off-chain) + secp256k1/EIP-712 (on-chain).
+
+use anyhow::{Context, Result};
+use base64::{Engine, engine::general_purpose::STANDARD as BASE64};
+use serde::{Deserialize, Serialize};
+use tiny_keccak::{Hasher, Keccak};
+
+use crate::identity::AgentIdentity;
+
+// =============================================================================
+// RECEIPT STRUCTURE (§5.1)
+// =============================================================================
+
+/// A signed execution receipt proving a mandated command ran.
+///
+/// This is the complete receipt returned by `GET /mandates/{id}/receipt`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExecutionReceipt {
+    /// Receipt format version.
+    pub version: String,
+
+    /// Mandate identifier (matches the API mandate ID).
+    pub mandate_id: String,
+
+    /// Optional task identifier for billing correlation.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub task_id: Option<String>,
+
+    /// Agent DID that produced this receipt.
+    pub agent_did: String,
+
+    /// Execution details.
+    pub execution: ExecutionDetails,
+
+    /// Kernel attestation metadata.
+    pub attestation: AttestationDetails,
+
+    /// EIP-712 domain separator fields.
+    pub domain: DomainSeparator,
+
+    /// Ed25519 signature (off-chain verification).
+    /// Format: "ed25519:<base64-encoded-64-byte-signature>"
+    pub signature: String,
+
+    /// secp256k1 recoverable signature (on-chain verification).
+    /// Format: "0x<65-byte-hex>" (r[32] || s[32] || v[1])
+    pub secp256k1_signature: String,
+}
+
+/// Details about the executed process.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExecutionDetails {
+    /// Process ID that was authorized.
+    pub pid: u32,
+
+    /// Parent process ID.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ppid: Option<u32>,
+
+    /// Binary path that was executed.
+    pub binary: String,
+
+    /// SipHash-2-4 of the canonicalized arguments.
+    pub args_hash: String,
+
+    /// Process exit code (0 = success).
+    pub exit_code: i32,
+
+    /// Execution start timestamp (nanoseconds since epoch).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub started_at_ns: Option<u64>,
+
+    /// Execution finish timestamp (nanoseconds since epoch).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub finished_at_ns: Option<u64>,
+
+    /// Execution duration in milliseconds.
+    pub duration_ms: u64,
+
+    /// CPU usage percentage during execution.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cpu_pct: Option<f32>,
+
+    /// Memory usage percentage during execution.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mem_pct: Option<f32>,
+}
+
+/// Kernel-level attestation proving the execution was LSM-gated.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AttestationDetails {
+    /// Kernel sequence number from the SequencedSlot ring.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub kernel_seq: Option<u64>,
+
+    /// Kernel boot ID (from /proc/sys/kernel/random/boot_id).
+    pub kernel_boot_id: String,
+
+    /// Size of the sequencer ring (slots).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sequencer_ring_size: Option<u64>,
+
+    /// Which LSM hook authorized this execution.
+    pub lsm_hook: String,
+
+    /// Enforcement mode when the mandate was checked.
+    pub enforcement_mode: String,
+}
+
+/// EIP-712 domain separator for anti-replay protection.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DomainSeparator {
+    pub name: String,
+    pub version: String,
+    pub chain_id: u64,
+    pub verifying_contract: String,
+    pub salt: String,
+}
+
+impl Default for DomainSeparator {
+    fn default() -> Self {
+        Self {
+            name: "Linnix-Claw".to_string(),
+            version: "0.1.0".to_string(),
+            chain_id: 8453, // Base mainnet
+            verifying_contract: "0x0000000000000000000000000000000000000000".to_string(),
+            salt: read_boot_id().unwrap_or_else(|| "unknown".to_string()),
+        }
+    }
+}
+
+// =============================================================================
+// RECEIPT BUILDER
+// =============================================================================
+
+/// Builder for constructing and signing execution receipts.
+pub struct ReceiptBuilder {
+    mandate_id: String,
+    task_id: Option<String>,
+    execution: ExecutionDetails,
+    attestation: AttestationDetails,
+    domain: DomainSeparator,
+}
+
+impl ReceiptBuilder {
+    /// Start building a receipt for the given mandate.
+    pub fn new(mandate_id: String, execution: ExecutionDetails) -> Self {
+        let boot_id = read_boot_id().unwrap_or_else(|| "unknown".to_string());
+
+        Self {
+            mandate_id,
+            task_id: None,
+            execution,
+            attestation: AttestationDetails {
+                kernel_seq: None,
+                kernel_boot_id: boot_id.clone(),
+                sequencer_ring_size: None,
+                lsm_hook: "bprm_check_security".to_string(),
+                enforcement_mode: "monitor".to_string(),
+            },
+            domain: DomainSeparator {
+                salt: boot_id,
+                ..Default::default()
+            },
+        }
+    }
+
+    pub fn task_id(mut self, id: String) -> Self {
+        self.task_id = Some(id);
+        self
+    }
+
+    pub fn kernel_seq(mut self, seq: u64) -> Self {
+        self.attestation.kernel_seq = Some(seq);
+        self
+    }
+
+    pub fn enforcement_mode(mut self, mode: &str) -> Self {
+        self.attestation.enforcement_mode = mode.to_string();
+        self
+    }
+
+    pub fn lsm_hook(mut self, hook: &str) -> Self {
+        self.attestation.lsm_hook = hook.to_string();
+        self
+    }
+
+    pub fn chain_id(mut self, id: u64) -> Self {
+        self.domain.chain_id = id;
+        self
+    }
+
+    pub fn verifying_contract(mut self, addr: &str) -> Self {
+        self.domain.verifying_contract = addr.to_string();
+        self
+    }
+
+    /// Sign and finalize the receipt using the agent's dual keypair.
+    ///
+    /// 1. Constructs the receipt JSON without signatures.
+    /// 2. Computes canonical JSON (keys sorted, no whitespace).
+    /// 3. Signs canonical JSON with Ed25519.
+    /// 4. Computes EIP-712 typed data hash and signs with secp256k1.
+    /// 5. Returns the complete receipt with both signatures.
+    pub fn sign(self, identity: &AgentIdentity) -> Result<ExecutionReceipt> {
+        // Build unsigned receipt for canonical JSON computation
+        let unsigned = UnsignedReceipt {
+            version: "0.1.0".to_string(),
+            mandate_id: self.mandate_id.clone(),
+            task_id: self.task_id.clone(),
+            agent_did: identity.did().to_string(),
+            execution: self.execution.clone(),
+            attestation: self.attestation.clone(),
+            domain: self.domain.clone(),
+        };
+
+        // ── Ed25519 signature ────────────────────────────────────────
+        let canonical_json = canonical_json(&unsigned)?;
+        let ed25519_sig = sign_ed25519(identity, canonical_json.as_bytes());
+
+        // ── secp256k1 / EIP-712 signature ────────────────────────────
+        let eip712_hash = compute_eip712_hash(&unsigned)?;
+        let secp256k1_sig = sign_secp256k1(identity, &eip712_hash)?;
+
+        Ok(ExecutionReceipt {
+            version: unsigned.version,
+            mandate_id: unsigned.mandate_id,
+            task_id: unsigned.task_id,
+            agent_did: unsigned.agent_did,
+            execution: unsigned.execution,
+            attestation: unsigned.attestation,
+            domain: unsigned.domain,
+            signature: format!("ed25519:{}", BASE64.encode(ed25519_sig.as_slice())),
+            secp256k1_signature: format!("0x{}", hex::encode(secp256k1_sig)),
+        })
+    }
+}
+
+// =============================================================================
+// UNSIGNED RECEIPT (for canonical JSON computation)
+// =============================================================================
+
+/// Receipt without signatures — used to compute the signing payload.
+/// Keys are sorted alphabetically in serialization (via serde default).
+#[derive(Debug, Serialize, Deserialize)]
+struct UnsignedReceipt {
+    version: String,
+    mandate_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    task_id: Option<String>,
+    agent_did: String,
+    execution: ExecutionDetails,
+    attestation: AttestationDetails,
+    domain: DomainSeparator,
+}
+
+// =============================================================================
+// SIGNING FUNCTIONS
+// =============================================================================
+
+/// Sign message bytes with Ed25519.
+fn sign_ed25519(identity: &AgentIdentity, message: &[u8]) -> Vec<u8> {
+    use ed25519_dalek::Signer;
+    let sig = identity.ed25519_signing_key().sign(message);
+    sig.to_bytes().to_vec()
+}
+
+/// Sign an EIP-712 hash with secp256k1, producing a 65-byte recoverable signature.
+///
+/// Returns [r (32 bytes) || s (32 bytes) || v (1 byte)].
+fn sign_secp256k1(identity: &AgentIdentity, digest: &[u8; 32]) -> Result<Vec<u8>> {
+    use k256::ecdsa::Signature;
+
+    let (sig, recid): (Signature, _) = identity
+        .secp256k1_signing_key()
+        .sign_prehash_recoverable(digest)
+        .map_err(|e| anyhow::anyhow!("secp256k1 signing failed: {e}"))?;
+
+    let mut bytes = Vec::with_capacity(65);
+    bytes.extend_from_slice(&sig.to_bytes()); // r || s (64 bytes)
+    bytes.push(recid.to_byte() + 27); // v = recovery_id + 27 (Ethereum convention)
+    Ok(bytes)
+}
+
+/// Compute canonical JSON for Ed25519 signing (§5.2).
+///
+/// Keys sorted alphabetically, no whitespace, UTF-8 encoded.
+/// We use serde_json::to_value → sort keys → serialize.
+fn canonical_json(receipt: &UnsignedReceipt) -> Result<String> {
+    let value = serde_json::to_value(receipt).context("failed to serialize receipt to JSON")?;
+    let sorted = sort_json_value(&value);
+    serde_json::to_string(&sorted).context("failed to serialize canonical JSON")
+}
+
+/// Recursively sort JSON keys alphabetically.
+fn sort_json_value(val: &serde_json::Value) -> serde_json::Value {
+    match val {
+        serde_json::Value::Object(map) => {
+            let mut sorted: serde_json::Map<String, serde_json::Value> = serde_json::Map::new();
+            let mut keys: Vec<&String> = map.keys().collect();
+            keys.sort();
+            for key in keys {
+                sorted.insert(key.clone(), sort_json_value(&map[key]));
+            }
+            serde_json::Value::Object(sorted)
+        }
+        serde_json::Value::Array(arr) => {
+            serde_json::Value::Array(arr.iter().map(sort_json_value).collect())
+        }
+        other => other.clone(),
+    }
+}
+
+// =============================================================================
+// EIP-712 TYPED DATA HASH (§5.2)
+// =============================================================================
+
+/// Compute EIP-712 typed structured data hash for secp256k1 signing.
+///
+/// `hash = keccak256("\x19\x01" || domain_separator || struct_hash)`
+fn compute_eip712_hash(receipt: &UnsignedReceipt) -> Result<[u8; 32]> {
+    let domain_sep = compute_domain_separator(&receipt.domain);
+    let struct_hash = compute_receipt_struct_hash(receipt)?;
+
+    let mut data = Vec::with_capacity(66);
+    data.extend_from_slice(b"\x19\x01");
+    data.extend_from_slice(&domain_sep);
+    data.extend_from_slice(&struct_hash);
+
+    Ok(keccak256(&data))
+}
+
+/// EIP-712 domain separator hash.
+///
+/// ```solidity
+/// keccak256(abi.encode(
+///     DOMAIN_TYPEHASH,
+///     keccak256("Linnix-Claw"),
+///     keccak256("0.1.0"),
+///     chainId,
+///     verifyingContract,
+///     salt
+/// ))
+/// ```
+fn compute_domain_separator(domain: &DomainSeparator) -> [u8; 32] {
+    let typehash = keccak256(
+        b"EIP712Domain(string name,string version,uint256 chainId,address verifyingContract,bytes32 salt)",
+    );
+
+    let name_hash = keccak256(domain.name.as_bytes());
+    let version_hash = keccak256(domain.version.as_bytes());
+
+    let mut chain_id_bytes = [0u8; 32];
+    chain_id_bytes[24..].copy_from_slice(&domain.chain_id.to_be_bytes());
+
+    let mut contract_bytes = [0u8; 32];
+    if let Some(hex_str) = domain.verifying_contract.strip_prefix("0x")
+        && let Ok(decoded) = hex::decode(hex_str)
+    {
+        let start = 32 - decoded.len().min(32);
+        contract_bytes[start..start + decoded.len().min(32)]
+            .copy_from_slice(&decoded[..decoded.len().min(32)]);
+    }
+
+    // Salt: keccak256 of the boot_id string (fits in bytes32)
+    let salt_hash = keccak256(domain.salt.as_bytes());
+
+    // abi.encode all components
+    let mut encoded = Vec::with_capacity(6 * 32);
+    encoded.extend_from_slice(&typehash);
+    encoded.extend_from_slice(&name_hash);
+    encoded.extend_from_slice(&version_hash);
+    encoded.extend_from_slice(&chain_id_bytes);
+    encoded.extend_from_slice(&contract_bytes);
+    encoded.extend_from_slice(&salt_hash);
+
+    keccak256(&encoded)
+}
+
+/// EIP-712 struct hash for the receipt.
+///
+/// We hash key receipt fields that the on-chain contract needs to verify:
+/// mandate_id, agent_did, binary, args_hash, exit_code, duration_ms, enforcement_mode.
+fn compute_receipt_struct_hash(receipt: &UnsignedReceipt) -> Result<[u8; 32]> {
+    let typehash = keccak256(
+        b"ExecutionReceipt(string mandateId,string agentDid,uint32 pid,string binary,string argsHash,int32 exitCode,uint64 durationMs,string enforcementMode)",
+    );
+
+    let mandate_id_hash = keccak256(receipt.mandate_id.as_bytes());
+    let agent_did_hash = keccak256(receipt.agent_did.as_bytes());
+
+    let mut pid_bytes = [0u8; 32];
+    pid_bytes[28..].copy_from_slice(&receipt.execution.pid.to_be_bytes());
+
+    let binary_hash = keccak256(receipt.execution.binary.as_bytes());
+    let args_hash_hash = keccak256(receipt.execution.args_hash.as_bytes());
+
+    let mut exit_code_bytes = [0u8; 32];
+    exit_code_bytes[28..].copy_from_slice(&receipt.execution.exit_code.to_be_bytes());
+
+    let mut duration_bytes = [0u8; 32];
+    duration_bytes[24..].copy_from_slice(&receipt.execution.duration_ms.to_be_bytes());
+
+    let enforcement_hash = keccak256(receipt.attestation.enforcement_mode.as_bytes());
+
+    let mut encoded = Vec::with_capacity(9 * 32);
+    encoded.extend_from_slice(&typehash);
+    encoded.extend_from_slice(&mandate_id_hash);
+    encoded.extend_from_slice(&agent_did_hash);
+    encoded.extend_from_slice(&pid_bytes);
+    encoded.extend_from_slice(&binary_hash);
+    encoded.extend_from_slice(&args_hash_hash);
+    encoded.extend_from_slice(&exit_code_bytes);
+    encoded.extend_from_slice(&duration_bytes);
+    encoded.extend_from_slice(&enforcement_hash);
+
+    Ok(keccak256(&encoded))
+}
+
+/// Keccak-256 hash.
+fn keccak256(data: &[u8]) -> [u8; 32] {
+    let mut hasher = Keccak::v256();
+    let mut hash = [0u8; 32];
+    hasher.update(data);
+    hasher.finalize(&mut hash);
+    hash
+}
+
+// =============================================================================
+// VERIFICATION (for tests and offline verification)
+// =============================================================================
+
+/// Verify an execution receipt's Ed25519 signature.
+///
+/// Re-constructs the canonical JSON from the receipt fields and verifies
+/// against the provided public key.
+pub fn verify_ed25519(
+    receipt: &ExecutionReceipt,
+    pubkey: &ed25519_dalek::VerifyingKey,
+) -> Result<bool> {
+    // Strip "ed25519:" prefix and decode
+    let sig_b64 = receipt
+        .signature
+        .strip_prefix("ed25519:")
+        .context("signature missing 'ed25519:' prefix")?;
+    let sig_bytes = BASE64
+        .decode(sig_b64)
+        .context("failed to decode Ed25519 signature from base64")?;
+
+    if sig_bytes.len() != 64 {
+        anyhow::bail!(
+            "Ed25519 signature must be 64 bytes, got {}",
+            sig_bytes.len()
+        );
+    }
+    let sig = ed25519_dalek::Signature::from_bytes(sig_bytes.as_slice().try_into().unwrap());
+
+    // Re-construct unsigned receipt
+    let unsigned = UnsignedReceipt {
+        version: receipt.version.clone(),
+        mandate_id: receipt.mandate_id.clone(),
+        task_id: receipt.task_id.clone(),
+        agent_did: receipt.agent_did.clone(),
+        execution: receipt.execution.clone(),
+        attestation: receipt.attestation.clone(),
+        domain: receipt.domain.clone(),
+    };
+
+    let canonical = canonical_json(&unsigned)?;
+
+    use ed25519_dalek::Verifier;
+    Ok(pubkey.verify(canonical.as_bytes(), &sig).is_ok())
+}
+
+/// Verify an execution receipt's secp256k1/EIP-712 signature.
+///
+/// Recovers the signer address from the recoverable signature and compares
+/// against the expected Ethereum address.
+pub fn verify_secp256k1(receipt: &ExecutionReceipt, expected_address: &[u8; 20]) -> Result<bool> {
+    // Strip "0x" prefix and decode
+    let hex_str = receipt
+        .secp256k1_signature
+        .strip_prefix("0x")
+        .context("secp256k1_signature missing '0x' prefix")?;
+    let sig_bytes =
+        hex::decode(hex_str).context("failed to decode secp256k1 signature from hex")?;
+
+    if sig_bytes.len() != 65 {
+        anyhow::bail!(
+            "secp256k1 signature must be 65 bytes, got {}",
+            sig_bytes.len()
+        );
+    }
+
+    // Split into r||s (64 bytes) and v (1 byte)
+    let v = sig_bytes[64];
+    let recid = k256::ecdsa::RecoveryId::try_from(v.wrapping_sub(27))
+        .map_err(|e| anyhow::anyhow!("invalid recovery id: {e}"))?;
+    let sig = k256::ecdsa::Signature::try_from(&sig_bytes[..64])
+        .map_err(|e| anyhow::anyhow!("invalid secp256k1 signature: {e}"))?;
+
+    // Re-compute EIP-712 hash
+    let unsigned = UnsignedReceipt {
+        version: receipt.version.clone(),
+        mandate_id: receipt.mandate_id.clone(),
+        task_id: receipt.task_id.clone(),
+        agent_did: receipt.agent_did.clone(),
+        execution: receipt.execution.clone(),
+        attestation: receipt.attestation.clone(),
+        domain: receipt.domain.clone(),
+    };
+    let eip712_hash = compute_eip712_hash(&unsigned)?;
+
+    // Recover public key from signature
+    let recovered_key = k256::ecdsa::VerifyingKey::recover_from_prehash(&eip712_hash, &sig, recid)
+        .map_err(|e| anyhow::anyhow!("failed to recover secp256k1 key: {e}"))?;
+
+    // Derive Ethereum address from recovered key
+    let point = recovered_key.to_encoded_point(false);
+    let pubkey_bytes = &point.as_bytes()[1..];
+
+    let mut keccak = Keccak::v256();
+    let mut hash = [0u8; 32];
+    keccak.update(pubkey_bytes);
+    keccak.finalize(&mut hash);
+
+    let mut recovered_addr = [0u8; 20];
+    recovered_addr.copy_from_slice(&hash[12..]);
+
+    Ok(&recovered_addr == expected_address)
+}
+
+// =============================================================================
+// UTILITIES
+// =============================================================================
+
+/// Read the kernel boot ID from /proc/sys/kernel/random/boot_id.
+fn read_boot_id() -> Option<String> {
+    std::fs::read_to_string("/proc/sys/kernel/random/boot_id")
+        .ok()
+        .map(|s| s.trim().to_string())
+}
+
+// =============================================================================
+// TESTS
+// =============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::identity::AgentIdentity;
+
+    fn test_identity() -> AgentIdentity {
+        let mut seed = [0u8; 32];
+        for (i, b) in seed.iter_mut().enumerate() {
+            *b = (i * 7 + 3) as u8;
+        }
+        AgentIdentity::from_seed(seed, "did:web:test.agent.example".into()).unwrap()
+    }
+
+    fn test_execution() -> ExecutionDetails {
+        ExecutionDetails {
+            pid: 12345,
+            ppid: Some(12300),
+            binary: "/usr/bin/curl".to_string(),
+            args_hash: "0xa1b2c3d4e5f60718".to_string(),
+            exit_code: 0,
+            started_at_ns: Some(1740000001234000000),
+            finished_at_ns: Some(1740000001567000000),
+            duration_ms: 333,
+            cpu_pct: Some(2.3),
+            mem_pct: Some(0.1),
+        }
+    }
+
+    #[test]
+    fn receipt_sign_produces_valid_structure() {
+        let identity = test_identity();
+        let receipt = ReceiptBuilder::new("mnd_00000001".to_string(), test_execution())
+            .task_id("task_abc".to_string())
+            .kernel_seq(1234)
+            .enforcement_mode("monitor")
+            .sign(&identity)
+            .unwrap();
+
+        assert_eq!(receipt.version, "0.1.0");
+        assert_eq!(receipt.mandate_id, "mnd_00000001");
+        assert_eq!(receipt.task_id, Some("task_abc".to_string()));
+        assert_eq!(receipt.agent_did, "did:web:test.agent.example");
+        assert!(receipt.signature.starts_with("ed25519:"));
+        assert!(receipt.secp256k1_signature.starts_with("0x"));
+        assert_eq!(receipt.execution.pid, 12345);
+        assert_eq!(receipt.execution.exit_code, 0);
+    }
+
+    #[test]
+    fn receipt_ed25519_verify_roundtrip() {
+        let identity = test_identity();
+        let receipt = ReceiptBuilder::new("mnd_verify_ed".to_string(), test_execution())
+            .sign(&identity)
+            .unwrap();
+
+        let pubkey = identity.ed25519_verifying_key();
+        assert!(
+            verify_ed25519(&receipt, &pubkey).unwrap(),
+            "Ed25519 signature verification failed"
+        );
+    }
+
+    #[test]
+    fn receipt_secp256k1_verify_roundtrip() {
+        let identity = test_identity();
+        let receipt = ReceiptBuilder::new("mnd_verify_secp".to_string(), test_execution())
+            .sign(&identity)
+            .unwrap();
+
+        let addr = identity.ethereum_address();
+        assert!(
+            verify_secp256k1(&receipt, &addr).unwrap(),
+            "secp256k1/EIP-712 signature verification failed"
+        );
+    }
+
+    #[test]
+    fn receipt_dual_verify() {
+        let identity = test_identity();
+        let receipt = ReceiptBuilder::new("mnd_dual".to_string(), test_execution())
+            .kernel_seq(42)
+            .enforcement_mode("enforce")
+            .chain_id(8453)
+            .sign(&identity)
+            .unwrap();
+
+        // Both signatures must verify
+        let ed_ok = verify_ed25519(&receipt, &identity.ed25519_verifying_key()).unwrap();
+        let secp_ok = verify_secp256k1(&receipt, &identity.ethereum_address()).unwrap();
+        assert!(ed_ok, "Ed25519 failed");
+        assert!(secp_ok, "secp256k1 failed");
+    }
+
+    #[test]
+    fn tampered_receipt_fails_ed25519() {
+        let identity = test_identity();
+        let mut receipt = ReceiptBuilder::new("mnd_tamper".to_string(), test_execution())
+            .sign(&identity)
+            .unwrap();
+
+        // Tamper with the mandate_id
+        receipt.mandate_id = "mnd_TAMPERED".to_string();
+
+        let pubkey = identity.ed25519_verifying_key();
+        assert!(
+            !verify_ed25519(&receipt, &pubkey).unwrap(),
+            "Ed25519 should reject tampered receipt"
+        );
+    }
+
+    #[test]
+    fn tampered_receipt_fails_secp256k1() {
+        let identity = test_identity();
+        let mut receipt = ReceiptBuilder::new("mnd_tamper2".to_string(), test_execution())
+            .sign(&identity)
+            .unwrap();
+
+        // Tamper with exit code
+        receipt.execution.exit_code = 1;
+
+        let addr = identity.ethereum_address();
+        assert!(
+            !verify_secp256k1(&receipt, &addr).unwrap(),
+            "secp256k1 should reject tampered receipt"
+        );
+    }
+
+    #[test]
+    fn wrong_key_fails_ed25519() {
+        let identity = test_identity();
+        let receipt = ReceiptBuilder::new("mnd_wrongkey".to_string(), test_execution())
+            .sign(&identity)
+            .unwrap();
+
+        // Verify with a different identity's key
+        let other = AgentIdentity::from_seed([0xFF; 32], "did:web:other".into()).unwrap();
+        let result = verify_ed25519(&receipt, &other.ed25519_verifying_key()).unwrap();
+        assert!(!result, "should fail with wrong key");
+    }
+
+    #[test]
+    fn wrong_address_fails_secp256k1() {
+        let identity = test_identity();
+        let receipt = ReceiptBuilder::new("mnd_wrongaddr".to_string(), test_execution())
+            .sign(&identity)
+            .unwrap();
+
+        // Verify with wrong Ethereum address
+        let wrong_addr = [0xAA; 20];
+        let result = verify_secp256k1(&receipt, &wrong_addr).unwrap();
+        assert!(!result, "should fail with wrong address");
+    }
+
+    #[test]
+    fn canonical_json_is_deterministic() {
+        let unsigned = UnsignedReceipt {
+            version: "0.1.0".to_string(),
+            mandate_id: "test".to_string(),
+            task_id: None,
+            agent_did: "did:web:x".to_string(),
+            execution: test_execution(),
+            attestation: AttestationDetails {
+                kernel_seq: Some(1),
+                kernel_boot_id: "boot-1".to_string(),
+                sequencer_ring_size: None,
+                lsm_hook: "bprm_check_security".to_string(),
+                enforcement_mode: "monitor".to_string(),
+            },
+            domain: DomainSeparator {
+                name: "Linnix-Claw".to_string(),
+                version: "0.1.0".to_string(),
+                chain_id: 8453,
+                verifying_contract: "0x0".to_string(),
+                salt: "test-salt".to_string(),
+            },
+        };
+
+        let json1 = canonical_json(&unsigned).unwrap();
+        let json2 = canonical_json(&unsigned).unwrap();
+        assert_eq!(json1, json2, "canonical JSON must be deterministic");
+
+        // Verify keys are actually sorted
+        assert!(
+            json1.find("\"agent_did\"").unwrap() < json1.find("\"attestation\"").unwrap(),
+            "keys should be alphabetically sorted"
+        );
+    }
+
+    #[test]
+    fn eip712_hash_is_deterministic() {
+        let unsigned = UnsignedReceipt {
+            version: "0.1.0".to_string(),
+            mandate_id: "test-eip712".to_string(),
+            task_id: None,
+            agent_did: "did:web:eip".to_string(),
+            execution: test_execution(),
+            attestation: AttestationDetails {
+                kernel_seq: None,
+                kernel_boot_id: "boot-2".to_string(),
+                sequencer_ring_size: None,
+                lsm_hook: "bprm_check_security".to_string(),
+                enforcement_mode: "enforce".to_string(),
+            },
+            domain: DomainSeparator::default(),
+        };
+
+        let hash1 = compute_eip712_hash(&unsigned).unwrap();
+        let hash2 = compute_eip712_hash(&unsigned).unwrap();
+        assert_eq!(hash1, hash2, "EIP-712 hash must be deterministic");
+        assert!(hash1.iter().any(|&b| b != 0), "hash shouldn't be all zeros");
+    }
+
+    #[test]
+    fn receipt_serializes_to_json() {
+        let identity = test_identity();
+        let receipt = ReceiptBuilder::new("mnd_json".to_string(), test_execution())
+            .sign(&identity)
+            .unwrap();
+
+        let json = serde_json::to_string_pretty(&receipt).unwrap();
+        assert!(json.contains("\"version\": \"0.1.0\""));
+        assert!(json.contains("\"mandate_id\": \"mnd_json\""));
+        assert!(json.contains("\"signature\": \"ed25519:"));
+        assert!(json.contains("\"secp256k1_signature\": \"0x"));
+
+        // Roundtrip deserialization
+        let parsed: ExecutionReceipt = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.mandate_id, "mnd_json");
+    }
+
+    #[test]
+    fn different_chain_ids_produce_different_secp256k1_sigs() {
+        let identity = test_identity();
+
+        let r1 = ReceiptBuilder::new("mnd_chain1".to_string(), test_execution())
+            .chain_id(8453)
+            .sign(&identity)
+            .unwrap();
+
+        let r2 = ReceiptBuilder::new("mnd_chain1".to_string(), test_execution())
+            .chain_id(42161)
+            .sign(&identity)
+            .unwrap();
+
+        assert_ne!(
+            r1.secp256k1_signature, r2.secp256k1_signature,
+            "different chain IDs must produce different secp256k1 signatures (anti-replay)"
+        );
+    }
+}

--- a/cognitod/src/runtime/stream_listener.rs
+++ b/cognitod/src/runtime/stream_listener.rs
@@ -23,6 +23,8 @@ fn event_label(kind: u32) -> &'static str {
         x if x == EventType::Syscall as u32 => "Syscall",
         x if x == EventType::BlockIo as u32 => "BlockIo",
         x if x == EventType::PageFault as u32 => "PageFault",
+        x if x == EventType::MandateAllow as u32 => "MandateAllow",
+        x if x == EventType::MandateDeny as u32 => "MandateDeny",
         _ => "Unknown",
     }
 }

--- a/cognitod/src/spend.rs
+++ b/cognitod/src/spend.rs
@@ -1,0 +1,597 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// cognitod/src/spend.rs — Linnix-Claw spend control engine (§9)
+//
+// Enforces per-mandate, per-hour, daily, monthly, and per-agent spending limits.
+// All amounts are in USD cents (integer). The kernel enforces authorization
+// (is this command allowed?); cognitod enforces economics (can we afford this?).
+//
+// See docs/linnix-claw/specs.md §9.1–§9.3.
+
+use log::{debug, info};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::{Duration, SystemTime};
+use tokio::sync::RwLock;
+
+use crate::config::SpendLimitsConfig;
+
+// =============================================================================
+// SPEND LIMIT VIOLATION
+// =============================================================================
+
+/// Describes which limit was exceeded.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum SpendLimitViolation {
+    /// Single mandate exceeds per-mandate cap.
+    PerMandate {
+        requested_cents: u64,
+        limit_cents: u64,
+    },
+    /// Hourly aggregate would be exceeded.
+    Hourly {
+        current_cents: u64,
+        requested_cents: u64,
+        limit_cents: u64,
+    },
+    /// Daily aggregate would be exceeded.
+    Daily {
+        current_cents: u64,
+        requested_cents: u64,
+        limit_cents: u64,
+    },
+    /// Monthly aggregate would be exceeded.
+    Monthly {
+        current_cents: u64,
+        requested_cents: u64,
+        limit_cents: u64,
+    },
+    /// Per-agent daily override exceeded.
+    PerAgentDaily {
+        agent_did: String,
+        current_cents: u64,
+        requested_cents: u64,
+        limit_cents: u64,
+    },
+}
+
+impl std::fmt::Display for SpendLimitViolation {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::PerMandate {
+                requested_cents,
+                limit_cents,
+            } => write!(
+                f,
+                "per-mandate limit exceeded: ${:.2} > ${:.2}",
+                *requested_cents as f64 / 100.0,
+                *limit_cents as f64 / 100.0
+            ),
+            Self::Hourly {
+                current_cents,
+                requested_cents,
+                limit_cents,
+            } => write!(
+                f,
+                "hourly limit exceeded: current ${:.2} + ${:.2} > ${:.2}",
+                *current_cents as f64 / 100.0,
+                *requested_cents as f64 / 100.0,
+                *limit_cents as f64 / 100.0
+            ),
+            Self::Daily {
+                current_cents,
+                requested_cents,
+                limit_cents,
+            } => write!(
+                f,
+                "daily limit exceeded: current ${:.2} + ${:.2} > ${:.2}",
+                *current_cents as f64 / 100.0,
+                *requested_cents as f64 / 100.0,
+                *limit_cents as f64 / 100.0
+            ),
+            Self::Monthly {
+                current_cents,
+                requested_cents,
+                limit_cents,
+            } => write!(
+                f,
+                "monthly limit exceeded: current ${:.2} + ${:.2} > ${:.2}",
+                *current_cents as f64 / 100.0,
+                *requested_cents as f64 / 100.0,
+                *limit_cents as f64 / 100.0
+            ),
+            Self::PerAgentDaily {
+                agent_did,
+                current_cents,
+                requested_cents,
+                limit_cents,
+            } => write!(
+                f,
+                "per-agent daily limit for {} exceeded: ${:.2} + ${:.2} > ${:.2}",
+                agent_did,
+                *current_cents as f64 / 100.0,
+                *requested_cents as f64 / 100.0,
+                *limit_cents as f64 / 100.0
+            ),
+        }
+    }
+}
+
+// =============================================================================
+// SPEND RECORD — tracks a single committed spend
+// =============================================================================
+
+#[derive(Debug, Clone)]
+struct SpendRecord {
+    /// Amount in cents.
+    amount_cents: u64,
+    /// Counterparty agent DID (if known).
+    agent_did: Option<String>,
+    /// Timestamp of the spend.
+    timestamp: SystemTime,
+}
+
+// =============================================================================
+// SPEND TRACKER
+// =============================================================================
+
+/// Tracks and enforces aggregate spending limits.
+///
+/// Thread-safe via `Arc<RwLock<_>>` — designed to be shared across
+/// the mandate API handlers.
+///
+/// Limits (from §9.1):
+/// - `per_mandate_cents` — max per individual mandate (default $50)
+/// - `hourly_cents` — max aggregate per hour (if configured)
+/// - `daily_cents` — max aggregate per day (default $500)
+/// - `monthly_cents` — max aggregate per month (default $5,000)
+/// - `per_agent` — per-counterparty daily overrides
+pub struct SpendTracker {
+    limits: SpendLimitsConfig,
+    /// Rolling window of all spend records.
+    ledger: Arc<RwLock<Vec<SpendRecord>>>,
+}
+
+impl std::fmt::Debug for SpendTracker {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SpendTracker")
+            .field("limits", &self.limits)
+            .finish_non_exhaustive()
+    }
+}
+
+impl SpendTracker {
+    /// Create a new tracker from config limits.
+    pub fn new(limits: SpendLimitsConfig) -> Self {
+        info!(
+            "spend tracker initialized: per_mandate=${:.2}, hourly=${}, daily=${:.2}, monthly=${:.2}, per_agent_overrides={}",
+            limits.per_mandate_cents as f64 / 100.0,
+            limits
+                .hourly_cents
+                .map_or("unlimited".to_string(), |c| format!(
+                    "{:.2}",
+                    c as f64 / 100.0
+                )),
+            limits.daily_cents as f64 / 100.0,
+            limits.monthly_cents as f64 / 100.0,
+            limits.per_agent.len(),
+        );
+        Self {
+            limits,
+            ledger: Arc::new(RwLock::new(Vec::new())),
+        }
+    }
+
+    /// Check whether a proposed spend would violate any limit.
+    ///
+    /// Returns `Ok(())` if allowed, or `Err(SpendLimitViolation)` if not.
+    /// Does NOT commit the spend — call `record_spend` after execution.
+    pub async fn check_spend(
+        &self,
+        amount_cents: u64,
+        counterparty_did: Option<&str>,
+    ) -> Result<(), SpendLimitViolation> {
+        // (1) Per-mandate check
+        if amount_cents > self.limits.per_mandate_cents {
+            return Err(SpendLimitViolation::PerMandate {
+                requested_cents: amount_cents,
+                limit_cents: self.limits.per_mandate_cents,
+            });
+        }
+
+        let now = SystemTime::now();
+        let ledger = self.ledger.read().await;
+
+        // (2) Hourly aggregate
+        if let Some(hourly_limit) = self.limits.hourly_cents {
+            let hour_ago = now - Duration::from_secs(3600);
+            let hourly_total: u64 = ledger
+                .iter()
+                .filter(|r| r.timestamp >= hour_ago)
+                .map(|r| r.amount_cents)
+                .sum();
+            if hourly_total + amount_cents > hourly_limit {
+                return Err(SpendLimitViolation::Hourly {
+                    current_cents: hourly_total,
+                    requested_cents: amount_cents,
+                    limit_cents: hourly_limit,
+                });
+            }
+        }
+
+        // (3) Daily aggregate (rolling 24h window)
+        let day_ago = now - Duration::from_secs(86400);
+        let daily_total: u64 = ledger
+            .iter()
+            .filter(|r| r.timestamp >= day_ago)
+            .map(|r| r.amount_cents)
+            .sum();
+        if daily_total + amount_cents > self.limits.daily_cents {
+            return Err(SpendLimitViolation::Daily {
+                current_cents: daily_total,
+                requested_cents: amount_cents,
+                limit_cents: self.limits.daily_cents,
+            });
+        }
+
+        // (4) Monthly aggregate (rolling 30-day window)
+        let month_ago = now - Duration::from_secs(30 * 86400);
+        let monthly_total: u64 = ledger
+            .iter()
+            .filter(|r| r.timestamp >= month_ago)
+            .map(|r| r.amount_cents)
+            .sum();
+        if monthly_total + amount_cents > self.limits.monthly_cents {
+            return Err(SpendLimitViolation::Monthly {
+                current_cents: monthly_total,
+                requested_cents: amount_cents,
+                limit_cents: self.limits.monthly_cents,
+            });
+        }
+
+        // (5) Per-agent daily override (let_chains stabilized in Rust 1.82)
+        if let Some(did) = counterparty_did
+            && let Some(agent_limit) = self.limits.per_agent.get(did)
+        {
+            let agent_daily: u64 = ledger
+                .iter()
+                .filter(|r| r.timestamp >= day_ago)
+                .filter(|r| r.agent_did.as_deref() == Some(did))
+                .map(|r| r.amount_cents)
+                .sum();
+            if agent_daily + amount_cents > agent_limit.daily_cents {
+                return Err(SpendLimitViolation::PerAgentDaily {
+                    agent_did: did.to_string(),
+                    current_cents: agent_daily,
+                    requested_cents: amount_cents,
+                    limit_cents: agent_limit.daily_cents,
+                });
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Record a committed spend. Call after successful mandate execution.
+    pub async fn record_spend(&self, amount_cents: u64, counterparty_did: Option<String>) {
+        let record = SpendRecord {
+            amount_cents,
+            agent_did: counterparty_did,
+            timestamp: SystemTime::now(),
+        };
+        debug!(
+            "recording spend: ${:.2}{}",
+            amount_cents as f64 / 100.0,
+            record
+                .agent_did
+                .as_ref()
+                .map_or(String::new(), |d| format!(" to {}", d))
+        );
+        self.ledger.write().await.push(record);
+    }
+
+    /// Evict records older than the retention window (31 days).
+    /// Called periodically to prevent unbounded memory growth.
+    pub async fn gc(&self) {
+        let cutoff = SystemTime::now() - Duration::from_secs(31 * 86400);
+        let mut ledger = self.ledger.write().await;
+        let before = ledger.len();
+        ledger.retain(|r| r.timestamp >= cutoff);
+        let after = ledger.len();
+        if before != after {
+            info!("spend tracker GC: evicted {} old records", before - after);
+        }
+    }
+
+    /// Current totals for observability.
+    pub async fn totals(&self) -> SpendTotals {
+        let now = SystemTime::now();
+        let hour_ago = now - Duration::from_secs(3600);
+        let day_ago = now - Duration::from_secs(86400);
+        let month_ago = now - Duration::from_secs(30 * 86400);
+        let ledger = self.ledger.read().await;
+
+        let hourly_cents = ledger
+            .iter()
+            .filter(|r| r.timestamp >= hour_ago)
+            .map(|r| r.amount_cents)
+            .sum();
+        let daily_cents = ledger
+            .iter()
+            .filter(|r| r.timestamp >= day_ago)
+            .map(|r| r.amount_cents)
+            .sum();
+        let monthly_cents = ledger
+            .iter()
+            .filter(|r| r.timestamp >= month_ago)
+            .map(|r| r.amount_cents)
+            .sum();
+        let record_count = ledger.len();
+
+        SpendTotals {
+            hourly_cents,
+            daily_cents,
+            monthly_cents,
+            record_count,
+        }
+    }
+
+    /// Per-agent daily totals for the last 24h.
+    pub async fn per_agent_totals(&self) -> HashMap<String, u64> {
+        let day_ago = SystemTime::now() - Duration::from_secs(86400);
+        let ledger = self.ledger.read().await;
+        let mut totals: HashMap<String, u64> = HashMap::new();
+        for record in ledger.iter().filter(|r| r.timestamp >= day_ago) {
+            if let Some(did) = &record.agent_did {
+                *totals.entry(did.clone()).or_default() += record.amount_cents;
+            }
+        }
+        totals
+    }
+
+    /// Get current limits (for API introspection).
+    pub fn limits(&self) -> &SpendLimitsConfig {
+        &self.limits
+    }
+}
+
+/// Summary of aggregate spending for diagnostics.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SpendTotals {
+    pub hourly_cents: u64,
+    pub daily_cents: u64,
+    pub monthly_cents: u64,
+    pub record_count: usize,
+}
+
+// =============================================================================
+// TESTS
+// =============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::PerAgentLimit;
+
+    fn default_limits() -> SpendLimitsConfig {
+        SpendLimitsConfig {
+            per_mandate_cents: 5000,   // $50
+            hourly_cents: Some(10000), // $100/hr
+            daily_cents: 50000,        // $500/day
+            monthly_cents: 500000,     // $5,000/mo
+            per_agent: HashMap::new(),
+        }
+    }
+
+    #[tokio::test]
+    async fn allow_spend_within_limits() {
+        let tracker = SpendTracker::new(default_limits());
+        // Well under all limits
+        assert!(tracker.check_spend(100, None).await.is_ok());
+        assert!(tracker.check_spend(5000, None).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn reject_per_mandate_exceeded() {
+        let tracker = SpendTracker::new(default_limits());
+        let err = tracker.check_spend(5001, None).await.unwrap_err();
+        assert!(matches!(err, SpendLimitViolation::PerMandate { .. }));
+    }
+
+    #[tokio::test]
+    async fn reject_daily_exceeded() {
+        let tracker = SpendTracker::new(SpendLimitsConfig {
+            per_mandate_cents: 50000, // raise per-mandate
+            hourly_cents: None,       // no hourly limit
+            daily_cents: 50000,       // $500/day
+            monthly_cents: 500000,
+            per_agent: HashMap::new(),
+        });
+        // Spend close to daily limit
+        tracker.record_spend(49000, None).await;
+        // This should push over
+        let err = tracker.check_spend(2000, None).await.unwrap_err();
+        assert!(matches!(err, SpendLimitViolation::Daily { .. }));
+    }
+
+    #[tokio::test]
+    async fn reject_hourly_exceeded() {
+        let tracker = SpendTracker::new(default_limits());
+        // Spend close to hourly limit
+        tracker.record_spend(9500, None).await;
+        let err = tracker.check_spend(600, None).await.unwrap_err();
+        assert!(matches!(err, SpendLimitViolation::Hourly { .. }));
+    }
+
+    #[tokio::test]
+    async fn reject_monthly_exceeded() {
+        let tracker = SpendTracker::new(SpendLimitsConfig {
+            per_mandate_cents: 100000, // raise per-mandate to not hit it first
+            hourly_cents: None,        // no hourly
+            daily_cents: 1_000_000,    // raise daily
+            monthly_cents: 500000,     // $5k/mo
+            per_agent: HashMap::new(),
+        });
+        // Push near monthly limit in chunks ≤ per_mandate
+        for _ in 0..5 {
+            tracker.record_spend(99000, None).await;
+        }
+        // 5 * $990 = $4950 → adding $100 = $5050 > $5000
+        let err = tracker.check_spend(10000, None).await.unwrap_err();
+        assert!(matches!(err, SpendLimitViolation::Monthly { .. }));
+    }
+
+    #[tokio::test]
+    async fn per_agent_override_blocks() {
+        let mut limits = default_limits();
+        limits.per_agent.insert(
+            "did:web:untrusted.io".to_string(),
+            PerAgentLimit { daily_cents: 1000 },
+        );
+        let tracker = SpendTracker::new(limits);
+        let did = "did:web:untrusted.io";
+
+        // Under global limit but at per-agent limit
+        tracker.record_spend(900, Some(did.to_string())).await;
+        let err = tracker.check_spend(200, Some(did)).await.unwrap_err();
+        assert!(matches!(err, SpendLimitViolation::PerAgentDaily { .. }));
+    }
+
+    #[tokio::test]
+    async fn per_agent_override_allows_other_agents() {
+        let mut limits = default_limits();
+        limits.per_agent.insert(
+            "did:web:untrusted.io".to_string(),
+            PerAgentLimit { daily_cents: 1000 },
+        );
+        let tracker = SpendTracker::new(limits);
+
+        // Spend against the restricted agent
+        tracker
+            .record_spend(900, Some("did:web:untrusted.io".to_string()))
+            .await;
+
+        // A different agent should not be affected by that override
+        assert!(
+            tracker
+                .check_spend(900, Some("did:web:trusted.io"))
+                .await
+                .is_ok()
+        );
+    }
+
+    #[tokio::test]
+    async fn record_and_totals() {
+        let tracker = SpendTracker::new(default_limits());
+        tracker.record_spend(1000, None).await;
+        tracker
+            .record_spend(2000, Some("did:web:a".to_string()))
+            .await;
+        let totals = tracker.totals().await;
+        assert_eq!(totals.hourly_cents, 3000);
+        assert_eq!(totals.daily_cents, 3000);
+        assert_eq!(totals.monthly_cents, 3000);
+        assert_eq!(totals.record_count, 2);
+    }
+
+    #[tokio::test]
+    async fn per_agent_totals() {
+        let tracker = SpendTracker::new(default_limits());
+        tracker
+            .record_spend(500, Some("did:web:a".to_string()))
+            .await;
+        tracker
+            .record_spend(300, Some("did:web:b".to_string()))
+            .await;
+        tracker
+            .record_spend(200, Some("did:web:a".to_string()))
+            .await;
+        let per_agent = tracker.per_agent_totals().await;
+        assert_eq!(per_agent.get("did:web:a"), Some(&700));
+        assert_eq!(per_agent.get("did:web:b"), Some(&300));
+    }
+
+    #[tokio::test]
+    async fn gc_preserves_recent() {
+        let tracker = SpendTracker::new(default_limits());
+        tracker.record_spend(1000, None).await;
+        tracker.gc().await;
+        let totals = tracker.totals().await;
+        assert_eq!(totals.record_count, 1);
+    }
+
+    #[tokio::test]
+    async fn exact_limit_allowed() {
+        let tracker = SpendTracker::new(default_limits());
+        // Exactly at per-mandate limit
+        assert!(tracker.check_spend(5000, None).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn zero_spend_always_allowed() {
+        let tracker = SpendTracker::new(default_limits());
+        assert!(tracker.check_spend(0, None).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn violation_display_formatting() {
+        let v = SpendLimitViolation::PerMandate {
+            requested_cents: 10000,
+            limit_cents: 5000,
+        };
+        let s = v.to_string();
+        assert!(s.contains("$100.00"));
+        assert!(s.contains("$50.00"));
+    }
+
+    #[tokio::test]
+    async fn multiple_agents_independent_tracking() {
+        let mut limits = default_limits();
+        limits.per_agent.insert(
+            "did:web:agent-a".to_string(),
+            PerAgentLimit { daily_cents: 2000 },
+        );
+        limits.per_agent.insert(
+            "did:web:agent-b".to_string(),
+            PerAgentLimit { daily_cents: 3000 },
+        );
+        let tracker = SpendTracker::new(limits);
+
+        // Agent A spends $19
+        tracker
+            .record_spend(1900, Some("did:web:agent-a".to_string()))
+            .await;
+        // Agent A blocked at $20 + $2 > $20
+        let err = tracker
+            .check_spend(200, Some("did:web:agent-a"))
+            .await
+            .unwrap_err();
+        assert!(matches!(err, SpendLimitViolation::PerAgentDaily { .. }));
+
+        // Agent B still has room ($30 limit, $0 spent)
+        assert!(
+            tracker
+                .check_spend(2500, Some("did:web:agent-b"))
+                .await
+                .is_ok()
+        );
+    }
+
+    #[tokio::test]
+    async fn no_hourly_limit_when_none() {
+        let tracker = SpendTracker::new(SpendLimitsConfig {
+            per_mandate_cents: 100000,
+            hourly_cents: None,
+            daily_cents: 200000,
+            monthly_cents: 500000,
+            per_agent: HashMap::new(),
+        });
+        // Spend way over what an hourly limit would catch,
+        // but there's no hourly limit configured
+        tracker.record_spend(50000, None).await;
+        tracker.record_spend(50000, None).await;
+        // Still under daily; no hourly check
+        assert!(tracker.check_spend(50000, None).await.is_ok());
+    }
+}

--- a/cognitod/tests/bdd_spend.rs
+++ b/cognitod/tests/bdd_spend.rs
@@ -1,0 +1,663 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// cognitod/tests/bdd_spend.rs — BDD step definitions for Phase 4
+//
+// Cucumber-rs test runner linking Gherkin `.feature` files to Rust code.
+// Run: cargo test --test bdd_spend
+//
+// Feature files in: cognitod/tests/features/
+
+use std::collections::HashMap;
+
+use cognitod::compliance::{
+    ComplianceEngine, OfacSdnProvider, ScreeningResult, StubScreeningProvider,
+};
+use cognitod::config::{ComplianceConfig, PerAgentLimit, SpendLimitsConfig};
+use cognitod::payment::{
+    NoopAdapter, PaymentAdapter, PaymentResult, SettlementPath, StripeStubAdapter, TokenInfo,
+};
+use cognitod::privacy::{ReceiptRedactor, RedactionLevel};
+use cognitod::spend::{SpendLimitViolation, SpendTracker};
+use cucumber::{World, given, then, when};
+
+// =============================================================================
+// WORLD — shared test state across steps
+// =============================================================================
+
+#[derive(Debug, World)]
+#[world(init = Self::new)]
+pub struct ClawWorld {
+    // ── Spend tracker state ──
+    spend_limits: SpendLimitsConfig,
+    spend_tracker: Option<SpendTracker>,
+    spend_result: Option<Result<(), SpendLimitViolation>>,
+    per_agent_overrides: HashMap<String, u64>,
+
+    // ── Compliance state ──
+    compliance_config: ComplianceConfig,
+    compliance_results: Vec<ScreeningResult>,
+    ofac_blocked_wallets: Vec<String>,
+    ofac_blocked_dids: Vec<String>,
+    compliance_engine: Option<ComplianceEngine>,
+    compliance_checked: bool,
+
+    // ── Payment state ──
+    token: Option<TokenInfo>,
+    conversion_result: Option<u128>,
+    round_trip_cents: Option<u64>,
+    payment_result: Option<PaymentResult>,
+    settlement_path: Option<SettlementPath>,
+
+    // ── Privacy state ──
+    redaction_level: Option<RedactionLevel>,
+    redacted_result: Option<String>,
+
+    // ── Adapter marker ──
+    use_noop_adapter: bool,
+
+    // ── Pipeline state ──
+    pipeline_compliance_passed: bool,
+    pipeline_spend_passed: bool,
+    pipeline_settled: bool,
+    pipeline_settled_amount: u64,
+}
+
+impl ClawWorld {
+    fn new() -> Self {
+        Self {
+            spend_limits: SpendLimitsConfig::default(),
+            spend_tracker: None,
+            spend_result: None,
+            per_agent_overrides: HashMap::new(),
+            compliance_config: ComplianceConfig::default(),
+            compliance_results: Vec::new(),
+            ofac_blocked_wallets: Vec::new(),
+            ofac_blocked_dids: Vec::new(),
+            compliance_engine: None,
+            compliance_checked: false,
+            token: None,
+            conversion_result: None,
+            round_trip_cents: None,
+            payment_result: None,
+            settlement_path: None,
+            use_noop_adapter: false,
+            redaction_level: None,
+            redacted_result: None,
+            pipeline_compliance_passed: false,
+            pipeline_spend_passed: false,
+            pipeline_settled: false,
+            pipeline_settled_amount: 0,
+        }
+    }
+
+    fn ensure_tracker(&mut self) {
+        if self.spend_tracker.is_none() {
+            let mut limits = self.spend_limits.clone();
+            for (did, daily) in &self.per_agent_overrides {
+                limits.per_agent.insert(
+                    did.clone(),
+                    PerAgentLimit {
+                        daily_cents: *daily,
+                    },
+                );
+            }
+            self.spend_tracker = Some(SpendTracker::new(limits));
+        }
+    }
+
+    async fn ensure_compliance_engine(&mut self) {
+        if self.compliance_engine.is_none() {
+            if !self.ofac_blocked_wallets.is_empty() || !self.ofac_blocked_dids.is_empty() {
+                let provider = OfacSdnProvider::new();
+                let mut blocklist: Vec<String> = self.ofac_blocked_wallets.clone();
+                blocklist.extend(self.ofac_blocked_dids.clone());
+                provider.load_blocklist(blocklist).await;
+                self.compliance_engine = Some(ComplianceEngine::new(
+                    self.compliance_config.clone(),
+                    Box::new(provider),
+                ));
+            } else {
+                self.compliance_engine = Some(ComplianceEngine::new(
+                    self.compliance_config.clone(),
+                    Box::new(StubScreeningProvider),
+                ));
+            }
+        }
+    }
+}
+
+// =============================================================================
+// SPEND CONTROL STEPS
+// =============================================================================
+
+#[given("the default spend limits are configured")]
+fn default_limits(world: &mut ClawWorld) {
+    world.spend_limits = SpendLimitsConfig {
+        per_mandate_cents: 5000,
+        hourly_cents: None,
+        daily_cents: 50000,
+        monthly_cents: 500000,
+        per_agent: HashMap::new(),
+    };
+}
+
+#[given(expr = "{int} cents have already been spent today")]
+async fn pre_spend_today(world: &mut ClawWorld, cents: u64) {
+    world.ensure_tracker();
+    let tracker = world.spend_tracker.as_ref().unwrap();
+    // Record as a single lump (within per-mandate by using elevated limits)
+    tracker.record_spend(cents, None).await;
+}
+
+#[given(expr = "an hourly limit of {int} cents is configured")]
+fn set_hourly_limit(world: &mut ClawWorld, cents: u64) {
+    world.spend_limits.hourly_cents = Some(cents);
+    world.spend_tracker = None; // force re-create
+}
+
+#[given(expr = "{int} cents have been spent in the last hour")]
+async fn pre_spend_hour(world: &mut ClawWorld, cents: u64) {
+    world.ensure_tracker();
+    let tracker = world.spend_tracker.as_ref().unwrap();
+    tracker.record_spend(cents, None).await;
+}
+
+#[given(expr = "{int} cents have already been spent this month")]
+async fn pre_spend_month(world: &mut ClawWorld, cents: u64) {
+    // Raise per-mandate and daily to allow recording large amounts
+    world.spend_limits.per_mandate_cents = 1_000_000;
+    world.spend_limits.daily_cents = 1_000_000;
+    world.spend_tracker = None;
+    world.ensure_tracker();
+    let tracker = world.spend_tracker.as_ref().unwrap();
+    tracker.record_spend(cents, None).await;
+    // Restore original per-mandate for subsequent checks
+    // (the tracker is already created, so we modify via a fresh check)
+}
+
+#[given(expr = "a per-agent override for {string} of {int} cents daily")]
+fn set_per_agent_override(world: &mut ClawWorld, did: String, cents: u64) {
+    world.per_agent_overrides.insert(did, cents);
+    world.spend_tracker = None; // force re-create with new overrides
+}
+
+#[given(expr = "the agent {string} has spent {int} cents today")]
+async fn agent_pre_spend(world: &mut ClawWorld, did: String, cents: u64) {
+    world.ensure_tracker();
+    let tracker = world.spend_tracker.as_ref().unwrap();
+    tracker.record_spend(cents, Some(did)).await;
+}
+
+#[when(expr = "an agent requests a mandate for {int} cents")]
+async fn check_spend_anonymous(world: &mut ClawWorld, cents: u64) {
+    world.ensure_tracker();
+    let tracker = world.spend_tracker.as_ref().unwrap();
+    world.spend_result = Some(tracker.check_spend(cents, None).await);
+}
+
+#[when(expr = "{string} requests a mandate for {int} cents")]
+async fn check_spend_agent(world: &mut ClawWorld, did: String, cents: u64) {
+    world.ensure_tracker();
+    let tracker = world.spend_tracker.as_ref().unwrap();
+    world.spend_result = Some(tracker.check_spend(cents, Some(&did)).await);
+}
+
+// (Monthly scenario split into two separate scenarios; no compound step needed)
+
+#[then("the spend check should pass")]
+fn spend_passes(world: &mut ClawWorld) {
+    let result = world
+        .spend_result
+        .take()
+        .expect("no spend check was performed");
+    assert!(result.is_ok(), "expected spend to pass, got: {:?}", result);
+}
+
+#[then(expr = "the spend check should fail with {string}")]
+fn spend_fails_with(world: &mut ClawWorld, violation_type: String) {
+    let result = world
+        .spend_result
+        .take()
+        .expect("no spend check was performed");
+    let err = result.expect_err("expected spend to fail, but it passed");
+    let err_debug = format!("{:?}", err);
+    assert!(
+        err_debug.starts_with(&violation_type),
+        "expected {} violation, got: {}",
+        violation_type,
+        err_debug
+    );
+}
+
+// =============================================================================
+// COMPLIANCE STEPS
+// =============================================================================
+
+#[given(expr = "compliance is enabled with blocked jurisdictions {string}")]
+fn compliance_with_jurisdictions(world: &mut ClawWorld, jurisdictions: String) {
+    world.compliance_config = ComplianceConfig {
+        enabled: true,
+        blocked_jurisdictions: jurisdictions
+            .split(',')
+            .map(|s| s.trim().to_string())
+            .collect(),
+        ..ComplianceConfig::default()
+    };
+    world.compliance_engine = None;
+}
+
+#[given(expr = "compliance is enabled with KYT threshold of {int} cents")]
+fn compliance_with_kyt(world: &mut ClawWorld, threshold: u64) {
+    world.compliance_config = ComplianceConfig {
+        enabled: true,
+        kyt_threshold_cents: threshold,
+        ..ComplianceConfig::default()
+    };
+    world.compliance_engine = None;
+}
+
+#[given("compliance is disabled")]
+fn compliance_disabled(world: &mut ClawWorld) {
+    world.compliance_config = ComplianceConfig {
+        enabled: false,
+        ..ComplianceConfig::default()
+    };
+    world.compliance_engine = None;
+}
+
+#[given(expr = "the OFAC SDN list contains wallet {string}")]
+fn ofac_add_wallet(world: &mut ClawWorld, wallet: String) {
+    world.ofac_blocked_wallets.push(wallet);
+    // Ensure compliance is enabled when using OFAC lists
+    world.compliance_config.enabled = true;
+    world.compliance_engine = None;
+}
+
+#[given(expr = "the OFAC SDN list contains DID {string}")]
+fn ofac_add_did(world: &mut ClawWorld, did: String) {
+    world.ofac_blocked_dids.push(did);
+    // Ensure compliance is enabled when using OFAC lists
+    world.compliance_config.enabled = true;
+    world.compliance_engine = None;
+}
+
+#[when(expr = "a task is proposed with counterparty {string} in jurisdiction {string}")]
+async fn propose_task_jurisdiction(world: &mut ClawWorld, did: String, jurisdiction: String) {
+    world.ensure_compliance_engine().await;
+    let engine = world.compliance_engine.as_ref().unwrap();
+    world.compliance_results = engine
+        .pre_task_screen(&did, None, Some(&jurisdiction), 100)
+        .await;
+    world.compliance_checked = true;
+}
+
+#[when(expr = "a task involves wallet {string} for {int} cents")]
+async fn propose_task_wallet(world: &mut ClawWorld, wallet: String, cents: u64) {
+    world.ensure_compliance_engine().await;
+    let engine = world.compliance_engine.as_ref().unwrap();
+    world.compliance_results = engine
+        .pre_task_screen("did:web:test", Some(&wallet), Some("US"), cents)
+        .await;
+    world.compliance_checked = true;
+}
+
+#[when(expr = "a task is proposed for {int} cents")]
+async fn propose_task_amount(world: &mut ClawWorld, cents: u64) {
+    world.ensure_compliance_engine().await;
+    let engine = world.compliance_engine.as_ref().unwrap();
+    world.compliance_results = engine
+        .pre_task_screen("did:web:test", None, Some("US"), cents)
+        .await;
+    world.compliance_checked = true;
+}
+
+#[then("the compliance check should hard-block")]
+fn compliance_blocks(world: &mut ClawWorld) {
+    assert!(
+        world.compliance_checked,
+        "no compliance check was performed"
+    );
+    assert!(
+        ComplianceEngine::has_hard_block(&world.compliance_results),
+        "expected hard block, got: {:?}",
+        world.compliance_results
+    );
+}
+
+#[then("the compliance check should pass")]
+fn compliance_passes(world: &mut ClawWorld) {
+    assert!(
+        world.compliance_checked,
+        "no compliance check was performed"
+    );
+    assert!(
+        !ComplianceEngine::has_hard_block(&world.compliance_results),
+        "expected pass, got hard block: {:?}",
+        world.compliance_results
+    );
+}
+
+#[then("the compliance result should require enhanced due diligence")]
+fn compliance_requires_edd(world: &mut ClawWorld) {
+    assert!(
+        world
+            .compliance_results
+            .iter()
+            .any(|r| r.requires_enhanced_dd()),
+        "expected KYT required, got: {:?}",
+        world.compliance_results
+    );
+}
+
+#[then("the compliance result should not require enhanced due diligence")]
+fn compliance_no_edd(world: &mut ClawWorld) {
+    assert!(
+        !world
+            .compliance_results
+            .iter()
+            .any(|r| r.requires_enhanced_dd()),
+        "expected no KYT, got: {:?}",
+        world.compliance_results
+    );
+}
+
+#[then(expr = "Travel Rule data is required for {int} cents")]
+async fn travel_rule_required(world: &mut ClawWorld, cents: u64) {
+    world.ensure_compliance_engine().await;
+    let engine = world.compliance_engine.as_ref().unwrap();
+    assert!(
+        engine.requires_travel_rule(cents),
+        "expected Travel Rule required for {} cents",
+        cents
+    );
+}
+
+#[then(expr = "Travel Rule data is not required for {int} cents")]
+async fn travel_rule_not_required(world: &mut ClawWorld, cents: u64) {
+    world.ensure_compliance_engine().await;
+    let engine = world.compliance_engine.as_ref().unwrap();
+    assert!(
+        !engine.requires_travel_rule(cents),
+        "expected Travel Rule NOT required for {} cents",
+        cents
+    );
+}
+
+// =============================================================================
+// PAYMENT ADAPTER STEPS
+// =============================================================================
+
+#[given(expr = "the token is USDC with {int} decimals")]
+fn set_token_usdc(world: &mut ClawWorld, _decimals: u32) {
+    world.token = Some(TokenInfo::usdc_base());
+}
+
+#[given(expr = "the token is DAI with {int} decimals")]
+fn set_token_dai(world: &mut ClawWorld, _decimals: u32) {
+    world.token = Some(TokenInfo::dai_mainnet());
+}
+
+#[given("a Stripe stub payment adapter")]
+fn set_stripe_adapter(world: &mut ClawWorld) {
+    // adapter created on-the-fly in when-step
+    let _ = world; // no state needed beyond marker
+}
+
+#[given("a noop payment adapter")]
+fn set_noop_adapter(world: &mut ClawWorld) {
+    world.use_noop_adapter = true;
+}
+
+#[when(expr = "converting {int} cents to base units")]
+fn convert_to_base(world: &mut ClawWorld, cents: u64) {
+    let token = world.token.as_ref().expect("token not set");
+    world.conversion_result = Some(token.cents_to_base_units(cents));
+}
+
+#[when(expr = "converting {int} cents to base units and back")]
+fn convert_round_trip(world: &mut ClawWorld, cents: u64) {
+    let token = world.token.as_ref().expect("token not set");
+    let base = token.cents_to_base_units(cents);
+    let back = token.base_units_to_cents(base);
+    world.round_trip_cents = Some(back);
+}
+
+#[when(expr = "settling a receipt for {int} cents")]
+async fn settle_receipt(world: &mut ClawWorld, cents: u64) {
+    // Use the adapter type marker set by Given steps
+    let adapter: Box<dyn PaymentAdapter> = if world.use_noop_adapter {
+        Box::new(NoopAdapter)
+    } else {
+        Box::new(StripeStubAdapter::new_stub())
+    };
+    let path = adapter
+        .resolve_settlement_path("did:web:test")
+        .await
+        .unwrap();
+    let result = adapter.settle("{}", cents, &path).await.unwrap();
+    world.settlement_path = Some(path);
+    world.payment_result = Some(result);
+}
+
+#[then(expr = "the result should be {int} base units")]
+fn check_base_units(world: &mut ClawWorld, expected: u128) {
+    let actual = world.conversion_result.expect("no conversion result");
+    assert_eq!(
+        actual, expected,
+        "expected {} base units, got {}",
+        expected, actual
+    );
+}
+
+#[then(expr = "the round-trip result should equal {int} cents")]
+fn check_round_trip(world: &mut ClawWorld, expected: u64) {
+    let actual = world.round_trip_cents.expect("no round-trip result");
+    assert_eq!(actual, expected);
+}
+
+#[then("the settlement should succeed")]
+fn settlement_succeeds(world: &mut ClawWorld) {
+    let result = world.payment_result.as_ref().expect("no payment result");
+    assert!(result.success, "settlement failed: {}", result.message);
+}
+
+#[then(expr = "the settled amount should be {int} cents")]
+fn check_settled_amount(world: &mut ClawWorld, expected: u64) {
+    let result = world.payment_result.as_ref().expect("no payment result");
+    assert_eq!(result.settled_cents, expected);
+}
+
+#[then(expr = "the settlement path should be {string}")]
+fn check_settlement_path(world: &mut ClawWorld, expected: String) {
+    let path = world.settlement_path.as_ref().expect("no settlement path");
+    let path_str = format!("{:?}", path);
+    assert!(
+        path_str.contains(&expected),
+        "expected path containing '{}', got: {}",
+        expected,
+        path_str
+    );
+}
+
+// =============================================================================
+// RECEIPT PRIVACY STEPS
+// =============================================================================
+
+#[given(expr = "redaction level is {string}")]
+fn set_redaction_level(world: &mut ClawWorld, level: String) {
+    world.redaction_level = Some(level.parse().expect("invalid redaction level"));
+}
+
+#[when(expr = "redacting binary {string}")]
+fn redact_binary(world: &mut ClawWorld, binary: String) {
+    let level = world.redaction_level.expect("redaction level not set");
+    let redactor = ReceiptRedactor::new(level);
+    world.redacted_result = Some(redactor.redact_binary(&binary));
+}
+
+#[when(expr = "redacting URL {string}")]
+fn redact_url(world: &mut ClawWorld, url: String) {
+    let level = world.redaction_level.expect("redaction level not set");
+    let redactor = ReceiptRedactor::new(level);
+    world.redacted_result = Some(redactor.redact_url(&url));
+}
+
+#[then(expr = "the result should be {string}")]
+fn check_redacted_result(world: &mut ClawWorld, expected: String) {
+    let actual = world.redacted_result.as_ref().expect("no redacted result");
+    assert_eq!(
+        actual, &expected,
+        "expected '{}', got '{}'",
+        expected, actual
+    );
+}
+
+#[then("arguments should be hash-only")]
+fn args_hash_only(world: &mut ClawWorld) {
+    let level = world.redaction_level.expect("redaction level not set");
+    let redactor = ReceiptRedactor::new(level);
+    assert!(
+        redactor.should_redact_args(),
+        "args must be hash-only at {:?}",
+        level
+    );
+}
+
+// =============================================================================
+// FULL PIPELINE STEPS
+// =============================================================================
+
+#[given(expr = "the spend limit is {int} cents per mandate")]
+fn pipeline_spend_limit(world: &mut ClawWorld, cents: u64) {
+    world.spend_limits.per_mandate_cents = cents;
+    world.spend_tracker = None;
+}
+
+#[given(expr = "compliance is enabled with {word} jurisdiction allowed")]
+fn pipeline_compliance_allowed(world: &mut ClawWorld, _jurisdiction: String) {
+    world.compliance_config = ComplianceConfig {
+        enabled: true,
+        ..ComplianceConfig::default()
+    };
+    world.compliance_engine = None;
+}
+
+#[given(expr = "compliance is enabled with {word} jurisdiction blocked")]
+fn pipeline_compliance_blocked(world: &mut ClawWorld, jurisdiction: String) {
+    world.compliance_config = ComplianceConfig {
+        enabled: true,
+        blocked_jurisdictions: vec![jurisdiction],
+        ..ComplianceConfig::default()
+    };
+    world.compliance_engine = None;
+}
+
+#[when(expr = "agent {string} in {string} proposes a {int}-cent task")]
+async fn pipeline_propose(world: &mut ClawWorld, did: String, jurisdiction: String, cents: u64) {
+    // Step 1: Compliance
+    world.ensure_compliance_engine().await;
+    let engine = world.compliance_engine.as_ref().unwrap();
+    world.compliance_results = engine
+        .pre_task_screen(&did, None, Some(&jurisdiction), cents)
+        .await;
+    world.compliance_checked = true;
+    world.pipeline_compliance_passed = !ComplianceEngine::has_hard_block(&world.compliance_results);
+
+    if !world.pipeline_compliance_passed {
+        return;
+    }
+
+    // Step 2: Spend check
+    world.ensure_tracker();
+    let tracker = world.spend_tracker.as_ref().unwrap();
+    let spend_result = tracker.check_spend(cents, Some(&did)).await;
+    world.pipeline_spend_passed = spend_result.is_ok();
+    world.spend_result = Some(spend_result);
+
+    if !world.pipeline_spend_passed {
+        return;
+    }
+
+    // Step 3: Settle
+    let adapter = StripeStubAdapter::new_stub();
+    let path = adapter.resolve_settlement_path(&did).await.unwrap();
+    let result = adapter.settle("{}", cents, &path).await.unwrap();
+    world.pipeline_settled = result.success;
+    world.pipeline_settled_amount = result.settled_cents;
+    world.payment_result = Some(result);
+}
+
+#[then("compliance screening passes")]
+fn pipeline_compliance_passes(world: &mut ClawWorld) {
+    assert!(
+        world.pipeline_compliance_passed,
+        "compliance was expected to pass but blocked: {:?}",
+        world.compliance_results
+    );
+}
+
+#[then("compliance screening blocks the task")]
+fn pipeline_compliance_blocks(world: &mut ClawWorld) {
+    assert!(
+        !world.pipeline_compliance_passed,
+        "compliance was expected to block but passed"
+    );
+}
+
+#[then("the spend check passes")]
+fn pipeline_spend_passes(world: &mut ClawWorld) {
+    assert!(
+        world.pipeline_spend_passed,
+        "spend check was expected to pass"
+    );
+}
+
+#[then(expr = "the spend check fails with {string}")]
+fn pipeline_spend_fails(world: &mut ClawWorld, violation_type: String) {
+    assert!(
+        !world.pipeline_spend_passed,
+        "spend check passed unexpectedly"
+    );
+    if let Some(Err(err)) = &world.spend_result {
+        let err_debug = format!("{:?}", err);
+        assert!(
+            err_debug.starts_with(&violation_type),
+            "expected {} violation, got: {}",
+            violation_type,
+            err_debug
+        );
+    }
+}
+
+#[then(expr = "settlement succeeds for {int} cents")]
+fn pipeline_settlement_ok(world: &mut ClawWorld, cents: u64) {
+    assert!(world.pipeline_settled, "settlement did not occur");
+    assert_eq!(world.pipeline_settled_amount, cents);
+}
+
+#[then("no settlement occurs")]
+fn pipeline_no_settlement(world: &mut ClawWorld) {
+    assert!(
+        !world.pipeline_settled,
+        "settlement occurred but was not expected"
+    );
+}
+
+#[then(expr = "the binary {string} is redacted to {string}")]
+fn pipeline_redact_check(world: &mut ClawWorld, binary: String, expected: String) {
+    let level = world.redaction_level.unwrap_or(RedactionLevel::External);
+    let redactor = ReceiptRedactor::new(level);
+    let actual = redactor.redact_binary(&binary);
+    assert_eq!(actual, expected);
+}
+
+// =============================================================================
+// MAIN — cucumber runner
+// =============================================================================
+
+fn main() {
+    let runner = ClawWorld::cucumber().max_concurrent_scenarios(Some(4));
+
+    // Run synchronously (cucumber handles its own async runtime)
+    futures::executor::block_on(runner.run("tests/features/"));
+}

--- a/cognitod/tests/features/compliance.feature
+++ b/cognitod/tests/features/compliance.feature
@@ -1,0 +1,64 @@
+Feature: Compliance Screening (§10.3)
+  As a regulated platform operator
+  I want sanctions screening, KYT thresholds, and jurisdiction blocks
+  So that agent commerce complies with financial regulations
+
+  # ── Jurisdiction Blocks ──
+
+  Scenario: Block transaction with sanctioned jurisdiction
+    Given compliance is enabled with blocked jurisdictions "KP,IR,CU,SY"
+    When a task is proposed with counterparty "did:web:nk-agent" in jurisdiction "KP"
+    Then the compliance check should hard-block
+
+  Scenario: Allow transaction from permitted jurisdiction
+    Given compliance is enabled with blocked jurisdictions "KP,IR,CU,SY"
+    When a task is proposed with counterparty "did:web:us-agent" in jurisdiction "US"
+    Then the compliance check should pass
+
+  Scenario: Jurisdiction check is case-insensitive
+    Given compliance is enabled with blocked jurisdictions "KP,IR,CU,SY"
+    When a task is proposed with counterparty "did:web:ir-agent" in jurisdiction "ir"
+    Then the compliance check should hard-block
+
+  # ── OFAC SDN Screening ──
+
+  Scenario: Block a wallet on the OFAC SDN list
+    Given the OFAC SDN list contains wallet "0xbadwallet123"
+    When a task involves wallet "0xBadWallet123" for 100 cents
+    Then the compliance check should hard-block
+
+  Scenario: Clear a wallet not on any list
+    Given the OFAC SDN list contains wallet "0xbadwallet123"
+    When a task involves wallet "0xgoodwallet456" for 100 cents
+    Then the compliance check should pass
+
+  Scenario: Block a DID on the OFAC SDN list
+    Given the OFAC SDN list contains DID "did:web:sanctioned-entity.kp"
+    When a task is proposed with counterparty "did:web:sanctioned-entity.kp" in jurisdiction "US"
+    Then the compliance check should hard-block
+
+  # ── KYT (Know Your Transaction) ──
+
+  Scenario: Trigger KYT for high-value transaction
+    Given compliance is enabled with KYT threshold of 300000 cents
+    When a task is proposed for 300000 cents
+    Then the compliance result should require enhanced due diligence
+
+  Scenario: No KYT for transaction below threshold
+    Given compliance is enabled with KYT threshold of 300000 cents
+    When a task is proposed for 299999 cents
+    Then the compliance result should not require enhanced due diligence
+
+  # ── Travel Rule ──
+
+  Scenario: Travel Rule required at $3,000
+    Given compliance is enabled with KYT threshold of 300000 cents
+    Then Travel Rule data is required for 300000 cents
+    But Travel Rule data is not required for 299999 cents
+
+  # ── Compliance Disabled ──
+
+  Scenario: All checks pass when compliance is disabled
+    Given compliance is disabled
+    When a task is proposed with counterparty "did:web:evil.kp" in jurisdiction "KP"
+    Then the compliance check should pass

--- a/cognitod/tests/features/full_pipeline.feature
+++ b/cognitod/tests/features/full_pipeline.feature
@@ -1,0 +1,30 @@
+Feature: Full Agent Commerce Pipeline
+  As an AI agent platform
+  I want spend checks, compliance screening, settlement, and privacy
+  to work together as a single pipeline
+  So that each transaction is safe, legal, and private
+
+  Scenario: Honest task succeeds end-to-end
+    Given the spend limit is 5000 cents per mandate
+    And compliance is enabled with US jurisdiction allowed
+    And redaction level is "external"
+    When agent "did:web:vendor.com" in "US" proposes a 1500-cent task
+    Then compliance screening passes
+    And the spend check passes
+    And settlement succeeds for 1500 cents
+    And the binary "/usr/bin/curl" is redacted to "curl"
+
+  Scenario: Sanctioned jurisdiction blocks the entire pipeline
+    Given the spend limit is 5000 cents per mandate
+    And compliance is enabled with KP jurisdiction blocked
+    When agent "did:web:evil.kp" in "KP" proposes a 100-cent task
+    Then compliance screening blocks the task
+    And no settlement occurs
+
+  Scenario: Spend limit blocks after compliance passes
+    Given the spend limit is 5000 cents per mandate
+    And compliance is enabled with US jurisdiction allowed
+    When agent "did:web:vendor.com" in "US" proposes a 6000-cent task
+    Then compliance screening passes
+    But the spend check fails with "PerMandate"
+    And no settlement occurs

--- a/cognitod/tests/features/payment.feature
+++ b/cognitod/tests/features/payment.feature
@@ -1,0 +1,46 @@
+Feature: Payment Adapter & Amount Conversion (§8)
+  As an agent commerce platform
+  I want correct conversion between USD cents and token base units
+  So that on-chain settlements match off-chain accounting
+
+  # ── USDC (6 decimals) ──
+
+  Scenario Outline: USDC cent-to-base-unit conversion
+    Given the token is USDC with 6 decimals
+    When converting <cents> cents to base units
+    Then the result should be <base_units> base units
+
+    Examples:
+      | cents  | base_units   |
+      | 1      | 10000        |
+      | 15     | 150000       |
+      | 100    | 1000000      |
+      | 5000   | 50000000     |
+
+  # ── DAI (18 decimals) ──
+
+  Scenario: DAI 18-decimal conversion
+    Given the token is DAI with 18 decimals
+    When converting 100 cents to base units
+    Then the result should be 1000000000000000000 base units
+
+  # ── Round-trip ──
+
+  Scenario: USDC round-trip conversion preserves value
+    Given the token is USDC with 6 decimals
+    When converting 4215 cents to base units and back
+    Then the round-trip result should equal 4215 cents
+
+  # ── Settlement Adapters ──
+
+  Scenario: Stripe stub settles successfully
+    Given a Stripe stub payment adapter
+    When settling a receipt for 1500 cents
+    Then the settlement should succeed
+    And the settled amount should be 1500 cents
+
+  Scenario: Noop adapter for offline mode
+    Given a noop payment adapter
+    When settling a receipt for 999 cents
+    Then the settlement should succeed
+    And the settlement path should be "Manual"

--- a/cognitod/tests/features/receipt_privacy.feature
+++ b/cognitod/tests/features/receipt_privacy.feature
@@ -1,0 +1,67 @@
+Feature: Receipt Privacy & Redaction (§10.4)
+  As a privacy-conscious operator
+  I want configurable redaction levels for execution receipts
+  So that sensitive operational details are not leaked to counterparties
+
+  # ── Redaction Level: None ──
+
+  Scenario: No redaction exposes full binary path
+    Given redaction level is "none"
+    When redacting binary "/usr/bin/curl"
+    Then the result should be "/usr/bin/curl"
+
+  Scenario: No redaction exposes full URL
+    Given redaction level is "none"
+    When redacting URL "https://api.secret.com/v1/data?key=abc"
+    Then the result should be "https://api.secret.com/v1/data?key=abc"
+
+  # ── Redaction Level: External (default) ──
+
+  Scenario: External redaction shows basename only
+    Given redaction level is "external"
+    When redacting binary "/usr/bin/curl"
+    Then the result should be "curl"
+
+  Scenario: External redaction extracts domain from URL
+    Given redaction level is "external"
+    When redacting URL "https://api.secret.com/v1/data?key=abc"
+    Then the result should be "api.secret.com"
+
+  # ── Redaction Level: Full ──
+
+  Scenario: Full redaction classifies curl as network_transfer
+    Given redaction level is "full"
+    When redacting binary "/usr/bin/curl"
+    Then the result should be "network_transfer"
+
+  Scenario: Full redaction classifies python3 as interpreter_execution
+    Given redaction level is "full"
+    When redacting binary "/usr/bin/python3"
+    Then the result should be "interpreter_execution"
+
+  Scenario: Full redaction classifies docker as container_tool
+    Given redaction level is "full"
+    When redacting binary "/usr/local/bin/docker"
+    Then the result should be "container_tool"
+
+  Scenario: Full redaction replaces URL with [redacted]
+    Given redaction level is "full"
+    When redacting URL "https://api.secret.com/v1/data"
+    Then the result should be "[redacted]"
+
+  Scenario: Full redaction classifies unknown binary as tool_execution
+    Given redaction level is "full"
+    When redacting binary "/opt/custom/my-proprietary-agent"
+    Then the result should be "tool_execution"
+
+  # ── Args are always hash-only ──
+
+  Scenario Outline: Arguments are always hash-only regardless of level
+    Given redaction level is "<level>"
+    Then arguments should be hash-only
+
+    Examples:
+      | level    |
+      | none     |
+      | external |
+      | full     |

--- a/cognitod/tests/features/spend_controls.feature
+++ b/cognitod/tests/features/spend_controls.feature
@@ -1,0 +1,79 @@
+Feature: Spend Controls (§9)
+  As a platform operator
+  I want configurable spending limits on agent commerce
+  So that a compromised or buggy agent cannot drain funds
+
+  Background:
+    Given the default spend limits are configured
+      | limit             | value  |
+      | per_mandate_cents | 5000   |
+      | daily_cents       | 50000  |
+      | monthly_cents     | 500000 |
+
+  # ── Per-Mandate Limits ──
+
+  Scenario: Allow a spend within the per-mandate limit
+    When an agent requests a mandate for 4999 cents
+    Then the spend check should pass
+
+  Scenario: Block a spend exceeding the per-mandate limit
+    When an agent requests a mandate for 5001 cents
+    Then the spend check should fail with "PerMandate"
+
+  Scenario: Exactly at the per-mandate limit is allowed
+    When an agent requests a mandate for 5000 cents
+    Then the spend check should pass
+
+  # ── Daily Aggregate Limits ──
+
+  Scenario: Accumulate daily spend and block at threshold
+    Given 48000 cents have already been spent today
+    When an agent requests a mandate for 3000 cents
+    Then the spend check should fail with "Daily"
+
+  Scenario: Daily spend just under the limit passes
+    Given 48000 cents have already been spent today
+    When an agent requests a mandate for 2000 cents
+    Then the spend check should pass
+
+  # ── Monthly Aggregate Limits ──
+
+  Scenario: Allow spend just under monthly ceiling
+    Given 495000 cents have already been spent this month
+    When an agent requests a mandate for 5000 cents
+    Then the spend check should pass
+
+  Scenario: Block spend that exceeds monthly ceiling
+    Given 495000 cents have already been spent this month
+    And 5000 cents have already been spent today
+    When an agent requests a mandate for 1 cents
+    Then the spend check should fail with "Monthly"
+
+  # ── Per-Agent Overrides ──
+
+  Scenario: Restrict an untrusted agent to lower daily limit
+    Given a per-agent override for "did:web:untrusted.io" of 1000 cents daily
+    And the agent "did:web:untrusted.io" has spent 900 cents today
+    When "did:web:untrusted.io" requests a mandate for 200 cents
+    Then the spend check should fail with "PerAgentDaily"
+
+  Scenario: Trusted agent is unaffected by untrusted override
+    Given a per-agent override for "did:web:untrusted.io" of 1000 cents daily
+    And the agent "did:web:untrusted.io" has spent 900 cents today
+    When "did:web:trusted.io" requests a mandate for 4000 cents
+    Then the spend check should pass
+
+  # ── Zero and Edge Cases ──
+
+  Scenario: Zero-cent mandate is always allowed
+    Given 49999 cents have already been spent today
+    When an agent requests a mandate for 0 cents
+    Then the spend check should pass
+
+  # ── Hourly Limit ──
+
+  Scenario: Hourly limit blocks burst spending
+    Given an hourly limit of 10000 cents is configured
+    And 9500 cents have been spent in the last hour
+    When an agent requests a mandate for 600 cents
+    Then the spend check should fail with "Hourly"

--- a/cognitod/tests/mandate_lsm.rs
+++ b/cognitod/tests/mandate_lsm.rs
@@ -34,6 +34,9 @@ async fn create_and_retrieve_mandate() {
         monitor_only: false,
         task_id: None,
         max_spend_cents: None,
+        counterparty_did: None,
+        wallet_address: None,
+        jurisdiction: None,
     };
 
     let resp = mgr.create(req).await.expect("create must succeed");
@@ -61,6 +64,9 @@ async fn revoke_mandate() {
         monitor_only: false,
         task_id: None,
         max_spend_cents: None,
+        counterparty_did: None,
+        wallet_address: None,
+        jurisdiction: None,
     };
 
     let resp = mgr.create(req).await.unwrap();
@@ -117,6 +123,9 @@ async fn stats_reflect_creates_and_revokes() {
         monitor_only: false,
         task_id: None,
         max_spend_cents: None,
+        counterparty_did: None,
+        wallet_address: None,
+        jurisdiction: None,
     };
 
     // Create 3 mandates (different args to get distinct keys)
@@ -130,6 +139,9 @@ async fn stats_reflect_creates_and_revokes() {
         monitor_only: false,
         task_id: None,
         max_spend_cents: None,
+        counterparty_did: None,
+        wallet_address: None,
+        jurisdiction: None,
     };
     let _r2 = mgr.create(req2).await.unwrap();
 
@@ -141,6 +153,9 @@ async fn stats_reflect_creates_and_revokes() {
         monitor_only: false,
         task_id: None,
         max_spend_cents: None,
+        counterparty_did: None,
+        wallet_address: None,
+        jurisdiction: None,
     };
     let _r3 = mgr.create(req3).await.unwrap();
 
@@ -184,6 +199,9 @@ async fn list_filters_by_status() {
         monitor_only: false,
         task_id: None,
         max_spend_cents: None,
+        counterparty_did: None,
+        wallet_address: None,
+        jurisdiction: None,
     };
     let resp = mgr.create(req).await.unwrap();
 
@@ -195,6 +213,9 @@ async fn list_filters_by_status() {
         monitor_only: false,
         task_id: None,
         max_spend_cents: None,
+        counterparty_did: None,
+        wallet_address: None,
+        jurisdiction: None,
     };
     let _resp2 = mgr.create(req2).await.unwrap();
 
@@ -230,6 +251,9 @@ async fn reconcile_removes_expired() {
         monitor_only: false,
         task_id: None,
         max_spend_cents: None,
+        counterparty_did: None,
+        wallet_address: None,
+        jurisdiction: None,
     };
     mgr.create(req).await.unwrap();
 
@@ -264,6 +288,9 @@ async fn monitor_only_sets_flag() {
         monitor_only: true,
         task_id: None,
         max_spend_cents: None,
+        counterparty_did: None,
+        wallet_address: None,
+        jurisdiction: None,
     };
     let resp = mgr.create(req).await.unwrap();
     assert_eq!(resp.status, MandateStatus::Active);
@@ -284,6 +311,9 @@ async fn multiple_mandates_same_pid_different_args() {
         monitor_only: false,
         task_id: None,
         max_spend_cents: None,
+        counterparty_did: None,
+        wallet_address: None,
+        jurisdiction: None,
     };
     let req2 = MandateRequest {
         pid,
@@ -293,6 +323,9 @@ async fn multiple_mandates_same_pid_different_args() {
         monitor_only: false,
         task_id: None,
         max_spend_cents: None,
+        counterparty_did: None,
+        wallet_address: None,
+        jurisdiction: None,
     };
 
     let r1 = mgr.create(req1).await.unwrap();

--- a/cognitod/tests/mandate_lsm.rs
+++ b/cognitod/tests/mandate_lsm.rs
@@ -1,0 +1,307 @@
+//! Integration tests for the Mandate subsystem.
+//!
+//! These tests exercise the MandateManager userspace logic: creating mandates,
+//! verifying hash consistency, reconciliation of expired entries, backpressure,
+//! and the API-level request/response cycle. Actual BPF map writes are skipped
+//! (bpf_available = false) since loading LSM programs requires root + CONFIG_BPF_LSM.
+
+use cognitod::mandate::{MandateManager, MandateRequest, MandateStatus};
+use linnix_ai_ebpf_common::MandateMode;
+use std::sync::Arc;
+
+/// Fixed test key so hashes are reproducible.
+const TEST_KEY: [u64; 2] = [0x0706050403020100, 0x0f0e0d0c0b0a0908];
+
+/// Use the current process PID so /proc/{pid}/stat is readable.
+fn self_pid() -> u32 {
+    std::process::id()
+}
+
+fn test_manager() -> Arc<MandateManager> {
+    Arc::new(MandateManager::new(TEST_KEY, false, MandateMode::Monitor))
+}
+
+#[tokio::test]
+async fn create_and_retrieve_mandate() {
+    let mgr = test_manager();
+    let pid = self_pid();
+
+    let req = MandateRequest {
+        pid,
+        args: vec!["/usr/bin/curl".into(), "https://api.example.com".into()],
+        ttl_ms: 5000,
+        container_id: None,
+        monitor_only: false,
+        task_id: None,
+        max_spend_cents: None,
+    };
+
+    let resp = mgr.create(req).await.expect("create must succeed");
+    assert_eq!(resp.status, MandateStatus::Active);
+    assert_eq!(resp.key.pid, pid);
+    assert!(resp.key.cmd_hash != 0, "cmd_hash should not be zero");
+    assert!(resp.expires_at_ms > 0, "expires_at_ms should be set");
+
+    // Retrieve by ID
+    let fetched = mgr.get(&resp.id).await.expect("mandate should exist");
+    assert_eq!(fetched.id, resp.id);
+    assert_eq!(fetched.key.cmd_hash, resp.key.cmd_hash);
+}
+
+#[tokio::test]
+async fn revoke_mandate() {
+    let mgr = test_manager();
+    let pid = self_pid();
+
+    let req = MandateRequest {
+        pid,
+        args: vec!["/bin/sh".into(), "-c".into(), "echo hello".into()],
+        ttl_ms: 60_000,
+        container_id: None,
+        monitor_only: false,
+        task_id: None,
+        max_spend_cents: None,
+    };
+
+    let resp = mgr.create(req).await.unwrap();
+    mgr.revoke(&resp.id).await.expect("revoke must succeed");
+
+    let fetched = mgr
+        .get(&resp.id)
+        .await
+        .expect("revoked mandate still exists");
+    assert_eq!(fetched.status, MandateStatus::Revoked);
+}
+
+#[tokio::test]
+async fn revoke_nonexistent_returns_error() {
+    let mgr = test_manager();
+    let result = mgr.revoke("nonexistent-id").await;
+    assert!(result.is_err(), "revoking unknown mandate should fail");
+}
+
+#[tokio::test]
+async fn hash_determinism() {
+    let mgr = test_manager();
+
+    let args = vec!["/usr/bin/python3".into(), "script.py".into()];
+    let h1 = mgr.hash_args(&args);
+    let h2 = mgr.hash_args(&args);
+    assert_eq!(h1, h2, "same args must produce identical hashes");
+
+    // Different args → different hash
+    let args2 = vec!["/usr/bin/python3".into(), "other.py".into()];
+    let h3 = mgr.hash_args(&args2);
+    assert_ne!(h1, h3, "different args must produce different hashes");
+}
+
+#[tokio::test]
+async fn hash_canonicalization_order_matters() {
+    let mgr = test_manager();
+
+    let h1 = mgr.hash_args(&["a".into(), "b".into()]);
+    let h2 = mgr.hash_args(&["b".into(), "a".into()]);
+    assert_ne!(h1, h2, "arg order must affect hash");
+}
+
+#[tokio::test]
+async fn stats_reflect_creates_and_revokes() {
+    let mgr = test_manager();
+    let pid = self_pid();
+
+    let req = MandateRequest {
+        pid,
+        args: vec!["/bin/ls".into()],
+        ttl_ms: 10_000,
+        container_id: None,
+        monitor_only: false,
+        task_id: None,
+        max_spend_cents: None,
+    };
+
+    // Create 3 mandates (different args to get distinct keys)
+    let r1 = mgr.create(req.clone()).await.unwrap();
+
+    let req2 = MandateRequest {
+        pid,
+        args: vec!["/bin/cat".into()],
+        ttl_ms: 10_000,
+        container_id: None,
+        monitor_only: false,
+        task_id: None,
+        max_spend_cents: None,
+    };
+    let _r2 = mgr.create(req2).await.unwrap();
+
+    let req3 = MandateRequest {
+        pid,
+        args: vec!["/bin/echo".into()],
+        ttl_ms: 10_000,
+        container_id: None,
+        monitor_only: false,
+        task_id: None,
+        max_spend_cents: None,
+    };
+    let _r3 = mgr.create(req3).await.unwrap();
+
+    let stats = mgr.stats().await;
+    assert_eq!(stats.total_created, 3);
+    assert_eq!(stats.active_count, 3);
+
+    // Revoke one
+    mgr.revoke(&r1.id).await.unwrap();
+    let stats = mgr.stats().await;
+    assert_eq!(stats.active_count, 2);
+    assert_eq!(stats.total_revoked, 1);
+}
+
+#[tokio::test]
+async fn health_reports_monitor_mode() {
+    let mgr = test_manager();
+    let health = mgr.health();
+    assert_eq!(health.enforcement_mode, "monitor");
+    assert!(!health.bpf_lsm_loaded, "BPF LSM not loaded in test");
+    assert!(health.siphash_key_set);
+}
+
+#[tokio::test]
+async fn health_reports_enforce_mode() {
+    let mgr = Arc::new(MandateManager::new(TEST_KEY, false, MandateMode::Enforce));
+    let health = mgr.health();
+    assert_eq!(health.enforcement_mode, "enforce");
+}
+
+#[tokio::test]
+async fn list_filters_by_status() {
+    let mgr = test_manager();
+    let pid = self_pid();
+
+    let req = MandateRequest {
+        pid,
+        args: vec!["/bin/date".into()],
+        ttl_ms: 60_000,
+        container_id: None,
+        monitor_only: false,
+        task_id: None,
+        max_spend_cents: None,
+    };
+    let resp = mgr.create(req).await.unwrap();
+
+    let req2 = MandateRequest {
+        pid,
+        args: vec!["/bin/whoami".into()],
+        ttl_ms: 60_000,
+        container_id: None,
+        monitor_only: false,
+        task_id: None,
+        max_spend_cents: None,
+    };
+    let _resp2 = mgr.create(req2).await.unwrap();
+
+    mgr.revoke(&resp.id).await.unwrap();
+
+    let active = mgr.list(Some(MandateStatus::Active)).await;
+    assert_eq!(active.len(), 1);
+
+    let revoked = mgr.list(Some(MandateStatus::Revoked)).await;
+    assert_eq!(revoked.len(), 1);
+
+    let all = mgr.list(None).await;
+    assert_eq!(all.len(), 2);
+}
+
+#[tokio::test]
+async fn reconcile_removes_expired() {
+    // Create a mandate with 1ms TTL using a PID that will vanish.
+    // We fork a short-lived subprocess so /proc/{pid} disappears after exit.
+    let mgr = test_manager();
+
+    // Use a subprocess that exits immediately
+    let mut child = std::process::Command::new("/bin/true")
+        .spawn()
+        .expect("spawn /bin/true");
+    let child_pid = child.id();
+
+    let req = MandateRequest {
+        pid: child_pid,
+        args: vec!["/bin/true".into()],
+        ttl_ms: 1, // 1ms = immediate expiry
+        container_id: None,
+        monitor_only: false,
+        task_id: None,
+        max_spend_cents: None,
+    };
+    mgr.create(req).await.unwrap();
+
+    // Wait for child to exit and be reaped so /proc/{pid} disappears
+    child.wait().expect("wait on child");
+    tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+
+    let expired = mgr.reconcile().await;
+    assert!(
+        expired >= 1,
+        "at least one mandate should be reconciled as expired"
+    );
+
+    let stats = mgr.stats().await;
+    assert_eq!(
+        stats.active_count, 0,
+        "no active mandates after reconciliation"
+    );
+    assert!(stats.total_expired >= 1);
+}
+
+#[tokio::test]
+async fn monitor_only_sets_flag() {
+    let mgr = test_manager();
+    let pid = self_pid();
+
+    let req = MandateRequest {
+        pid,
+        args: vec!["/usr/bin/wget".into()],
+        ttl_ms: 5000,
+        container_id: None,
+        monitor_only: true,
+        task_id: None,
+        max_spend_cents: None,
+    };
+    let resp = mgr.create(req).await.unwrap();
+    assert_eq!(resp.status, MandateStatus::Active);
+    // The MandateValue FLAG_MONITOR bit is set internally; verified via
+    // the BPF map in production. In unit tests, creation succeeds.
+}
+
+#[tokio::test]
+async fn multiple_mandates_same_pid_different_args() {
+    let mgr = test_manager();
+    let pid = self_pid();
+
+    let req1 = MandateRequest {
+        pid,
+        args: vec!["/bin/a".into()],
+        ttl_ms: 5000,
+        container_id: None,
+        monitor_only: false,
+        task_id: None,
+        max_spend_cents: None,
+    };
+    let req2 = MandateRequest {
+        pid,
+        args: vec!["/bin/b".into()],
+        ttl_ms: 5000,
+        container_id: None,
+        monitor_only: false,
+        task_id: None,
+        max_spend_cents: None,
+    };
+
+    let r1 = mgr.create(req1).await.unwrap();
+    let r2 = mgr.create(req2).await.unwrap();
+
+    // Different cmd_hash → different map keys → both allowed
+    assert_ne!(r1.key.cmd_hash, r2.key.cmd_hash);
+    assert_ne!(r1.id, r2.id);
+
+    let stats = mgr.stats().await;
+    assert_eq!(stats.active_count, 2);
+}

--- a/cognitod/tests/spend_controls.rs
+++ b/cognitod/tests/spend_controls.rs
@@ -1,0 +1,476 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// cognitod/tests/spend_controls.rs — Phase 4 integration tests
+//
+// Verifies the full spend control + compliance + privacy pipeline.
+
+use cognitod::compliance::{ComplianceEngine, OfacSdnProvider, StubScreeningProvider};
+use cognitod::config::{ComplianceConfig, PerAgentLimit, SpendLimitsConfig};
+use cognitod::payment::{
+    NoopAdapter, PaymentAdapter, SettlementPath, StripeStubAdapter, TokenInfo,
+};
+use cognitod::privacy::{ReceiptRedactor, RedactionLevel};
+use cognitod::spend::{SpendLimitViolation, SpendTracker};
+use std::collections::HashMap;
+
+// =============================================================================
+// §9 — Spend Control Engine
+// =============================================================================
+
+#[tokio::test]
+async fn spend_happy_path_within_all_limits() {
+    let tracker = SpendTracker::new(SpendLimitsConfig::default());
+    // $10 well within $50 per-mandate, $500 daily, $5000 monthly
+    assert!(tracker.check_spend(1000, None).await.is_ok());
+    tracker.record_spend(1000, None).await;
+    let totals = tracker.totals().await;
+    assert_eq!(totals.hourly_cents, 1000);
+    assert_eq!(totals.daily_cents, 1000);
+}
+
+#[tokio::test]
+async fn spend_per_mandate_boundary() {
+    let tracker = SpendTracker::new(SpendLimitsConfig {
+        per_mandate_cents: 5000,
+        ..SpendLimitsConfig::default()
+    });
+    // Exact limit: OK
+    assert!(tracker.check_spend(5000, None).await.is_ok());
+    // One cent over: blocked
+    let err = tracker.check_spend(5001, None).await.unwrap_err();
+    assert!(matches!(err, SpendLimitViolation::PerMandate { .. }));
+}
+
+#[tokio::test]
+async fn spend_daily_accumulation() {
+    let tracker = SpendTracker::new(SpendLimitsConfig {
+        per_mandate_cents: 50000, // raise to test daily
+        daily_cents: 10000,       // $100 daily
+        ..SpendLimitsConfig::default()
+    });
+    // Spend $80
+    tracker.record_spend(8000, None).await;
+    // $30 more would exceed $100
+    let err = tracker.check_spend(3000, None).await.unwrap_err();
+    assert!(matches!(err, SpendLimitViolation::Daily { .. }));
+    // $20 is fine
+    assert!(tracker.check_spend(2000, None).await.is_ok());
+}
+
+#[tokio::test]
+async fn spend_per_agent_isolation() {
+    let mut per_agent = HashMap::new();
+    per_agent.insert(
+        "did:web:cheap-agent.io".to_string(),
+        PerAgentLimit { daily_cents: 500 },
+    );
+    per_agent.insert(
+        "did:web:premium-agent.io".to_string(),
+        PerAgentLimit { daily_cents: 10000 },
+    );
+    let tracker = SpendTracker::new(SpendLimitsConfig {
+        per_mandate_cents: 50000,
+        daily_cents: 100000,
+        monthly_cents: 500000,
+        hourly_cents: None,
+        per_agent,
+    });
+
+    // Cheap agent: $4.50 spent → $1 more blocked
+    tracker
+        .record_spend(450, Some("did:web:cheap-agent.io".to_string()))
+        .await;
+    let err = tracker
+        .check_spend(100, Some("did:web:cheap-agent.io"))
+        .await
+        .unwrap_err();
+    assert!(matches!(err, SpendLimitViolation::PerAgentDaily { .. }));
+
+    // Premium agent: still has $100 budget
+    assert!(
+        tracker
+            .check_spend(9000, Some("did:web:premium-agent.io"))
+            .await
+            .is_ok()
+    );
+
+    // Unknown agent: no per-agent limit, uses global limits
+    assert!(
+        tracker
+            .check_spend(5000, Some("did:web:new-agent.io"))
+            .await
+            .is_ok()
+    );
+}
+
+#[tokio::test]
+async fn spend_gc_preserves_recent_records() {
+    let tracker = SpendTracker::new(SpendLimitsConfig::default());
+    tracker.record_spend(100, None).await;
+    tracker
+        .record_spend(200, Some("did:web:a".to_string()))
+        .await;
+    tracker.gc().await;
+    let totals = tracker.totals().await;
+    assert_eq!(totals.record_count, 2); // Recent records preserved
+}
+
+// =============================================================================
+// §8 — Payment Adapter & Amount Conversion
+// =============================================================================
+
+#[test]
+fn usdc_conversion_table() {
+    let usdc = TokenInfo::usdc_base();
+    let cases = [
+        (1u64, 10_000u128),       // 1 cent
+        (15, 150_000),            // $0.15
+        (100, 1_000_000),         // $1.00
+        (5000, 50_000_000),       // $50.00
+        (100_000, 1_000_000_000), // $1,000
+    ];
+    for (cents, expected_base) in cases {
+        assert_eq!(
+            usdc.cents_to_base_units(cents),
+            expected_base,
+            "cents={} failed",
+            cents
+        );
+        assert_eq!(
+            usdc.base_units_to_cents(expected_base),
+            cents,
+            "base_units={} failed",
+            expected_base
+        );
+    }
+}
+
+#[test]
+fn dai_18_decimal_conversion() {
+    let dai = TokenInfo::dai_mainnet();
+    // 1 cent = 10^16 base units (18 - 2 = 16)
+    assert_eq!(dai.cents_to_base_units(1), 10_000_000_000_000_000);
+    // $1 = 10^18 base units
+    assert_eq!(dai.cents_to_base_units(100), 1_000_000_000_000_000_000);
+}
+
+#[tokio::test]
+async fn stripe_stub_settles_successfully() {
+    let adapter = StripeStubAdapter::new_stub();
+    let path = adapter
+        .resolve_settlement_path("did:web:vendor.com")
+        .await
+        .unwrap();
+    assert!(matches!(path, SettlementPath::Webhook { .. }));
+
+    let result = adapter.settle("{}", 1500, &path).await.unwrap();
+    assert!(result.success);
+    assert_eq!(result.settled_cents, 1500);
+    assert!(result.reference.is_some());
+}
+
+#[tokio::test]
+async fn noop_adapter_for_offline_mode() {
+    let adapter = NoopAdapter;
+    let path = adapter
+        .resolve_settlement_path("did:web:any.com")
+        .await
+        .unwrap();
+    assert_eq!(path, SettlementPath::Manual);
+
+    let result = adapter.settle("{}", 999, &path).await.unwrap();
+    assert!(result.success);
+}
+
+// =============================================================================
+// §10.3 — Compliance Controls
+// =============================================================================
+
+#[tokio::test]
+async fn compliance_blocks_sanctioned_jurisdictions() {
+    let config = ComplianceConfig {
+        enabled: true,
+        blocked_jurisdictions: vec!["KP".to_string(), "IR".to_string()],
+        ..ComplianceConfig::default()
+    };
+    let engine = ComplianceEngine::new(config, Box::new(StubScreeningProvider));
+
+    // North Korea blocked
+    let results = engine
+        .pre_task_screen("did:web:nk-agent", None, Some("KP"), 100)
+        .await;
+    assert!(ComplianceEngine::has_hard_block(&results));
+
+    // US allowed
+    let results = engine
+        .pre_task_screen("did:web:us-agent", None, Some("US"), 100)
+        .await;
+    assert!(!ComplianceEngine::has_hard_block(&results));
+}
+
+#[tokio::test]
+async fn compliance_kyt_threshold_at_3000() {
+    let config = ComplianceConfig {
+        enabled: true,
+        kyt_threshold_cents: 300_000,
+        ..ComplianceConfig::default()
+    };
+    let engine = ComplianceEngine::new(config, Box::new(StubScreeningProvider));
+
+    // $2,999.99 → no KYT
+    let results = engine
+        .pre_task_screen("did:web:ok", None, Some("US"), 299_999)
+        .await;
+    assert!(!results.iter().any(|r| r.requires_enhanced_dd()));
+
+    // $3,000 → KYT required
+    let results = engine
+        .pre_task_screen("did:web:ok", None, Some("US"), 300_000)
+        .await;
+    assert!(results.iter().any(|r| r.requires_enhanced_dd()));
+}
+
+#[tokio::test]
+async fn compliance_ofac_blocks_sanctioned_wallet() {
+    let provider = OfacSdnProvider::new();
+    provider
+        .load_blocklist(vec!["0xbad_wallet".to_string()])
+        .await;
+    let config = ComplianceConfig {
+        enabled: true,
+        ..ComplianceConfig::default()
+    };
+    let engine = ComplianceEngine::new(config, Box::new(provider));
+
+    let results = engine
+        .pre_task_screen("did:web:ok", Some("0xBAD_WALLET"), Some("US"), 100)
+        .await;
+    assert!(ComplianceEngine::has_hard_block(&results));
+}
+
+#[tokio::test]
+async fn compliance_disabled_passes_everything() {
+    let config = ComplianceConfig {
+        enabled: false,
+        ..ComplianceConfig::default()
+    };
+    let engine = ComplianceEngine::new(config, Box::new(StubScreeningProvider));
+
+    let results = engine
+        .pre_task_screen("did:web:evil", None, Some("KP"), 999_999)
+        .await;
+    assert!(!ComplianceEngine::has_hard_block(&results));
+}
+
+#[tokio::test]
+async fn compliance_travel_rule_check() {
+    let config = ComplianceConfig {
+        enabled: true,
+        kyt_threshold_cents: 300_000,
+        ..ComplianceConfig::default()
+    };
+    let engine = ComplianceEngine::new(config, Box::new(StubScreeningProvider));
+    assert!(engine.requires_travel_rule(300_000));
+    assert!(engine.requires_travel_rule(1_000_000));
+    assert!(!engine.requires_travel_rule(299_999));
+}
+
+// =============================================================================
+// §10.4 — Receipt Privacy & Redaction
+// =============================================================================
+
+#[test]
+fn redaction_none_preserves_full_path() {
+    let r = ReceiptRedactor::new(RedactionLevel::None);
+    assert_eq!(r.redact_binary("/usr/bin/curl"), "/usr/bin/curl");
+    assert_eq!(
+        r.redact_url("https://api.secret.com/v1/data?key=abc123"),
+        "https://api.secret.com/v1/data?key=abc123"
+    );
+}
+
+#[test]
+fn redaction_external_shows_basename_only() {
+    let r = ReceiptRedactor::new(RedactionLevel::External);
+    assert_eq!(r.redact_binary("/usr/bin/curl"), "curl");
+    assert_eq!(r.redact_binary("/opt/custom/my-agent"), "my-agent");
+    assert_eq!(
+        r.redact_url("https://api.secret.com/v1/data?key=abc123"),
+        "api.secret.com"
+    );
+}
+
+#[test]
+fn redaction_full_shows_category() {
+    let r = ReceiptRedactor::new(RedactionLevel::Full);
+    assert_eq!(r.redact_binary("/usr/bin/curl"), "network_transfer");
+    assert_eq!(r.redact_binary("/usr/bin/python3"), "interpreter_execution");
+    assert_eq!(r.redact_binary("/usr/bin/docker"), "container_tool");
+    assert_eq!(r.redact_url("https://api.secret.com/v1/data"), "[redacted]");
+}
+
+#[test]
+fn redaction_args_always_hash_only() {
+    for level in [
+        RedactionLevel::None,
+        RedactionLevel::External,
+        RedactionLevel::Full,
+    ] {
+        let r = ReceiptRedactor::new(level);
+        assert!(
+            r.should_redact_args(),
+            "args must be hash-only at {:?}",
+            level
+        );
+    }
+}
+
+// =============================================================================
+// FULL PIPELINE: Spend + Compliance + Privacy together
+// =============================================================================
+
+#[tokio::test]
+async fn full_pipeline_honest_task() {
+    // 1. Compliance screening
+    let compliance = ComplianceEngine::new(
+        ComplianceConfig {
+            enabled: true,
+            ..ComplianceConfig::default()
+        },
+        Box::new(StubScreeningProvider),
+    );
+    let results = compliance
+        .pre_task_screen("did:web:vendor.com", None, Some("US"), 1500)
+        .await;
+    assert!(!ComplianceEngine::has_hard_block(&results));
+
+    // 2. Spend check
+    let tracker = SpendTracker::new(SpendLimitsConfig::default());
+    assert!(
+        tracker
+            .check_spend(1500, Some("did:web:vendor.com"))
+            .await
+            .is_ok()
+    );
+
+    // 3. Settle
+    let adapter = StripeStubAdapter::new_stub();
+    let path = adapter
+        .resolve_settlement_path("did:web:vendor.com")
+        .await
+        .unwrap();
+    let result = adapter.settle("{}", 1500, &path).await.unwrap();
+    assert!(result.success);
+
+    // 4. Record spend
+    tracker
+        .record_spend(1500, Some("did:web:vendor.com".to_string()))
+        .await;
+
+    // 5. Redact receipt
+    let redactor = ReceiptRedactor::new(RedactionLevel::External);
+    assert_eq!(redactor.redact_binary("/usr/bin/curl"), "curl");
+
+    // 6. Verify totals
+    let totals = tracker.totals().await;
+    assert_eq!(totals.daily_cents, 1500);
+}
+
+#[tokio::test]
+async fn full_pipeline_blocked_by_compliance() {
+    let compliance = ComplianceEngine::new(
+        ComplianceConfig {
+            enabled: true,
+            ..ComplianceConfig::default()
+        },
+        Box::new(StubScreeningProvider),
+    );
+    // Sanctioned jurisdiction
+    let results = compliance
+        .pre_task_screen("did:web:evil.kp", None, Some("KP"), 100)
+        .await;
+    assert!(ComplianceEngine::has_hard_block(&results));
+    // Pipeline aborts — no spend check, no settlement
+}
+
+#[tokio::test]
+async fn full_pipeline_blocked_by_spend_limit() {
+    let compliance = ComplianceEngine::new(
+        ComplianceConfig {
+            enabled: true,
+            ..ComplianceConfig::default()
+        },
+        Box::new(StubScreeningProvider),
+    );
+    // Compliance: OK
+    let results = compliance
+        .pre_task_screen("did:web:vendor.com", None, Some("US"), 100)
+        .await;
+    assert!(!ComplianceEngine::has_hard_block(&results));
+
+    // Spend: blocked (over per-mandate limit)
+    let tracker = SpendTracker::new(SpendLimitsConfig {
+        per_mandate_cents: 5000,
+        ..SpendLimitsConfig::default()
+    });
+    let err = tracker.check_spend(6000, Some("did:web:vendor.com")).await;
+    assert!(err.is_err());
+    // Pipeline aborts — no settlement
+}
+
+// =============================================================================
+// Config parsing integration
+// =============================================================================
+
+#[test]
+fn config_round_trip_spend_limits() {
+    let toml = r#"
+[spend_limits]
+per_mandate_cents = 10000
+daily_cents = 80000
+monthly_cents = 800000
+
+[spend_limits.per_agent."did:web:limited.io"]
+daily_cents = 2000
+"#;
+    let cfg: cognitod::Config = toml::from_str(toml).unwrap();
+    assert_eq!(cfg.spend_limits.per_mandate_cents, 10000);
+    assert_eq!(cfg.spend_limits.daily_cents, 80000);
+    assert_eq!(
+        cfg.spend_limits
+            .per_agent
+            .get("did:web:limited.io")
+            .unwrap()
+            .daily_cents,
+        2000
+    );
+}
+
+#[test]
+fn config_round_trip_compliance() {
+    let toml = r#"
+[compliance]
+enabled = true
+screening_provider = "chainalysis"
+kyt_threshold_cents = 500000
+blocked_jurisdictions = ["KP", "IR", "CU"]
+"#;
+    let cfg: cognitod::Config = toml::from_str(toml).unwrap();
+    assert!(cfg.compliance.enabled);
+    assert_eq!(cfg.compliance.screening_provider, "chainalysis");
+    assert_eq!(cfg.compliance.kyt_threshold_cents, 500000);
+}
+
+#[test]
+fn config_round_trip_receipt_privacy() {
+    let toml = r#"
+[receipt_privacy]
+redaction_level = "full"
+retention_days = 30
+encrypt_db = true
+"#;
+    let cfg: cognitod::Config = toml::from_str(toml).unwrap();
+    assert_eq!(cfg.receipt_privacy.redaction_level, "full");
+    assert_eq!(cfg.receipt_privacy.retention_days, 30);
+    assert!(cfg.receipt_privacy.encrypt_db);
+}

--- a/cognitod/tests/uds_listener.rs
+++ b/cognitod/tests/uds_listener.rs
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// cognitod/tests/uds_listener.rs — Unix domain socket integration tests
+//
+// Tests UDS config parsing, path creation, and socket permission semantics.
+
+use cognitod::config::{ApiConfig, Config};
+use std::os::unix::fs::{FileTypeExt, PermissionsExt};
+
+// =============================================================================
+// CONFIG TESTS
+// =============================================================================
+
+#[test]
+fn uds_config_defaults_to_none() {
+    let api = ApiConfig::default();
+    assert!(
+        api.unix_socket.is_none(),
+        "UDS should be disabled by default"
+    );
+}
+
+#[test]
+fn uds_config_parses_from_toml() {
+    let toml_str = r#"
+[api]
+listen_addr = "0.0.0.0:3000"
+unix_socket = "/var/run/linnix/cognitod.sock"
+"#;
+    let config: Config = toml::from_str(toml_str).expect("valid TOML");
+    assert_eq!(
+        config.api.unix_socket.as_deref(),
+        Some("/var/run/linnix/cognitod.sock")
+    );
+}
+
+#[test]
+fn uds_config_absent_field_is_none() {
+    let toml_str = r#"
+[api]
+listen_addr = "127.0.0.1:3000"
+"#;
+    let config: Config = toml::from_str(toml_str).expect("valid TOML");
+    assert!(config.api.unix_socket.is_none());
+}
+
+#[test]
+fn uds_config_round_trip() {
+    let api = ApiConfig {
+        listen_addr: "0.0.0.0:3000".to_string(),
+        auth_token: Some("secret".to_string()),
+        unix_socket: Some("/tmp/test.sock".to_string()),
+    };
+    let serialized = toml::to_string(&api).expect("serialize");
+    let back: ApiConfig = toml::from_str(&serialized).expect("deserialize");
+    assert_eq!(back.unix_socket.as_deref(), Some("/tmp/test.sock"));
+    assert_eq!(back.auth_token.as_deref(), Some("secret"));
+}
+
+// =============================================================================
+// UDS BIND + CONNECT (live socket test)
+// =============================================================================
+
+#[tokio::test]
+async fn uds_bind_and_connect_smoke() {
+    use tokio::net::UnixListener;
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let sock_path = dir.path().join("test.sock");
+
+    let listener = UnixListener::bind(&sock_path).expect("bind");
+
+    // Verify socket file exists with expected permissions
+    let meta = std::fs::metadata(&sock_path).expect("stat");
+    assert!(meta.file_type().is_socket());
+
+    // Set permissions like production code does
+    std::fs::set_permissions(&sock_path, std::fs::Permissions::from_mode(0o660)).unwrap();
+    let perms = std::fs::metadata(&sock_path).unwrap().permissions();
+    assert_eq!(perms.mode() & 0o777, 0o660);
+
+    // Connect and verify the listener accepts
+    let connect_handle = tokio::spawn({
+        let path = sock_path.clone();
+        async move { tokio::net::UnixStream::connect(path).await }
+    });
+
+    let (accepted, _addr) = listener.accept().await.expect("accept");
+    let connected = connect_handle.await.expect("join").expect("connect");
+
+    // Both sides should have valid streams
+    drop(accepted);
+    drop(connected);
+}
+
+#[tokio::test]
+async fn uds_stale_socket_cleanup() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let sock_path = dir.path().join("stale.sock");
+
+    // Create a stale socket file
+    let _first = tokio::net::UnixListener::bind(&sock_path).expect("first bind");
+    drop(_first);
+
+    // The file still exists after dropping the listener
+    assert!(sock_path.exists());
+
+    // Remove and re-bind — the pattern used in main.rs
+    let _ = std::fs::remove_file(&sock_path);
+    let _second = tokio::net::UnixListener::bind(&sock_path).expect("second bind after cleanup");
+    assert!(sock_path.exists());
+}
+
+// =============================================================================
+// NOTE: uds_routes() is defined in cognitod's binary (main.rs api module),
+// not lib.rs, so it can't be tested from integration tests directly.
+// The function is exercised at compile time and via the full daemon startup.
+// =============================================================================

--- a/configs/linnix.toml
+++ b/configs/linnix.toml
@@ -45,3 +45,11 @@ enabled = true
 [psi]
 # Duration in seconds of sustained pressure required to trigger attribution
 sustained_pressure_seconds = 15
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Linnix-Claw: Mandate Enforcement (Phase 0)
+# ─────────────────────────────────────────────────────────────────────────────
+[mandate]
+mode = "monitor"                    # "monitor" (log only) or "enforce" (block unauthorized)
+map_capacity = 65536                # max entries in BPF LRU mandate map
+allow_commerce_without_lsm = true   # allow mandate API even without BPF LSM kernel support

--- a/deny.toml
+++ b/deny.toml
@@ -18,6 +18,7 @@ allow = [
   "Unicode-3.0",
   "Zlib",                  # <- NEW: for foldhash
   "CDLA-Permissive-2.0",   # <- NEW: for webpki-roots
+  "CC0-1.0",               # Creative Commons Zero — tiny-keccak
 ]
 # (Optional) warn if you listed a license above that doesn't actually appear
 unused-allowed-license = "warn"

--- a/linnix-ai-ebpf/linnix-ai-ebpf-common/src/lib.rs
+++ b/linnix-ai-ebpf/linnix-ai-ebpf-common/src/lib.rs
@@ -264,7 +264,10 @@ pub struct TelemetryConfig {
     pub _reserved: u32,
     pub total_memory_bytes: u64,
     pub rss_source: u32,
-    pub _pad: u32,
+    /// Byte offset of `start_boottime` field in `task_struct`.
+    /// Used by LSM hooks to build the MandateKey uniquely per process
+    /// across PID recycling.  Discovered via BTF at daemon start.
+    pub task_start_boottime_offset: u32,
 }
 
 impl TelemetryConfig {
@@ -288,7 +291,7 @@ impl TelemetryConfig {
             _reserved: 0,
             total_memory_bytes: 0,
             rss_source: 0,
-            _pad: 0,
+            task_start_boottime_offset: 0,
         }
     }
 }
@@ -326,7 +329,108 @@ pub enum EventType {
     Syscall = 5,
     BlockIo = 6,
     PageFault = 7,
+    MandateAllow = 8,
+    MandateDeny = 9,
 }
+
+// =============================================================================
+// LINNIX-CLAW: MANDATE DATA STRUCTURES
+// =============================================================================
+//
+// Shared between kernel-space (BPF LSM programs) and user-space (cognitod).
+// These structs form the BPF map protocol for the mandate enforcement system.
+//
+// See docs/linnix-claw/specs.md §1.1 for full specification.
+
+/// Key for the MANDATE_MAP BPF LRU hash map.
+///
+/// 24 bytes, naturally aligned. The combination of `pid` + `start_time_ns`
+/// uniquely identifies a process even across PID recycling. The `cmd_hash`
+/// binds the mandate to a specific command (SipHash-2-4 of canonical args).
+#[repr(C)]
+#[derive(Copy, Clone, Debug, Pod, Zeroable)]
+pub struct MandateKey {
+    /// Target process TID (task group ID), i.e. `current->tgid`.
+    pub pid: u32,
+    /// Alignment padding — must be zero.
+    pub _pad: u32,
+    /// Process start time in boot-monotonic nanoseconds.
+    /// Kernel: `current->group_leader->start_boottime`.
+    /// Userspace: `/proc/<pid>/stat` field 22, converted to ns.
+    pub start_time_ns: u64,
+    /// SipHash-2-4 hash of the canonicalized command arguments.
+    pub cmd_hash: u64,
+}
+
+// 24 bytes exactly
+#[cfg(test)]
+const _: () = {
+    assert!(size_of::<MandateKey>() == 24);
+};
+
+/// Value stored in the MANDATE_MAP for each authorized operation.
+///
+/// 24 bytes. Contains expiry time, flags controlling enforcement mode,
+/// and a sequence number linking to the receipt.
+#[repr(C)]
+#[derive(Copy, Clone, Debug, Pod, Zeroable)]
+pub struct MandateValue {
+    /// Absolute expiry time in boot-monotonic nanoseconds.
+    /// After this time, the LSM program treats the mandate as absent.
+    pub expires_ns: u64,
+    /// Flags controlling mandate behavior.
+    /// Bit 0: 0 = enforce (deny if absent), 1 = monitor (allow but tag).
+    /// Bits 1-31: reserved, must be zero.
+    pub flags: u32,
+    /// Reserved for future use (alignment padding).
+    pub _reserved: u32,
+    /// Sequence number from the mandate creation, used to correlate receipt.
+    pub mandate_seq: u64,
+}
+
+// 24 bytes exactly
+#[cfg(test)]
+const _: () = {
+    assert!(size_of::<MandateValue>() == 24);
+};
+
+impl MandateValue {
+    /// Flag bit: mandate is in monitor-only mode (allow but tag as unmanaged).
+    pub const FLAG_MONITOR: u32 = 1 << 0;
+
+    /// Check if this mandate has expired relative to the given time.
+    #[inline(always)]
+    pub fn is_expired(&self, now_ns: u64) -> bool {
+        now_ns >= self.expires_ns
+    }
+
+    /// Check if this mandate is in monitor-only mode.
+    #[inline(always)]
+    pub fn is_monitor_mode(&self) -> bool {
+        self.flags & Self::FLAG_MONITOR != 0
+    }
+}
+
+/// Mandate enforcement mode for the global MANDATE_MODE map.
+#[repr(u32)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum MandateMode {
+    /// Log violations but allow all operations.
+    Monitor = 0,
+    /// Block unauthorized operations (return -EPERM).
+    Enforce = 1,
+}
+
+/// Maximum number of entries in the MANDATE_MAP BPF LRU hash.
+pub const MANDATE_MAP_MAX_ENTRIES: u32 = 65_536;
+
+/// Watermark threshold (80%) — when map usage exceeds this, cognitod
+/// should apply backpressure (return 429 to new mandate requests).
+pub const MANDATE_MAP_WATERMARK: u32 = MANDATE_MAP_MAX_ENTRIES * 80 / 100;
+
+/// Reconciliation interval in seconds — cognitod scans and evicts expired
+/// mandates from the BPF map at this frequency.
+pub const MANDATE_RECONCILE_INTERVAL_SECS: u64 = 5;
 
 #[cfg(all(feature = "user", not(target_os = "none")))]
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
@@ -484,6 +588,39 @@ mod tests {
             0,
             "wire format should be 8-byte aligned"
         );
+    }
+
+    #[test]
+    fn mandate_key_layout() {
+        assert_eq!(size_of::<MandateKey>(), 24, "MandateKey must be 24 bytes");
+        assert_eq!(
+            std::mem::align_of::<MandateKey>(),
+            8,
+            "MandateKey must be 8-byte aligned"
+        );
+    }
+
+    #[test]
+    fn mandate_value_layout() {
+        assert_eq!(
+            size_of::<MandateValue>(),
+            24,
+            "MandateValue must be 24 bytes"
+        );
+    }
+
+    #[test]
+    fn mandate_value_flags() {
+        let val = MandateValue {
+            expires_ns: 1_000_000_000,
+            flags: MandateValue::FLAG_MONITOR,
+            _reserved: 0,
+            mandate_seq: 42,
+        };
+        assert!(val.is_monitor_mode());
+        assert!(!val.is_expired(500_000_000));
+        assert!(val.is_expired(1_000_000_000));
+        assert!(val.is_expired(2_000_000_000));
     }
 
     #[test]

--- a/linnix-ai-ebpf/linnix-ai-ebpf-ebpf/src/lsm.rs
+++ b/linnix-ai-ebpf/linnix-ai-ebpf-ebpf/src/lsm.rs
@@ -1,0 +1,520 @@
+// =============================================================================
+// LINNIX-CLAW: BPF LSM PROGRAMS — Mandate Enforcement
+// =============================================================================
+//
+// Two LSM hooks that enforce the mandate system at the kernel level:
+//
+//   1. `bprm_check_security` — intercepts execve/execveat. Hashes argv with
+//      SipHash-2-4, looks up the MANDATE_MAP, and allows or denies execution.
+//
+//   2. `socket_connect` — intercepts outbound connect(). Hashes addr:port,
+//      looks up the MANDATE_MAP, and allows or denies the connection.
+//
+// Both hooks produce execution receipts pushed to the SEQUENCER_RING for
+// monotonic ordering alongside other process lifecycle events.
+//
+// See docs/linnix-claw/specs.md §2 for full specification.
+// See docs/linnix-claw/architecture.md Domain 3 for rationale.
+//
+// Requirements:
+//   - Kernel ≥ 5.7 with CONFIG_BPF_LSM=y
+//   - Boot parameter: lsm=...,bpf (or apparmor,...,bpf)
+//   - BTF support (/sys/kernel/btf/vmlinux)
+
+use aya_ebpf::{
+    helpers::{bpf_get_current_task_btf, bpf_ktime_get_ns, bpf_probe_read},
+    macros::{lsm, map},
+    maps::{Array, HashMap as BpfHashMap},
+    programs::LsmContext,
+};
+use aya_log_ebpf::info;
+use linnix_ai_ebpf_common::{
+    EventType, MandateKey, MandateMode, MandateValue, ProcessEvent, MANDATE_MAP_MAX_ENTRIES,
+    PERCENT_MILLI_UNKNOWN,
+};
+
+use crate::siphash::SipHasher;
+
+// =============================================================================
+// MANDATE MAPS
+// =============================================================================
+
+/// BPF LRU hash map storing active mandates.
+/// Key: MandateKey (24 bytes) = pid + start_time_ns + cmd_hash
+/// Value: MandateValue (24 bytes) = expires_ns + flags + mandate_seq
+///
+/// LRU eviction ensures the map never OOMs — least recently used entries
+/// are silently dropped. Cognitod's reconciliation loop (every 5s) also
+/// proactively evicts expired entries.
+#[map(name = "MANDATE_MAP")]
+static MANDATE_MAP: BpfHashMap<MandateKey, MandateValue> =
+    BpfHashMap::with_max_entries(MANDATE_MAP_MAX_ENTRIES, 0);
+
+/// Global enforcement mode.
+/// Element 0: 0 = Monitor (log but allow), 1 = Enforce (block unauthorized).
+/// Written by cognitod at startup based on config.
+#[map(name = "MANDATE_MODE")]
+static MANDATE_MODE: Array<u32> = Array::with_max_entries(1, 0);
+
+/// 128-bit SipHash key stored in .rodata (immutable after load).
+/// k0 = element 0, k1 = element 1.
+/// Seeded from /dev/urandom by cognitod at eBPF load time.
+#[map(name = "SIPHASH_KEY")]
+static SIPHASH_KEY: Array<u64> = Array::with_max_entries(2, 0);
+
+/// Metrics counters for mandate enforcement.
+/// Index 0: total mandate lookups
+/// Index 1: mandate hits (allowed)
+/// Index 2: mandate misses (denied or unmanaged)
+/// Index 3: mandate expired (found but expired)
+#[map(name = "MANDATE_METRICS")]
+static MANDATE_METRICS: Array<u64> = Array::with_max_entries(4, 0);
+
+const METRIC_LOOKUPS: u32 = 0;
+const METRIC_HITS: u32 = 1;
+const METRIC_MISSES: u32 = 2;
+const METRIC_EXPIRED: u32 = 3;
+
+// =============================================================================
+// HELPERS
+// =============================================================================
+
+/// Read the global enforcement mode from the MANDATE_MODE map.
+#[inline(always)]
+fn get_mandate_mode() -> u32 {
+    match MANDATE_MODE.get(0) {
+        Some(val) => *val,
+        None => MandateMode::Monitor as u32, // default: monitor
+    }
+}
+
+/// Read the SipHash key from the SIPHASH_KEY map.
+#[inline(always)]
+fn get_siphash_key() -> [u64; 2] {
+    let k0 = match SIPHASH_KEY.get(0) {
+        Some(val) => *val,
+        None => 0,
+    };
+    let k1 = match SIPHASH_KEY.get(1) {
+        Some(val) => *val,
+        None => 0,
+    };
+    [k0, k1]
+}
+
+/// Increment a metric counter atomically.
+#[inline(always)]
+fn increment_metric(index: u32) {
+    unsafe {
+        if let Some(ptr) = MANDATE_METRICS.get_ptr_mut(index) {
+            let val = &mut *ptr;
+            *val = val.wrapping_add(1);
+        }
+    }
+}
+
+/// Read `start_boottime` from `current->group_leader->start_boottime`.
+///
+/// The byte offset is discovered at daemon start via BTF and written into
+/// `TelemetryConfig.task_start_boottime_offset`.  If the offset is zero
+/// (unsupported kernel or field not found) we fall back to 0, which means
+/// the mandate key won't carry start_time and PID-reuse protection is
+/// disabled.  This is safe — mandates will expire by TTL anyway.
+#[inline(always)]
+fn read_start_time_ns(task: *const u8) -> u64 {
+    let config = crate::program::load_config();
+    if config.task_start_boottime_offset == 0 {
+        return 0;
+    }
+    crate::program::read_field::<u64>(task, config.task_start_boottime_offset).unwrap_or(0)
+}
+
+/// Push a mandate execution receipt to SEQUENCER_RING.
+///
+/// Each allow/deny decision at the kernel LSM boundary produces a receipt
+/// visible to userspace consumers via the same zero-copy ring that carries
+/// process lifecycle events.  The receipt carries:
+///   event_type  = MandateAllow (8) or MandateDeny (9)
+///   pid         = the process TID that triggered the check
+///   data        = cmd_hash of the checked operation
+///   data2       = mandate_seq (0 if no mandate matched)
+///   aux         = enforcement mode (0=monitor, 1=enforce)
+#[inline(always)]
+fn push_mandate_receipt(
+    event_type: EventType,
+    pid: u32,
+    cmd_hash: u64,
+    mandate_seq: u64,
+    mode: u32,
+    ts_ns: u64,
+) {
+    let event = ProcessEvent {
+        pid,
+        ppid: 0,
+        uid: 0,
+        gid: 0,
+        event_type: event_type as u32,
+        ts_ns,
+        seq: mandate_seq,
+        comm: [0u8; 16],
+        exit_time_ns: 0,
+        cpu_pct_milli: PERCENT_MILLI_UNKNOWN,
+        mem_pct_milli: PERCENT_MILLI_UNKNOWN,
+        data: cmd_hash,
+        data2: mandate_seq,
+        aux: mode,
+        aux2: 0,
+    };
+    let _ = crate::program::submit_to_sequencer(&event);
+}
+
+// =============================================================================
+// EXECVE CANONICALIZATION
+// =============================================================================
+//
+// Per specs.md §1.1.1, the canonical form for execve is:
+//   filename \x00 arg1 \x00 arg2 \x00 ... (NUL-separated, UTF-8)
+//
+// BPF stack limit: 512 bytes. We extract up to 256 bytes total across
+// the filename and first 6 arguments.
+
+/// Maximum bytes for argument canonicalization (BPF stack budget).
+const MAX_CANON_BYTES: usize = 256;
+
+/// Maximum number of argv entries to hash.
+#[allow(dead_code)] // Used in Phase 1 for argv-based hashing
+const MAX_ARGV: usize = 6;
+
+/// Hash the filename from a `linux_binprm` struct for execve mandate lookup.
+///
+/// In the `bprm_check_security` LSM hook, the first argument is a pointer
+/// to `struct linux_binprm`. We read `binprm->filename` (the resolved path)
+/// and hash it as the canonical representation.
+///
+/// For Phase 0, we hash only the filename (not full argv). Full argv
+/// canonicalization requires reading the user-space stack, which needs
+/// `bpf_probe_read_user_str` and careful BPF verifier handling.
+#[inline(always)]
+fn hash_binprm_filename(ctx: &LsmContext, key: &[u64; 2]) -> Option<u64> {
+    // linux_binprm layout (simplified):
+    //   offset 0...: various fields
+    //   offset 192 (typical): filename pointer (char *)
+    //
+    // The exact offset varies by kernel version. For Phase 0, we read
+    // the filename from the first argument using BTF-aware access.
+
+    // Read the linux_binprm pointer (arg 0 of bprm_check_security)
+    let binprm: *const u8 = unsafe { ctx.arg(0) };
+    if binprm.is_null() {
+        return None;
+    }
+
+    // Read filename pointer from linux_binprm.
+    // Typical offset: 192 bytes on 6.x kernels, but we use bpf_probe_read
+    // to get it. The filename field is a `const char *`.
+    //
+    // NOTE: This offset should be discovered via BTF. For Phase 0, we use
+    // a common offset. Production code will read from TelemetryConfig.
+    const BINPRM_FILENAME_OFFSET: usize = 192;
+
+    let filename_ptr: usize =
+        unsafe { bpf_probe_read((binprm.add(BINPRM_FILENAME_OFFSET)) as *const usize).ok()? };
+
+    if filename_ptr == 0 {
+        return None;
+    }
+
+    // Read filename bytes (up to MAX_CANON_BYTES)
+    let mut buf = [0u8; MAX_CANON_BYTES];
+    let mut len = 0usize;
+
+    // Read up to MAX_CANON_BYTES from the filename
+    // We use byte-by-byte reading with bounded loop for BPF verifier
+    let fname_ptr = filename_ptr as *const u8;
+    let mut i = 0usize;
+    while i < MAX_CANON_BYTES {
+        match unsafe { bpf_probe_read(fname_ptr.add(i)) } {
+            Ok(b) => {
+                if b == 0 {
+                    break;
+                }
+                buf[i] = b;
+                len += 1;
+            }
+            Err(_) => break,
+        }
+        i += 1;
+    }
+
+    if len == 0 {
+        return None;
+    }
+
+    // SipHash-2-4 the filename bytes
+    let mut hasher = SipHasher::new(key[0], key[1]);
+    let mut j = 0usize;
+    while j < len && j < MAX_CANON_BYTES {
+        hasher.write_byte(buf[j]);
+        j += 1;
+    }
+    Some(hasher.finish())
+}
+
+// =============================================================================
+// LSM HOOK: bprm_check_security (execve interception)
+// =============================================================================
+//
+// Called after the binary is resolved but BEFORE it runs.
+// Has access to linux_binprm->filename and argv.
+//
+// Returns:
+//   0     → allow execution
+//   -1    → deny execution (EPERM)
+
+#[lsm(hook = "bprm_check_security")]
+pub fn mandate_execve_check(ctx: LsmContext) -> i32 {
+    match try_mandate_execve_check(&ctx) {
+        Ok(ret) => ret,
+        Err(_) => 0, // On error, fail open (allow) to avoid breaking the system
+    }
+}
+
+#[inline(always)]
+fn try_mandate_execve_check(ctx: &LsmContext) -> Result<i32, i64> {
+    let now = unsafe { bpf_ktime_get_ns() };
+
+    // Get current PID (tgid)
+    let task = unsafe { bpf_get_current_task_btf() } as *const u8;
+    if task.is_null() {
+        return Ok(0); // Can't identify process, fail open
+    }
+
+    // Read tgid from task_struct
+    // NOTE: Using the same dynamic offset approach as the main program.rs
+    let config = crate::program::load_config();
+    let pid: i32 = match crate::program::read_field(task, config.task_tgid_offset) {
+        Some(v) => v,
+        None => return Ok(0),
+    };
+    let pid = pid as u32;
+
+    // Skip kernel threads and init
+    if pid <= 1 {
+        return Ok(0);
+    }
+
+    // Get SipHash key
+    let key = get_siphash_key();
+    if key[0] == 0 && key[1] == 0 {
+        // Key not initialized yet — cognitod hasn't loaded. Fail open.
+        return Ok(0);
+    }
+
+    // Hash the filename from linux_binprm
+    let cmd_hash = match hash_binprm_filename(ctx, &key) {
+        Some(h) => h,
+        None => return Ok(0), // Can't read filename, fail open
+    };
+
+    // Construct the mandate key
+    let start_time_ns = read_start_time_ns(task);
+    let mandate_key = MandateKey {
+        pid,
+        _pad: 0,
+        start_time_ns,
+        cmd_hash,
+    };
+
+    // Increment lookup counter
+    increment_metric(METRIC_LOOKUPS);
+
+    let mode = get_mandate_mode();
+
+    // Look up mandate in the map
+    let mandate = unsafe { MANDATE_MAP.get(&mandate_key) };
+
+    match mandate {
+        Some(val) => {
+            // Mandate found — check expiry
+            if val.is_expired(now) {
+                increment_metric(METRIC_EXPIRED);
+
+                // Expired mandate — treat as missing
+                if mode == MandateMode::Enforce as u32 {
+                    push_mandate_receipt(EventType::MandateDeny, pid, cmd_hash, 0, mode, now);
+                    return Ok(-1); // EPERM
+                }
+                return Ok(0);
+            }
+
+            // Valid mandate — allow execution; push allow receipt
+            increment_metric(METRIC_HITS);
+            push_mandate_receipt(
+                EventType::MandateAllow,
+                pid,
+                cmd_hash,
+                val.mandate_seq,
+                mode,
+                now,
+            );
+
+            Ok(0)
+        }
+        None => {
+            // No mandate found
+            increment_metric(METRIC_MISSES);
+
+            if mode == MandateMode::Enforce as u32 {
+                // Enforce mode: block the syscall and push deny receipt
+                push_mandate_receipt(EventType::MandateDeny, pid, cmd_hash, 0, mode, now);
+                Ok(-1) // Return -EPERM
+            } else {
+                // Monitor mode: allow but log
+                Ok(0)
+            }
+        }
+    }
+}
+
+// =============================================================================
+// LSM HOOK: socket_connect (outbound connection interception)
+// =============================================================================
+//
+// Called before an outbound TCP/UDP connection is established.
+// Has access to struct socket and struct sockaddr (IP + port).
+//
+// Returns:
+//   0     → allow connection
+//   -1    → deny connection (EPERM)
+
+#[lsm(hook = "socket_connect")]
+pub fn mandate_socket_connect(ctx: LsmContext) -> i32 {
+    match try_mandate_socket_connect(&ctx) {
+        Ok(ret) => ret,
+        Err(_) => 0, // Fail open on error
+    }
+}
+
+#[inline(always)]
+fn try_mandate_socket_connect(ctx: &LsmContext) -> Result<i32, i64> {
+    let now = unsafe { bpf_ktime_get_ns() };
+
+    // Get current PID
+    let task = unsafe { bpf_get_current_task_btf() } as *const u8;
+    if task.is_null() {
+        return Ok(0);
+    }
+
+    let config = crate::program::load_config();
+    let pid: i32 = match crate::program::read_field(task, config.task_tgid_offset) {
+        Some(v) => v,
+        None => return Ok(0),
+    };
+    let pid = pid as u32;
+
+    if pid <= 1 {
+        return Ok(0);
+    }
+
+    // Read sockaddr from the second argument (arg 1)
+    // socket_connect(struct socket *sock, struct sockaddr *address, int addrlen)
+    let sockaddr: *const u8 = unsafe { ctx.arg(1) };
+    if sockaddr.is_null() {
+        return Ok(0);
+    }
+
+    // Read sa_family (first 2 bytes of sockaddr)
+    let sa_family: u16 = unsafe { bpf_probe_read(sockaddr as *const u16).map_err(|e| e)? };
+
+    // Only intercept AF_INET (2) and AF_INET6 (10) connections
+    if sa_family != 2 && sa_family != 10 {
+        return Ok(0);
+    }
+
+    // Hash the sockaddr for mandate lookup
+    let key = get_siphash_key();
+    if key[0] == 0 && key[1] == 0 {
+        return Ok(0); // Key not yet initialized
+    }
+
+    let mut hasher = SipHasher::new(key[0], key[1]);
+
+    // Write "connect\0" prefix for canonicalization
+    hasher.write(b"connect\x00");
+
+    if sa_family == 2 {
+        // AF_INET: sockaddr_in = { sa_family: u16, sin_port: u16, sin_addr: u32, ... }
+        // Read port (offset 2, big-endian u16)
+        let port: u16 = unsafe { bpf_probe_read(sockaddr.add(2) as *const u16).unwrap_or(0) };
+        // Read IPv4 address (offset 4, 4 bytes)
+        let addr: u32 = unsafe { bpf_probe_read(sockaddr.add(4) as *const u32).unwrap_or(0) };
+
+        hasher.write_u32(addr);
+        // Port is in network byte order (big-endian), write raw bytes
+        hasher.write_byte((port >> 8) as u8);
+        hasher.write_byte(port as u8);
+    } else {
+        // AF_INET6: sockaddr_in6 = { sa_family: u16, sin6_port: u16, sin6_flowinfo: u32,
+        //                             sin6_addr: [u8; 16], sin6_scope_id: u32 }
+        let port: u16 = unsafe { bpf_probe_read(sockaddr.add(2) as *const u16).unwrap_or(0) };
+
+        // Read 16-byte IPv6 address at offset 8
+        let mut addr6 = [0u8; 16];
+        let mut i = 0usize;
+        while i < 16 {
+            addr6[i] = unsafe { bpf_probe_read(sockaddr.add(8 + i) as *const u8).unwrap_or(0) };
+            i += 1;
+        }
+
+        hasher.write(&addr6);
+        hasher.write_byte((port >> 8) as u8);
+        hasher.write_byte(port as u8);
+    }
+
+    let cmd_hash = hasher.finish();
+    let start_time_ns = read_start_time_ns(task);
+    let mandate_key = MandateKey {
+        pid,
+        _pad: 0,
+        start_time_ns,
+        cmd_hash,
+    };
+
+    increment_metric(METRIC_LOOKUPS);
+
+    let mode = get_mandate_mode();
+    let mandate = unsafe { MANDATE_MAP.get(&mandate_key) };
+
+    match mandate {
+        Some(val) => {
+            if val.is_expired(now) {
+                increment_metric(METRIC_EXPIRED);
+                if mode == MandateMode::Enforce as u32 {
+                    push_mandate_receipt(EventType::MandateDeny, pid, cmd_hash, 0, mode, now);
+                    return Ok(-1);
+                }
+                return Ok(0);
+            }
+
+            increment_metric(METRIC_HITS);
+            push_mandate_receipt(
+                EventType::MandateAllow,
+                pid,
+                cmd_hash,
+                val.mandate_seq,
+                mode,
+                now,
+            );
+            Ok(0)
+        }
+        None => {
+            increment_metric(METRIC_MISSES);
+            if mode == MandateMode::Enforce as u32 {
+                push_mandate_receipt(EventType::MandateDeny, pid, cmd_hash, 0, mode, now);
+                Ok(-1)
+            } else {
+                Ok(0)
+            }
+        }
+    }
+}

--- a/linnix-ai-ebpf/linnix-ai-ebpf-ebpf/src/main.rs
+++ b/linnix-ai-ebpf/linnix-ai-ebpf-ebpf/src/main.rs
@@ -7,7 +7,16 @@
 mod program;
 
 #[cfg(target_arch = "bpf")]
+mod siphash;
+
+#[cfg(target_arch = "bpf")]
+mod lsm;
+
+#[cfg(target_arch = "bpf")]
 pub use program::*;
+
+#[cfg(target_arch = "bpf")]
+pub use lsm::*;
 
 #[cfg(not(target_arch = "bpf"))]
 fn main() {}

--- a/linnix-ai-ebpf/linnix-ai-ebpf-ebpf/src/program.rs
+++ b/linnix-ai-ebpf/linnix-ai-ebpf-ebpf/src/program.rs
@@ -211,11 +211,11 @@ fn emit_block_event_common(
     )
 }
 
-fn load_config() -> TelemetryConfig {
+pub(crate) fn load_config() -> TelemetryConfig {
     unsafe { core::ptr::read_volatile(&TELEMETRY_CONFIG) }
 }
 
-fn read_field<T: Copy>(base: *const u8, offset: u32) -> Option<T> {
+pub(crate) fn read_field<T: Copy>(base: *const u8, offset: u32) -> Option<T> {
     if base.is_null() {
         return None;
     }
@@ -569,7 +569,7 @@ unsafe fn atomic_fetch_add_u64(ptr: *mut u64, val: u64) -> u64 {
 /// 4. u8 flags to reduce write bandwidth
 /// 5. Direct field writes (event passed by reference, written directly)
 #[inline(always)]
-fn submit_to_sequencer(event: &ProcessEvent) -> Result<(), i64> {
+pub(crate) fn submit_to_sequencer(event: &ProcessEvent) -> Result<(), i64> {
     // 1. ATOMIC RESERVATION (Direct memory access - no map lookup!)
     // --------------------------------------------------------
     // GLOBAL_SEQUENCER is a cache-line-aligned .bss global.

--- a/linnix-ai-ebpf/linnix-ai-ebpf-ebpf/src/siphash.rs
+++ b/linnix-ai-ebpf/linnix-ai-ebpf-ebpf/src/siphash.rs
@@ -1,0 +1,215 @@
+// =============================================================================
+// SipHash-2-4: Cryptographic hash for BPF mandate enforcement
+// =============================================================================
+//
+// Inline `#![no_std]` implementation of SipHash-2-4 for eBPF programs.
+// Used to hash canonical command arguments for mandate key construction.
+//
+// Properties:
+//   - 128-bit key, 64-bit output
+//   - ~3ns per hash on modern CPUs
+//   - Collision-resistant against adversarial inputs
+//   - Already used internally by the Linux kernel for hash table randomization
+//
+// Reference: https://cr.yp.to/siphash/siphash-20120918.pdf
+//
+// The 128-bit key is seeded from /dev/urandom at eBPF load time and stored
+// in BPF .rodata (read-only after load).
+
+/// SipHash-2-4 state.
+#[derive(Clone)]
+pub struct SipHasher {
+    v0: u64,
+    v1: u64,
+    v2: u64,
+    v3: u64,
+    buf: u64,
+    count: usize,
+}
+
+#[inline(always)]
+fn rotl(x: u64, b: u32) -> u64 {
+    (x << b) | (x >> (64 - b))
+}
+
+#[inline(always)]
+fn sipround(v0: &mut u64, v1: &mut u64, v2: &mut u64, v3: &mut u64) {
+    *v0 = v0.wrapping_add(*v1);
+    *v1 = rotl(*v1, 13);
+    *v1 ^= *v0;
+    *v0 = rotl(*v0, 32);
+    *v2 = v2.wrapping_add(*v3);
+    *v3 = rotl(*v3, 16);
+    *v3 ^= *v2;
+    *v0 = v0.wrapping_add(*v3);
+    *v3 = rotl(*v3, 21);
+    *v3 ^= *v0;
+    *v2 = v2.wrapping_add(*v1);
+    *v1 = rotl(*v1, 17);
+    *v1 ^= *v2;
+    *v2 = rotl(*v2, 32);
+}
+
+impl SipHasher {
+    /// Create a new SipHash-2-4 hasher from a 128-bit key.
+    /// `k0` and `k1` are the two 64-bit halves of the key.
+    #[inline(always)]
+    pub fn new(k0: u64, k1: u64) -> Self {
+        Self {
+            v0: k0 ^ 0x736f6d6570736575,
+            v1: k1 ^ 0x646f72616e646f6d,
+            v2: k0 ^ 0x6c7967656e657261,
+            v3: k1 ^ 0x7465646279746573,
+            buf: 0,
+            count: 0,
+        }
+    }
+
+    /// Write a single byte into the hasher.
+    #[inline(always)]
+    pub fn write_byte(&mut self, byte: u8) {
+        let shift = (self.count % 8) * 8;
+        self.buf |= (byte as u64) << shift;
+        self.count += 1;
+
+        if self.count % 8 == 0 {
+            self.compress();
+        }
+    }
+
+    /// Write a slice of bytes into the hasher.
+    ///
+    /// Note: In BPF context, the caller must ensure the slice length
+    /// is bounded (BPF verifier requires bounded loops).
+    #[inline(always)]
+    pub fn write(&mut self, data: &[u8]) {
+        for &b in data {
+            self.write_byte(b);
+        }
+    }
+
+    /// Write a u32 value (little-endian).
+    #[inline(always)]
+    pub fn write_u32(&mut self, val: u32) {
+        let bytes = val.to_le_bytes();
+        self.write_byte(bytes[0]);
+        self.write_byte(bytes[1]);
+        self.write_byte(bytes[2]);
+        self.write_byte(bytes[3]);
+    }
+
+    /// Write a u64 value (little-endian).
+    #[inline(always)]
+    #[allow(dead_code)] // Used in Phase 1+ for hashing structured args
+    pub fn write_u64(&mut self, val: u64) {
+        let bytes = val.to_le_bytes();
+        self.write_byte(bytes[0]);
+        self.write_byte(bytes[1]);
+        self.write_byte(bytes[2]);
+        self.write_byte(bytes[3]);
+        self.write_byte(bytes[4]);
+        self.write_byte(bytes[5]);
+        self.write_byte(bytes[6]);
+        self.write_byte(bytes[7]);
+    }
+
+    /// Compress the current 8-byte buffer block (SipHash-2 rounds).
+    #[inline(always)]
+    fn compress(&mut self) {
+        self.v3 ^= self.buf;
+        sipround(&mut self.v0, &mut self.v1, &mut self.v2, &mut self.v3);
+        sipround(&mut self.v0, &mut self.v1, &mut self.v2, &mut self.v3);
+        self.v0 ^= self.buf;
+        self.buf = 0;
+    }
+
+    /// Finalize and return the 64-bit hash.
+    #[inline(always)]
+    pub fn finish(mut self) -> u64 {
+        // Pad the final block with the total byte count in the high byte
+        let b = (self.count as u64) << 56;
+        self.buf |= b;
+
+        // Process final block
+        self.v3 ^= self.buf;
+        sipround(&mut self.v0, &mut self.v1, &mut self.v2, &mut self.v3);
+        sipround(&mut self.v0, &mut self.v1, &mut self.v2, &mut self.v3);
+        self.v0 ^= self.buf;
+
+        // Finalization (SipHash-4 rounds)
+        self.v2 ^= 0xff;
+        sipround(&mut self.v0, &mut self.v1, &mut self.v2, &mut self.v3);
+        sipround(&mut self.v0, &mut self.v1, &mut self.v2, &mut self.v3);
+        sipround(&mut self.v0, &mut self.v1, &mut self.v2, &mut self.v3);
+        sipround(&mut self.v0, &mut self.v1, &mut self.v2, &mut self.v3);
+
+        self.v0 ^ self.v1 ^ self.v2 ^ self.v3
+    }
+}
+
+/// Compute SipHash-2-4 of a byte slice with the given 128-bit key.
+///
+/// This is the primary entry point for BPF programs hashing command arguments.
+/// The key should come from the SIPHASH_KEY BPF .rodata global.
+#[inline(always)]
+#[allow(dead_code)] // Convenience wrapper used by tests and Phase 1+
+pub fn siphash_2_4(key: [u64; 2], data: &[u8]) -> u64 {
+    let mut hasher = SipHasher::new(key[0], key[1]);
+    hasher.write(data);
+    hasher.finish()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_empty_input() {
+        // SipHash-2-4 of empty input with zero key should produce a deterministic value.
+        let hash = siphash_2_4([0, 0], &[]);
+        assert_ne!(hash, 0, "empty input should not hash to zero");
+    }
+
+    #[test]
+    fn test_reference_vector() {
+        // Test vector from the SipHash paper (Appendix A).
+        // Key: 00 01 02 ... 0f
+        // Input: 00 01 02 ... 0e (15 bytes)
+        let k0 = u64::from_le_bytes([0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07]);
+        let k1 = u64::from_le_bytes([0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f]);
+
+        let input: Vec<u8> = (0..15u8).collect();
+        let hash = siphash_2_4([k0, k1], &input);
+
+        // Expected: a129ca6149be45e5 (from reference implementation)
+        assert_eq!(
+            hash, 0xa129ca6149be45e5,
+            "SipHash-2-4 reference vector mismatch"
+        );
+    }
+
+    #[test]
+    fn test_deterministic() {
+        let key = [0xdeadbeef_u64, 0xcafebabe_u64];
+        let data = b"curl https://example.com";
+        let h1 = siphash_2_4(key, data);
+        let h2 = siphash_2_4(key, data);
+        assert_eq!(h1, h2, "same input must produce same hash");
+    }
+
+    #[test]
+    fn test_different_inputs() {
+        let key = [0xdeadbeef_u64, 0xcafebabe_u64];
+        let h1 = siphash_2_4(key, b"curl https://example.com");
+        let h2 = siphash_2_4(key, b"wget https://example.com");
+        assert_ne!(h1, h2, "different inputs should produce different hashes");
+    }
+
+    #[test]
+    fn test_different_keys() {
+        let data = b"curl https://example.com";
+        let h1 = siphash_2_4([1, 2], data);
+        let h2 = siphash_2_4([3, 4], data);
+        assert_ne!(h1, h2, "different keys should produce different hashes");
+    }
+}

--- a/run_claw_test.sh
+++ b/run_claw_test.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+# Run cognitod natively with BPF LSM support for Claw testing
+set -e
+
+cd "$(dirname "$0")"
+
+# Kill any existing cognitod
+sudo pkill -f "target/release/cognitod" 2>/dev/null || true
+sleep 1
+
+echo "Starting cognitod with BPF LSM support..."
+sudo LINNIX_BPF_PATH="$PWD/target/bpfel-unknown-none/release/linnix-ai-ebpf-ebpf" \
+  LINNIX_LISTEN_ADDR=0.0.0.0:3000 \
+  "$PWD/target/release/cognitod" \
+  --config "$PWD/configs/linnix.toml" \
+  --handler "rules:$PWD/configs/rules.yaml" &
+
+COGNITOD_PID=$!
+sleep 3
+
+echo ""
+echo "=== Mandate Health ==="
+curl -s http://localhost:3000/health/mandate | python3 -m json.tool
+
+echo ""
+echo "=== Create Mandate ==="
+RESPONSE=$(curl -s -X POST http://localhost:3000/mandates \
+  -H 'Content-Type: application/json' \
+  -d "{\"pid\": $$, \"args\": [\"/bin/ls\", \"-la\", \"/tmp\"], \"ttl_ms\": 30000}")
+echo "$RESPONSE" | python3 -m json.tool
+MANDATE_ID=$(echo "$RESPONSE" | python3 -c "import sys,json; print(json.load(sys.stdin)['id'])")
+
+echo ""
+echo "=== Get Mandate ==="
+curl -s "http://localhost:3000/mandates/$MANDATE_ID" | python3 -m json.tool
+
+echo ""
+echo "=== Stats ==="
+curl -s http://localhost:3000/mandates/stats | python3 -m json.tool
+
+echo ""
+echo "=== Receipt for Active Mandate (expect 202) ==="
+curl -s -w "\nHTTP %{http_code}\n" "http://localhost:3000/mandates/$MANDATE_ID/receipt"
+
+echo ""
+echo "=== Revoke Mandate ==="
+HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X DELETE "http://localhost:3000/mandates/$MANDATE_ID")
+echo "HTTP $HTTP_CODE"
+
+echo ""
+echo "=== Receipt for Revoked Mandate (expect 404) ==="
+curl -s -w "\nHTTP %{http_code}\n" "http://localhost:3000/mandates/$MANDATE_ID/receipt"
+
+echo ""
+echo "=== Get After Revoke ==="
+curl -s "http://localhost:3000/mandates/$MANDATE_ID" | python3 -m json.tool
+
+echo ""
+echo "=== Final Stats ==="
+curl -s http://localhost:3000/mandates/stats | python3 -m json.tool
+
+echo ""
+echo "=== Invalid PID ==="
+curl -s -w "\nHTTP %{http_code}\n" -X POST http://localhost:3000/mandates \
+  -H 'Content-Type: application/json' \
+  -d '{"pid": 999999, "args": ["/bin/ls"], "ttl_ms": 5000}'
+
+echo ""
+echo "=== Nonexistent Receipt (expect 404) ==="
+curl -s -w "\nHTTP %{http_code}\n" http://localhost:3000/mandates/00000000-0000-0000-0000-000000000000/receipt
+
+echo ""
+echo "Smoke test complete! cognitod running as PID $COGNITOD_PID"
+echo "Kill with: sudo kill $COGNITOD_PID"

--- a/scripts/demo_claw.sh
+++ b/scripts/demo_claw.sh
@@ -1,0 +1,194 @@
+#!/bin/bash
+# =============================================================================
+# scripts/demo_claw.sh — Linnix-Claw Phase 2 Demo Script
+# =============================================================================
+#
+# Exercises all mandate/receipt/agent-card API endpoints.
+# Requires cognitod running on localhost:3000.
+#
+# Usage:
+#   # Start cognitod first (needs BPF, run as root):
+#   sudo LINNIX_BPF_PATH=target/bpfel-unknown-none/release/linnix-ai-ebpf-ebpf \
+#     LINNIX_LISTEN_ADDR=0.0.0.0:3000 \
+#     ./target/release/cognitod --config configs/linnix.toml \
+#     --handler rules:configs/rules.yaml
+#
+#   # Then run demo:
+#   bash scripts/demo_claw.sh
+#
+set -euo pipefail
+
+BASE_URL="${LINNIX_API_URL:-http://localhost:3000}"
+PASS=0
+FAIL=0
+
+# Colors (if terminal supports them)
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+CYAN='\033[0;36m'
+NC='\033[0m' # No Color
+
+check() {
+    local label="$1"
+    local expected_code="$2"
+    local actual_code="$3"
+
+    if [[ "$actual_code" == "$expected_code" ]]; then
+        echo -e "  ${GREEN}✓${NC} ${label} (HTTP ${actual_code})"
+        PASS=$((PASS + 1))
+    else
+        echo -e "  ${RED}✗${NC} ${label} — expected HTTP ${expected_code}, got ${actual_code}"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# ── Wait for cognitod ────────────────────────────────────────────────────────
+echo -e "${CYAN}Waiting for cognitod at ${BASE_URL}...${NC}"
+for i in $(seq 1 10); do
+    if curl -sf "${BASE_URL}/healthz" >/dev/null 2>&1; then
+        break
+    fi
+    if [[ $i -eq 10 ]]; then
+        echo "ERROR: cognitod not reachable at ${BASE_URL}"
+        exit 1
+    fi
+    sleep 1
+done
+echo ""
+
+# ── 1. Health ────────────────────────────────────────────────────────────────
+echo -e "${CYAN}1. GET /health/mandate${NC}"
+CODE=$(curl -s -o /dev/null -w "%{http_code}" "${BASE_URL}/health/mandate")
+check "mandate health" "200" "$CODE"
+curl -s "${BASE_URL}/health/mandate" | python3 -m json.tool
+echo ""
+
+# ── 2. Agent Card ────────────────────────────────────────────────────────────
+echo -e "${CYAN}2. GET /.well-known/agent-card.json${NC}"
+CODE=$(curl -s -o /dev/null -w "%{http_code}" "${BASE_URL}/.well-known/agent-card.json")
+check "agent card" "200" "$CODE"
+CARD=$(curl -s "${BASE_URL}/.well-known/agent-card.json")
+echo "$CARD" | python3 -m json.tool
+# Verify x-linnix-claw extension present
+echo "$CARD" | python3 -c "import sys,json; d=json.load(sys.stdin); assert 'x-linnix-claw' in d, 'missing x-linnix-claw'" && \
+    echo -e "  ${GREEN}✓${NC} x-linnix-claw extension present" && PASS=$((PASS + 1)) || \
+    (echo -e "  ${RED}✗${NC} x-linnix-claw extension missing" && FAIL=$((FAIL + 1)))
+echo ""
+
+# ── 3. Create Mandate ───────────────────────────────────────────────────────
+echo -e "${CYAN}3. POST /mandates${NC}"
+RESPONSE=$(curl -s -w "\n%{http_code}" -X POST "${BASE_URL}/mandates" \
+    -H 'Content-Type: application/json' \
+    -d "{\"pid\": 1, \"args\": [\"/bin/ls\", \"-la\", \"/tmp\"], \"ttl_ms\": 60000}")
+BODY=$(echo "$RESPONSE" | head -n -1)
+CODE=$(echo "$RESPONSE" | tail -n 1)
+check "create mandate" "201" "$CODE"
+echo "$BODY" | python3 -m json.tool
+MANDATE_ID=$(echo "$BODY" | python3 -c "import sys,json; print(json.load(sys.stdin)['id'])" 2>/dev/null || echo "")
+echo ""
+
+# ── 4. Get Mandate ──────────────────────────────────────────────────────────
+echo -e "${CYAN}4. GET /mandates/{id}${NC}"
+if [[ -n "$MANDATE_ID" ]]; then
+    CODE=$(curl -s -o /dev/null -w "%{http_code}" "${BASE_URL}/mandates/${MANDATE_ID}")
+    check "get mandate" "200" "$CODE"
+    curl -s "${BASE_URL}/mandates/${MANDATE_ID}" | python3 -m json.tool
+else
+    echo -e "  ${RED}✗${NC} skipped (no mandate_id)"
+    FAIL=$((FAIL + 1))
+fi
+echo ""
+
+# ── 5. List Mandates ────────────────────────────────────────────────────────
+echo -e "${CYAN}5. GET /mandates${NC}"
+CODE=$(curl -s -o /dev/null -w "%{http_code}" "${BASE_URL}/mandates")
+check "list mandates" "200" "$CODE"
+curl -s "${BASE_URL}/mandates" | python3 -m json.tool
+echo ""
+
+# ── 6. Mandate Stats ────────────────────────────────────────────────────────
+echo -e "${CYAN}6. GET /mandates/stats${NC}"
+CODE=$(curl -s -o /dev/null -w "%{http_code}" "${BASE_URL}/mandates/stats")
+check "mandate stats" "200" "$CODE"
+curl -s "${BASE_URL}/mandates/stats" | python3 -m json.tool
+echo ""
+
+# ── 7. Receipt for Active Mandate (expect 202) ──────────────────────────────
+echo -e "${CYAN}7. GET /mandates/{id}/receipt (active → 202)${NC}"
+if [[ -n "$MANDATE_ID" ]]; then
+    CODE=$(curl -s -o /dev/null -w "%{http_code}" "${BASE_URL}/mandates/${MANDATE_ID}/receipt")
+    check "receipt (active→202)" "202" "$CODE"
+    curl -s "${BASE_URL}/mandates/${MANDATE_ID}/receipt" | python3 -m json.tool
+else
+    echo -e "  ${RED}✗${NC} skipped"
+    FAIL=$((FAIL + 1))
+fi
+echo ""
+
+# ── 8. Batch Create ─────────────────────────────────────────────────────────
+echo -e "${CYAN}8. POST /mandates/batch${NC}"
+BATCH_RESPONSE=$(curl -s -w "\n%{http_code}" -X POST "${BASE_URL}/mandates/batch" \
+    -H 'Content-Type: application/json' \
+    -d "{\"mandates\": [
+        {\"pid\": 1, \"args\": [\"/usr/bin/curl\", \"https://example.com\"], \"ttl_ms\": 30000},
+        {\"pid\": 1, \"args\": [\"/usr/bin/python3\", \"script.py\"], \"ttl_ms\": 30000},
+        {\"pid\": 999999, \"args\": [\"/bin/false\"], \"ttl_ms\": 5000}
+    ]}")
+BATCH_BODY=$(echo "$BATCH_RESPONSE" | head -n -1)
+BATCH_CODE=$(echo "$BATCH_RESPONSE" | tail -n 1)
+check "batch create" "200" "$BATCH_CODE"
+echo "$BATCH_BODY" | python3 -m json.tool
+# Verify partial success (2 ok, 1 failed for PID 999999)
+echo "$BATCH_BODY" | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+assert d['succeeded'] >= 2, f'expected >=2 succeeded, got {d[\"succeeded\"]}'
+assert d['failed'] >= 1, f'expected >=1 failed, got {d[\"failed\"]}'
+" && echo -e "  ${GREEN}✓${NC} batch partial success verified" && PASS=$((PASS + 1)) || \
+    (echo -e "  ${RED}✗${NC} batch result mismatch" && FAIL=$((FAIL + 1)))
+echo ""
+
+# ── 9. Revoke Mandate ───────────────────────────────────────────────────────
+echo -e "${CYAN}9. DELETE /mandates/{id}${NC}"
+if [[ -n "$MANDATE_ID" ]]; then
+    CODE=$(curl -s -o /dev/null -w "%{http_code}" -X DELETE "${BASE_URL}/mandates/${MANDATE_ID}")
+    check "revoke mandate" "204" "$CODE"
+else
+    echo -e "  ${RED}✗${NC} skipped"
+    FAIL=$((FAIL + 1))
+fi
+echo ""
+
+# ── 10. Receipt for Revoked (expect 404) ────────────────────────────────────
+echo -e "${CYAN}10. GET /mandates/{id}/receipt (revoked → 404)${NC}"
+if [[ -n "$MANDATE_ID" ]]; then
+    CODE=$(curl -s -o /dev/null -w "%{http_code}" "${BASE_URL}/mandates/${MANDATE_ID}/receipt")
+    check "receipt (revoked→404)" "404" "$CODE"
+else
+    echo -e "  ${RED}✗${NC} skipped"
+    FAIL=$((FAIL + 1))
+fi
+echo ""
+
+# ── 11. Receipt for nonexistent (expect 404) ────────────────────────────────
+echo -e "${CYAN}11. GET /mandates/nonexistent/receipt (404)${NC}"
+CODE=$(curl -s -o /dev/null -w "%{http_code}" "${BASE_URL}/mandates/00000000-0000-0000-0000-000000000000/receipt")
+check "receipt (nonexistent→404)" "404" "$CODE"
+echo ""
+
+# ── 12. Final Stats ─────────────────────────────────────────────────────────
+echo -e "${CYAN}12. GET /mandates/stats (final)${NC}"
+curl -s "${BASE_URL}/mandates/stats" | python3 -m json.tool
+echo ""
+
+# ── Summary ──────────────────────────────────────────────────────────────────
+TOTAL=$((PASS + FAIL))
+echo "=============================================="
+if [[ $FAIL -eq 0 ]]; then
+    echo -e "${GREEN}ALL ${TOTAL} CHECKS PASSED${NC}"
+else
+    echo -e "${RED}${FAIL}/${TOTAL} CHECKS FAILED${NC}"
+fi
+echo "=============================================="
+
+exit $FAIL

--- a/scripts/run_phase2_smoke.sh
+++ b/scripts/run_phase2_smoke.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# Run cognitod + demo_claw.sh smoke test
+# Usage: sudo bash scripts/run_phase2_smoke.sh
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+# Kill lingering cognitod
+pkill -f "target/release/cognitod" 2>/dev/null || true
+sleep 1
+
+echo "Starting cognitod..."
+LINNIX_BPF_PATH=target/bpfel-unknown-none/release/linnix-ai-ebpf-ebpf \
+  LINNIX_LISTEN_ADDR=0.0.0.0:3000 \
+  ./target/release/cognitod --config configs/linnix.toml \
+  --handler rules:configs/rules.yaml &
+PID=$!
+
+cleanup() { kill $PID 2>/dev/null || true; wait $PID 2>/dev/null || true; }
+trap cleanup EXIT
+
+# Wait for startup
+for i in $(seq 1 15); do
+    if curl -sf http://localhost:3000/healthz >/dev/null 2>&1; then
+        echo "cognitod ready (pid $PID)"
+        break
+    fi
+    [[ $i -eq 15 ]] && { echo "TIMEOUT"; exit 1; }
+    sleep 1
+done
+
+echo ""
+bash scripts/demo_claw.sh


### PR DESCRIPTION
## Summary
- Wire up BPF mandate enforcement with LSM (Linux Security Module) receipts and PSI (Pressure Stall Information) detectors in the `claw` module
- Add compliance, identity, privacy, payment, spend controls, and commerce modules to cognitod
- Introduce LSM eBPF program with SipHash-based receipt signing and mandate enforcement at the kernel level
- Add comprehensive BDD and integration tests for spend controls, mandate LSM, and UDS listener

## Test plan
- [ ] Verify BDD spend control tests pass (`cognitod/tests/bdd_spend.rs`)
- [ ] Verify mandate LSM tests pass (`cognitod/tests/mandate_lsm.rs`)
- [ ] Verify spend control tests pass (`cognitod/tests/spend_controls.rs`)
- [ ] Verify UDS listener tests pass (`cognitod/tests/uds_listener.rs`)
- [ ] Run `cargo build --release` to confirm workspace compiles
- [ ] Run full test suite with `cargo nextest run --workspace`

🤖 Generated with [Claude Code](https://claude.com/claude-code)