### PR TITLE
fix(ebpf): apply +alu32 from workspace root; correct advertised kernel floor

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,10 @@
 [alias]
 xtask = "run --package xtask --"
+
+# Applies to `cargo xtask build-ebpf`, which runs from the workspace root.
+# Cargo reads .cargo/config.toml from the invocation CWD upward, so a config
+# inside linnix-ai-ebpf/ is NOT read for workspace-root builds.
+# +alu32 is required: without it LLVM rejects the atomic fetch-and-add in
+# submit_to_sequencer() with "Invalid usage of the XADD return value".
+[target.bpfel-unknown-none]
+rustflags = ["-C", "linker=bpf-linker", "-C", "target-feature=+alu32"]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -2,8 +2,11 @@
 xtask = "run --package xtask --"
 
 # Applies to `cargo xtask build-ebpf`, which runs from the workspace root.
-# Cargo reads .cargo/config.toml from the invocation CWD upward, so a config
-# inside linnix-ai-ebpf/ is NOT read for workspace-root builds.
+# Cargo reads .cargo/config.toml from the invocation CWD upward, so the config
+# in linnix-ai-ebpf/ is NOT read for workspace-root builds — that one only
+# covers the Dockerfile, which cds into the crate directory first.
+# Keep the rustflags below in sync with linnix-ai-ebpf/.cargo/config.toml.
+#
 # +alu32 is required: without it LLVM rejects the atomic fetch-and-add in
 # submit_to_sequencer() with "Invalid usage of the XADD return value".
 [target.bpfel-unknown-none]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ cargo nextest run --workspace
 Recommended toolchain versions:
 - Rust stable (check `rust-toolchain.toml` if present)
 - `clang`/`llvm` ≥ 14 for eBPF builds
-- Linux kernel 5.8+ with BTF data for local testing
+- Linux kernel 5.12+ (x86_64) / 5.18+ (arm64) with BTF data for local testing
 
 ## Workflow
 

