### PR TITLE
ci: build eBPF via cargo xtask in the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,9 +34,13 @@ COPY linnix-reasoner/Cargo.toml ./linnix-reasoner/
 # Copy source code
 COPY . .
 
-# Build eBPF programs
-WORKDIR /build/linnix-ai-ebpf/linnix-ai-ebpf-ebpf
-RUN cargo build --release --target=bpfel-unknown-none
+# Build eBPF programs.
+# Use the xtask entrypoint so this shares one build path (and one set of
+# rustflags, incl. +alu32) with CI and local dev. Building from inside the
+# crate directory instead would pick up linnix-ai-ebpf/.cargo/config.toml,
+# which the workspace-root path does not read -- that divergence is what let
+# the aarch64 eBPF build break unnoticed (see #48).
+RUN cargo xtask build-ebpf
 
 # Stage 2: Build Rust userspace binaries
 FROM rust:1.93-bookworm AS rust-builder

--- a/linnix-ai-ebpf/.cargo/config.toml
+++ b/linnix-ai-ebpf/.cargo/config.toml
@@ -1,7 +1,11 @@
-# Applies when cargo is invoked from within this directory tree — notably the
-# Dockerfile, which does `WORKDIR /build/linnix-ai-ebpf/linnix-ai-ebpf-ebpf`
-# before `cargo build`. It does NOT apply to `cargo xtask build-ebpf`, which
-# runs from the workspace root; the root .cargo/config.toml covers that path.
+# Applies only when cargo is invoked from within this directory tree, i.e. a
+# manual `cd linnix-ai-ebpf/... && cargo build`. The canonical build is
+# `cargo xtask build-ebpf` from the workspace root (used by CI and the
+# Dockerfile), which reads the ROOT .cargo/config.toml instead.
+#
+# This file is kept because without it an in-directory `cargo build` would
+# target the host rather than bpfel-unknown-none and silently produce a no-op
+# binary (see the `cfg(not(target_arch = "bpf"))` main in src/main.rs).
 # Keep the rustflags here in sync with the root config.
 
 [build]


### PR DESCRIPTION
Collapses the two eBPF build paths into one.

The Dockerfile did `WORKDIR /build/linnix-ai-ebpf/linnix-ai-ebpf-ebpf` then `cargo build --release --target=bpfel-unknown-none`, so it picked up `linnix-ai-ebpf/.cargo/config.toml`. CI's `cargo xtask build-ebpf` runs from the workspace root and does **not** read that file. Same crate, two commands, two configs — which is precisely how the missing `+alu32` went unnoticed until #48 (CI passed only because bpf-linker 0.9.13 didn't enforce the XADD check; the Docker path had the flag all along).

Now both run `cargo xtask build-ebpf` with identical rustflags.

**The nested config stays.** It's still needed for a manual `cd linnix-ai-ebpf/... && cargo build` — without it that targets the host instead of `bpfel-unknown-none` and silently produces a no-op binary, because the crate has a `#[cfg(not(target_arch = "bpf"))] fn main() {}`. Its comment now says which invocation it covers.

The Docker stage already installs `nightly-2024-12-10` with `rust-src`, which is what xtask pins, so no new toolchain requirement.

## Test plan
- [x] `cargo xtask build-ebpf` from workspace root — succeeds
- [ ] `Build Cognitod Image` — the real check, since it exercises the changed Dockerfile line

🤖 Generated with [Claude Code](https://claude.com/claude-code)