--- a/cognitod/src/main.rs
+++ b/cognitod/src/main.rs
@@ -402,7 +402,9 @@ fn check_capabilities() -> anyhow::Result<()> {
     eprintln!(
         "  docker run --cap-add=BPF --cap-add=PERFMON --cap-drop=ALL ghcr.io/linnix-os/cognitod:latest"
     );
-    eprintln!("\nRequires: Linux 5.8+ with BTF support (/sys/kernel/btf/vmlinux)");
+    eprintln!(
+        "\nRequires: Linux 5.12+ (x86_64) or 5.18+ (arm64) with BTF support (/sys/kernel/btf/vmlinux)"
+    );
     eprintln!("Docs: https://docs.linnix.io/installation\n");
 
     anyhow::bail!("missing CAP_BPF and CAP_PERFMON")

--- a/docs/AWS_EC2_DEPLOYMENT.md
+++ b/docs/AWS_EC2_DEPLOYMENT.md
@@ -40,7 +40,7 @@ Complete guide for deploying Linnix eBPF observability platform on AWS EC2 insta
 ✅ **Debian 12**
 
 ### Kernel Requirements
-- **Minimum Kernel:** 5.8+
+- **Minimum Kernel:** 5.12+ (x86_64) / 5.18+ (arm64) — required for the `BPF_FETCH` atomics used by the sequencer
 - **Recommended Kernel:** 5.15+ (Ubuntu 22.04), 6.1+ (Amazon Linux 2023)
 - **Required Features:**
   - eBPF support (CONFIG_BPF=y, CONFIG_BPF_SYSCALL=y)
@@ -99,7 +99,7 @@ For Docker-based LLM deployment, use `./quickstart.sh` which includes the LLM se
 
 ### What the docs/examples/install-ec2.sh Script Does
 
-1. ✅ Detects OS and validates kernel version (>= 5.8)
+1. ✅ Detects OS and validates kernel version (>= 5.12 on x86_64, >= 5.18 on arm64)
 2. ✅ Installs system dependencies (libelf, kernel headers, OpenSSL)
 3. ✅ Downloads or builds Linnix binaries
    - Installs Rust toolchain with eBPF support (nightly-2024-12-10)
@@ -189,7 +189,7 @@ ssh -i ~/.ssh/my-keypair.pem ubuntu@$INSTANCE_IP
 ```bash
 # Check kernel version
 uname -r
-# Should be >= 5.8
+# Should be >= 5.12 (x86_64) or >= 5.18 (arm64)
 
 # Check BTF support
 ls -la /sys/kernel/btf/vmlinux

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -1,8 +1,9 @@
 # Linnix FAQ
 
 ## What kernel versions are supported?
-- **Recommended**: Linux 5.8+ with BTF packages installed (Ubuntu 20.04+, Fedora 33+, modern Debian).
-- **Minimum**: Linux 4.4 with `CONFIG_BPF_SYSCALL` enabled. Older kernels run in a “core-only” mode that captures fork/exec/exit but skips advanced RSS and page-fault metrics.
+- **Minimum**: Linux **5.12** on x86_64, Linux **5.18** on arm64/aarch64. The eBPF programs use atomic fetch-and-add (`BPF_FETCH`) for the sequencer's ticket reservation, and the kernel verifier rejects those instructions below these versions. Support landed in 5.12 for x86_64 and 5.18 for arm64.
+- **Recommended**: Linux 5.15+ (x86_64) / 6.1+ (arm64) with BTF packages installed (Ubuntu 22.04+, Amazon Linux 2023, Fedora 33+, modern Debian).
+- **Below the minimum**: both the primary and the `rss_trace` fallback object fail to load. `cognitod` does not crash — it logs `eBPF initialization failed ...; running without kernel instrumentation` and continues in userspace-only mode, which means **no eBPF telemetry at all**. Check your logs for that warning if metrics look empty.
 - **BTF tips**: Ship `/sys/kernel/btf/vmlinux` (or package-specific paths) so Linnix can compute struct offsets dynamically. Without BTF, the daemon logs a warning and continues with degraded telemetry.
 
 ## How much overhead should I expect?

--- a/docs/HOW_IT_WORKS.md
+++ b/docs/HOW_IT_WORKS.md
@@ -55,7 +55,7 @@ Linnix combines eBPF probes, BTF-powered compatibility helpers, and an AI reason
 
 | Step | Component | What to check |
 |------|-----------|---------------|
-| 1 | Kernel | `uname -r` ≥ 5.8 recommended, `ls /sys/kernel/btf/vmlinux` to confirm BTF |
+| 1 | Kernel | `uname -r` ≥ 5.12 (x86_64) / ≥ 5.18 (arm64) required, `ls /sys/kernel/btf/vmlinux` to confirm BTF |
 | 2 | eBPF assets | `cargo xtask build-ebpf` (development) or use shipped object files |
 | 3 | Daemon | `sudo systemctl status cognitod` or `./quickstart.sh` |
 | 4 | LLM endpoint | `curl http://localhost:8090/v1/models` |

--- a/docs/wiki/Collector-Guide.md
+++ b/docs/wiki/Collector-Guide.md
@@ -24,8 +24,8 @@ The Linnix collector uses eBPF to capture kernel events with minimal overhead.
 
 | Kernel | Support Level |
 |--------|--------------|
-| 5.4+ | Basic (sched tracepoints) |
-| 5.8+ | Full (BTF support) |
+| < 5.12 (x86_64) / < 5.18 (arm64) | **Unsupported** — verifier rejects the sequencer's `BPF_FETCH` atomics; daemon falls back to userspace-only |
+| 5.12+ (x86_64) / 5.18+ (arm64) | Supported (requires BTF) |
 | 5.15+ | Enhanced (page fault tracking) |
 
 ## Required Capabilities

--- a/docs/wiki/Getting-Started.md
+++ b/docs/wiki/Getting-Started.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites
 
-- Linux kernel 5.4+ (5.8+ recommended)
+- Linux kernel 5.12+ on x86_64 / 5.18+ on arm64 (5.15+ / 6.1+ recommended)
 - Docker and Docker Compose (for quick start)
 - Or: Rust toolchain (for building from source)
 

--- a/linnix-ai-ebpf/.cargo/config.toml
+++ b/linnix-ai-ebpf/.cargo/config.toml
@@ -1,8 +1,0 @@
-[build]
-target = "bpfel-unknown-none"
-
-[unstable]
-build-std = ["core"]
-
-[target.bpfel-unknown-none]
-rustflags = ["-C", "linker=bpf-linker", "-C", "target-feature=+alu32"]

--- a/linnix-ai-ebpf/.cargo/config.toml
+++ b/linnix-ai-ebpf/.cargo/config.toml
@@ -1,0 +1,14 @@
+# Applies when cargo is invoked from within this directory tree — notably the
+# Dockerfile, which does `WORKDIR /build/linnix-ai-ebpf/linnix-ai-ebpf-ebpf`
+# before `cargo build`. It does NOT apply to `cargo xtask build-ebpf`, which
+# runs from the workspace root; the root .cargo/config.toml covers that path.
+# Keep the rustflags here in sync with the root config.
+
+[build]
+target = "bpfel-unknown-none"
+
+[unstable]
+build-std = ["core"]
+
+[target.bpfel-unknown-none]
+rustflags = ["-C", "linker=bpf-linker", "-C", "target-feature=+alu32"]

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -27,9 +27,18 @@ KERNEL_VERSION=$(uname -r)
 MAJOR_VERSION=$(echo "$KERNEL_VERSION" | cut -d. -f1)
 MINOR_VERSION=$(echo "$KERNEL_VERSION" | cut -d. -f2)
 
+# The eBPF objects use BPF_FETCH atomics (atomic fetch-and-add) in the sequencer's
+# ticket reservation. Kernel support: 5.12+ on x86_64, 5.18+ on arm64.
+# Below this the verifier rejects the programs and cognitod runs userspace-only.
+case "$(uname -m)" in
+    aarch64|arm64) MIN_MINOR=18 ;;
+    *)             MIN_MINOR=12 ;;
+esac
+
 echo -n "Checking Kernel ($KERNEL_VERSION)... "
-if [ "$MAJOR_VERSION" -lt 5 ] || ([ "$MAJOR_VERSION" -eq 5 ] && [ "$MINOR_VERSION" -lt 8 ]); then
-    echo -e "${YELLOW}Warning: Kernel 5.8+ recommended for CO-RE. You may need to compile from source.${NC}"
+if [ "$MAJOR_VERSION" -lt 5 ] || ([ "$MAJOR_VERSION" -eq 5 ] && [ "$MINOR_VERSION" -lt "$MIN_MINOR" ]); then
+    echo -e "${YELLOW}Warning: Kernel 5.$MIN_MINOR+ required on $(uname -m) for eBPF instrumentation.${NC}"
+    echo -e "${YELLOW}         cognitod will start but fall back to userspace-only monitoring.${NC}"
 else
     echo -e "${GREEN}OK${NC}"
 fi


### PR DESCRIPTION
## What this fixes

Two related problems, both found while investigating why PR #33's aarch64 CI leg fails.

### 1. `cargo xtask build-ebpf` never picked up the eBPF build flags

There are **two different eBPF build paths**, and they read different configs:

| path | CWD | reads `linnix-ai-ebpf/.cargo/config.toml`? |
|---|---|---|
| `cargo xtask build-ebpf` (CI `test-ebpf`) | workspace root | ❌ no |
| `Dockerfile` (`WORKDIR .../linnix-ai-ebpf-ebpf`, then `cargo build`) | crate dir | ✅ yes |

Cargo reads `.cargo/config.toml` from the invocation CWD upward. `xtask` runs from the workspace root, so the nested config — which sets `-C target-feature=+alu32` — was silently skipped there. Confirmed with a linker shim that dumps argv:

```
ARGV: --export-symbols ... --cpu generic -o ... -O3 --debug
```

No `--cpu-features`. (The linker still resolved because rustc's `bpfel-unknown-none` target uses `linker-flavor: bpf`, which invokes `bpf-linker` by default.)

Fix: add the same flags to the **root** `.cargo/config.toml` so the xtask path gets them too. The nested config stays — it is load-bearing for the Docker build — with comments on both noting which invocation each covers and that they must stay in sync.

### 2. `+alu32` — not an ISA bump — is what the aarch64 build needs

Without it, LLVM rejects the atomic fetch-and-add in `submit_to_sequencer()` with `Invalid usage of the XADD return value`. bpf-linker 0.9.13 (what the x86_64 leg installs) doesn't enforce this; 0.10.x (used on the aarch64 leg in #33) does. **The arm64 failure is the newer toolchain surfacing a pre-existing condition, not an arm64 bug** — and since the Docker path always had `+alu32`, the shipped image was never affected.

Matrix build, run locally against bpf-linker 0.10.4:

| flags | result | atomics | jmp32 |
|---|---|---|---|
| none (`--cpu generic`) | ❌ FAIL | – | – |
| `target-cpu=v1` | ❌ FAIL | – | – |
| **`target-feature=+alu32`** | ✅ **OK** | 13 | **0** |
| `target-cpu=v3` | ✅ OK | 13 | 47 |
| `target-cpu=v1 +alu32` | ✅ OK | 13 | 0 |

`+alu32` alone fixes it and emits **zero new instruction classes** vs. what ships today. `--cpu v3` would add 47 `jmp32` instructions for no benefit, so this PR does not do that.

### 3. The advertised kernel floor is wrong

I pulled `ghcr.io/linnix-os/cognitod:latest` from the registry, extracted `/usr/local/share/linnix/linnix-ai-ebpf-ebpf`, and disassembled it. **It already contains 13 `atomic_fetch_add` instructions** (opcode `db`, imm `0x01` = `BPF_ADD | BPF_FETCH`) — in `linnix_ai_ebpf`, `handle_exec_raw`, `handle_fork(_raw)`, `handle_exit(_raw)`, `try_trace_page_fault`, `mandate_execve_check` (3x), `mandate_socket_connect` (3x). These arrived with the sequencer in #23.

Kernel support for `BPF_FETCH`: **x86_64 5.12+, arm64 5.18+** (riscv 5.19+).

So the real floor has been 5.12/5.18 for a while, while the docs advertise **5.8+** (and `docs/wiki/Getting-Started.md` said 5.4+). Below the floor the verifier rejects both the primary object *and* the `rss_trace` fallback (7 atomics of its own), and `cognitod` logs `eBPF initialization failed ...; running without kernel instrumentation` and continues **userspace-only** — no crash, but no eBPF telemetry either. On a DaemonSet that means healthy-looking pods doing nothing.

Updated: `docs/FAQ.md`, `docs/HOW_IT_WORKS.md`, `docs/AWS_EC2_DEPLOYMENT.md`, `docs/wiki/Getting-Started.md`, `docs/wiki/Collector-Guide.md`, `CONTRIBUTING.md`, the `cognitod` startup hint, and `scripts/install.sh` (now arch-aware: 5.12 vs 5.18).

`docker-compose.yml` and `k8s/README.md` mention 5.8 for **CAP_BPF**, which is correct and left alone.

## Test plan
- [x] `cargo xtask build-ebpf` from workspace root — previously failed under bpf-linker 0.10.4, now succeeds
- [x] `cd linnix-ai-ebpf/linnix-ai-ebpf-ebpf && cargo build --release --target=bpfel-unknown-none` (Dockerfile's invocation) — succeeds
- [x] Both paths emit 13 `atomic_fetch_add`, 0 `jmp32`, matching the shipped object's profile
- [x] `bash -n scripts/install.sh`, `cargo fmt --all -- --check` clean
- [x] CI `Build Cognitod Image` — caught a first attempt that deleted the nested config; restored

## Follow-up (not in this PR)
1. Whether the arm64 5.18 floor is acceptable is a product decision. If it isn't, the fix is per-CPU rings rather than a global sequencer ticket — `program.rs` already notes it "relies on the per-CPU nature of BPF execution", which sits oddly beside a cross-CPU atomic.
2. The two build paths reading different configs is a footgun in its own right; having the Dockerfile call `cargo xtask build-ebpf` would collapse them to one.
3. Falling back to userspace-only should be loud (health endpoint / metric), not a `warn!`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)