### PR TITLE
feat(api): make degraded eBPF visible via /readyz instead of silent

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -99,7 +99,7 @@ ENV RUST_LOG=info
 EXPOSE 3000
 
 HEALTHCHECK --interval=10s --timeout=5s --start-period=30s --retries=3 \
-    CMD curl -f http://localhost:3000/healthz || exit 1
+    CMD curl -f http://localhost:3000/readyz || exit 1
 
 # Security: runs as root with minimal capabilities (CAP_BPF + CAP_PERFMON)
 # Docker capabilities require root user. See SECURITY.md for details.

--- a/cognitod/src/api/mod.rs
+++ b/cognitod/src/api/mod.rs
@@ -1201,8 +1201,66 @@ pub async fn get_insights(
     Ok(Json(output))
 }
 
-pub async fn healthz() -> axum::Json<serde_json::Value> {
-    axum::Json(serde_json::json!({ "status": "ok" }))
+/// Liveness. Answers "is the process alive?" and nothing more.
+///
+/// Deliberately returns 200 even when the eBPF probes failed to attach: a
+/// kernel that cannot load our programs will never load them, so failing
+/// liveness would produce a restart loop that hides the real cause. The
+/// degradation is reported here for humans, and gated on by /readyz.
+pub async fn healthz(State(app_state): State<Arc<AppState>>) -> axum::Json<serde_json::Value> {
+    let instrumented = kernel_instrumentation_active(&app_state);
+    axum::Json(serde_json::json!({
+        "status": "ok",
+        "kernel_instrumentation": if instrumented { "active" } else { "unavailable" },
+        "transport": app_state.transport,
+    }))
+}
+
+/// True when the eBPF probes actually attached and events can flow.
+///
+/// `transport` is set to "perf" only after `init_ebpf` succeeds; it stays
+/// "userspace" when the object failed to load or verify.
+pub fn kernel_instrumentation_active(app_state: &AppState) -> bool {
+    app_state.transport != "userspace"
+}
+
+/// Readiness. Answers "is this instance doing its job?"
+///
+/// Linnix exists to attribute stalls to processes using kernel telemetry. When
+/// the probes are not attached, PSI still reports that pressure exists — but the
+/// per-process attribution, the part that distinguishes Linnix from reading
+/// /proc/pressure directly, is gone. Reporting ready in that state hides a dead
+/// collector behind a green pod.
+pub async fn readyz(State(app_state): State<Arc<AppState>>) -> impl IntoResponse {
+    let instrumented = kernel_instrumentation_active(&app_state);
+    let required = app_state.require_kernel_instrumentation;
+    let ready = instrumented || !required;
+
+    let body = serde_json::json!({
+        "ready": ready,
+        "kernel_instrumentation": if instrumented { "active" } else { "unavailable" },
+        "transport": app_state.transport,
+        "btf_available": app_state.probe_state.btf_available,
+        "rss_probe": app_state.probe_state.rss_probe.as_str(),
+        "reason": if ready {
+            serde_json::Value::Null
+        } else {
+            serde_json::Value::String(
+                "eBPF probes are not attached; running userspace-only, so no \
+                 per-process stall attribution is being produced. Check the kernel \
+                 version (5.12+ x86_64 / 5.18+ arm64), BTF availability, tracefs \
+                 mount, and CAP_BPF/CAP_PERFMON."
+                    .to_string(),
+            )
+        },
+    });
+
+    let code = if ready {
+        StatusCode::OK
+    } else {
+        StatusCode::SERVICE_UNAVAILABLE
+    };
+    (code, axum::Json(body))
 }
 
 async fn get_actions(
@@ -1376,6 +1434,17 @@ pub async fn prometheus_metrics(State(app_state): State<Arc<AppState>>) -> Respo
     };
 
     let mut body = String::new();
+
+    let _ = writeln!(
+        body,
+        "# HELP linnix_kernel_instrumentation_active 1 if the eBPF probes are attached, 0 if running userspace-only."
+    );
+    let _ = writeln!(body, "# TYPE linnix_kernel_instrumentation_active gauge");
+    let _ = writeln!(
+        body,
+        "linnix_kernel_instrumentation_active {}",
+        u8::from(kernel_instrumentation_active(&app_state))
+    );
 
     let _ = writeln!(
         body,
@@ -1612,6 +1681,8 @@ pub struct AppState {
     pub offline: Arc<OfflineGuard>,
     pub transport: &'static str,
     pub probe_state: ProbeState,
+    /// When true, /readyz returns 503 if the eBPF probes are not attached.
+    pub require_kernel_instrumentation: bool,
     pub reasoner: ReasonerConfig,
     pub prometheus_enabled: bool,
     pub alert_history: Arc<AlertHistory>,
@@ -1654,6 +1725,7 @@ pub fn all_routes(app_state: Arc<AppState>) -> Router {
         .route("/metrics", get(metrics_handler))
         .route("/status", get(status_handler))
         .route("/healthz", get(healthz))
+        .route("/readyz", get(readyz))
         // .route("/insights/schema", get(get_insight_schema_route)) // Removed (YAGNI cleanup)
         .route("/actions", get(get_actions))
         .route("/actions/{id}", get(get_action_by_id))
@@ -1711,6 +1783,7 @@ pub fn uds_routes(app_state: Arc<AppState>) -> Router {
         .route("/metrics", get(metrics_handler))
         .route("/status", get(status_handler))
         .route("/healthz", get(healthz))
+        .route("/readyz", get(readyz))
         .route("/actions", get(get_actions))
         .route("/actions/{id}", get(get_action_by_id))
         .route("/actions/{id}/approve", axum::routing::post(approve_action))
@@ -2231,6 +2304,72 @@ mod tests {
         assert!(metrics.dropped_events_total.load(Ordering::Relaxed) > 0);
     }
 
+    /// AppState for a node where the eBPF probes failed to attach:
+    /// transport stays "userspace", which is what init_ebpf leaves on failure.
+    fn degraded_app_state() -> Arc<AppState> {
+        Arc::new(AppState {
+            context: Arc::new(ContextStore::new(Duration::from_secs(60), 10, None)),
+            metrics: Arc::new(Metrics::new()),
+            alerts: None,
+            insights: Arc::new(InsightStore::new(16, None)),
+            offline: Arc::new(OfflineGuard::new(false)),
+            transport: "userspace",
+            probe_state: ProbeState::disabled(),
+            require_kernel_instrumentation: true,
+            enforcement: None,
+            reasoner: ReasonerConfig::default(),
+            prometheus_enabled: false,
+            alert_history: Arc::new(AlertHistory::new(16)),
+            auth_token: None,
+            incident_store: None,
+            k8s: None,
+        })
+    }
+
+    #[tokio::test]
+    async fn readyz_503_when_probes_not_attached() {
+        // transport stays "userspace" when init_ebpf fails -- the exact state a
+        // node below the kernel floor ends up in. It must not report ready.
+        let app_state = degraded_app_state();
+        let app = all_routes(Arc::clone(&app_state));
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/readyz")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
+        let body = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+        let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(v["ready"], false);
+        assert_eq!(v["kernel_instrumentation"], "unavailable");
+        assert!(v["reason"].as_str().unwrap().contains("userspace-only"));
+    }
+
+    #[tokio::test]
+    async fn healthz_stays_200_when_degraded() {
+        // Liveness must not flap on an unsupported kernel -- restarting cannot fix it.
+        let app_state = degraded_app_state();
+        let app = all_routes(Arc::clone(&app_state));
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/healthz")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+        let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(v["status"], "ok");
+        assert_eq!(v["kernel_instrumentation"], "unavailable");
+    }
+
     #[tokio::test]
     async fn status_keys_present() {
         let ctx = Arc::new(ContextStore::new(Duration::from_secs(60), 10, None));
@@ -2243,6 +2382,7 @@ mod tests {
             offline: Arc::new(OfflineGuard::new(false)),
             transport: "perf",
             probe_state: ProbeState::disabled(),
+            require_kernel_instrumentation: true,
             enforcement: None,
             reasoner: ReasonerConfig::default(),
             prometheus_enabled: false,
@@ -2291,6 +2431,7 @@ mod tests {
                 rss_probe: RssProbeMode::CoreMm,
                 btf_available: true,
             },
+            require_kernel_instrumentation: true,
             enforcement: None,
             reasoner: ReasonerConfig::default(),
             prometheus_enabled: false,
@@ -2322,6 +2463,7 @@ mod tests {
             offline: Arc::new(OfflineGuard::new(false)),
             transport: "perf",
             probe_state: ProbeState::disabled(),
+            require_kernel_instrumentation: true,
             enforcement: None,
             reasoner: ReasonerConfig::default(),
             prometheus_enabled: false,
@@ -2356,6 +2498,7 @@ mod tests {
             offline: Arc::new(OfflineGuard::new(false)),
             transport: "perf",
             probe_state: ProbeState::disabled(),
+            require_kernel_instrumentation: true,
             enforcement: None,
             reasoner: ReasonerConfig::default(),
             prometheus_enabled: true,
@@ -2404,6 +2547,7 @@ mod tests {
             offline: Arc::new(OfflineGuard::new(false)),
             transport: "perf",
             probe_state: ProbeState::disabled(),
+            require_kernel_instrumentation: true,
             enforcement: None,
             reasoner: ReasonerConfig::default(),
             prometheus_enabled: false,
@@ -2437,6 +2581,7 @@ mod tests {
             offline: Arc::new(OfflineGuard::new(false)),
             transport: "perf",
             probe_state: ProbeState::disabled(),
+            require_kernel_instrumentation: true,
             enforcement: None,
             reasoner: ReasonerConfig::default(),
             prometheus_enabled: false,
@@ -2470,6 +2615,7 @@ mod tests {
             offline: Arc::new(OfflineGuard::new(false)),
             transport: "perf",
             probe_state: ProbeState::disabled(),
+            require_kernel_instrumentation: true,
             enforcement: None,
             reasoner: ReasonerConfig::default(),
             prometheus_enabled: false,
@@ -2504,6 +2650,7 @@ mod tests {
             offline: Arc::new(OfflineGuard::new(false)),
             transport: "perf",
             probe_state: ProbeState::disabled(),
+            require_kernel_instrumentation: true,
             enforcement: None,
             reasoner: ReasonerConfig::default(),
             prometheus_enabled: false,
@@ -2538,6 +2685,7 @@ mod tests {
             offline: Arc::new(OfflineGuard::new(false)),
             transport: "perf",
             probe_state: ProbeState::disabled(),
+            require_kernel_instrumentation: true,
             enforcement: None,
             reasoner: ReasonerConfig::default(),
             prometheus_enabled: false,

--- a/cognitod/src/config.rs
+++ b/cognitod/src/config.rs
@@ -17,6 +17,17 @@ pub struct ApiConfig {
     /// Default: None (UDS disabled). Set to e.g. "/var/run/linnix/cognitod.sock" to enable.
     #[serde(default)]
     pub unix_socket: Option<String>,
+    /// When true (default), /readyz reports NOT ready if the eBPF probes failed
+    /// to attach. Linnix's whole function is kernel-derived stall attribution, so
+    /// a node running userspace-only is not doing its job and should be visible
+    /// as such rather than reporting healthy. Set false for deployments that
+    /// intentionally run without kernel instrumentation.
+    #[serde(default = "default_require_kernel_instrumentation")]
+    pub require_kernel_instrumentation: bool,
+}
+
+fn default_require_kernel_instrumentation() -> bool {
+    true
 }
 
 impl Default for ApiConfig {
@@ -25,6 +36,7 @@ impl Default for ApiConfig {
             listen_addr: default_listen_addr(),
             auth_token: None,
             unix_socket: None,
+            require_kernel_instrumentation: default_require_kernel_instrumentation(),
         }
     }
 }

--- a/cognitod/src/main.rs
+++ b/cognitod/src/main.rs
@@ -1143,6 +1143,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         offline: Arc::clone(&offline_guard),
         transport,
         probe_state,
+        require_kernel_instrumentation: config.api.require_kernel_instrumentation,
         reasoner: config.reasoner.clone(),
         prometheus_enabled: config.outputs.prometheus,
         alert_history: Arc::clone(&alert_history),

--- a/cognitod/tests/uds_listener.rs
+++ b/cognitod/tests/uds_listener.rs
@@ -50,6 +50,7 @@ fn uds_config_round_trip() {
         listen_addr: "0.0.0.0:3000".to_string(),
         auth_token: Some("secret".to_string()),
         unix_socket: Some("/tmp/test.sock".to_string()),
+        require_kernel_instrumentation: true,
     };
     let serialized = toml::to_string(&api).expect("serialize");
     let back: ApiConfig = toml::from_str(&serialized).expect("deserialize");

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,7 +62,7 @@ services:
     restart: unless-stopped
 
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:3000/healthz"]
+      test: ["CMD", "curl", "-f", "http://localhost:3000/readyz"]
       interval: 10s
       timeout: 5s
       retries: 3

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -6,6 +6,27 @@
 - **Below the minimum**: both the primary and the `rss_trace` fallback object fail to load. `cognitod` does not crash — it logs `eBPF initialization failed ...; running without kernel instrumentation` and continues in userspace-only mode, which means **no eBPF telemetry at all**. Check your logs for that warning if metrics look empty.
 - **BTF tips**: Ship `/sys/kernel/btf/vmlinux` (or package-specific paths) so Linnix can compute struct offsets dynamically. Without BTF, the daemon logs a warning and continues with degraded telemetry.
 
+## How do I tell whether Linnix is actually collecting?
+
+Linnix does not fail closed. If the eBPF probes cannot attach, `cognitod` keeps
+running and still serves PSI read from `/proc/pressure` — but the per-process
+stall attribution, the part you installed it for, is gone. Two endpoints
+distinguish these states:
+
+- **`/healthz`** — liveness. 200 whenever the process is up. It stays 200 even
+  when degraded, because restarting cannot fix an unsupported kernel; the body
+  carries `kernel_instrumentation: active | unavailable`.
+- **`/readyz`** — readiness. **503** when the probes are not attached, with a
+  `reason` explaining what to check. This is what the Kubernetes readinessProbe
+  and the container HEALTHCHECK use, so a degraded node shows as `0/1 Ready`
+  rather than looking healthy.
+
+For alerting, scrape `linnix_kernel_instrumentation_active` (1 = probes
+attached, 0 = userspace-only) from `/metrics/prometheus`.
+
+Deployments that intentionally run without kernel instrumentation can set
+`require_kernel_instrumentation = false` under `[api]` in `linnix.toml`.
+
 ## How much overhead should I expect?
 - The end-to-end pipeline (eBPF + cognitod) stays under **1% CPU and 10–20 MB RAM** on typical hosts.
 - Reasons it is lightweight:

--- a/k8s/daemonset.yaml
+++ b/k8s/daemonset.yaml
@@ -47,6 +47,27 @@ spec:
           ports:
             - containerPort: 3000
               name: http
+          # Liveness only asks "is the process alive?". It deliberately does NOT
+          # check eBPF: a kernel that cannot load our programs never will, so
+          # failing liveness would CrashLoopBackOff and bury the real reason.
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          # Readiness reflects whether this agent is actually producing
+          # per-process stall attribution. A node below the kernel floor
+          # (5.12+ x86_64 / 5.18+ arm64), without BTF, or missing CAP_BPF runs
+          # userspace-only -- it stays up but collects nothing useful, and shows
+          # as 0/1 Ready instead of silently looking healthy.
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: http
+            initialDelaySeconds: 20
+            periodSeconds: 30
+            failureThreshold: 2
       volumes:
         - name: config
           configMap:


### PR DESCRIPTION
## The problem, reproduced

Ran the published image on a real kernel (Docker Desktop VM, 6.12.5-linuxkit, BTF present). The probes failed to attach, and this is what came out:

```
WARN  eBPF initialization failed (tracefs not found);
      running without kernel instrumentation.
INFO  Kernel instrumentation disabled; continuing in userspace-only mode.
```

Meanwhile, in the same run:

| surface | reported |
| --- | --- |
| `/healthz` | `{"status":"ok"}` — **HTTP 200** |
| `docker ps` | `Up 25 seconds **(healthy)**` |
| container HEALTHCHECK | passing |
| `/status` | `"transport":"userspace"`, `"rss_probe":"disabled"`, `"events_per_sec":0` |

So the daemon **knew** it had no kernel instrumentation and published that on `/status` and `/metrics` — but the endpoints orchestrators actually gate on said everything was fine.

**What makes this worse than a plain outage:** PSI keeps working, because it reads `/proc/pressure/cpu` rather than eBPF. A degraded agent doesn't go dark — it silently falls back to exactly the commodity pressure signal the README opens by saying isn't enough. You keep *"there is pressure"* and lose *"which process caused it"*. The differentiated half disappears, invisibly.

This is not hypothetical: the kernel floor is 5.12+ (x86_64) / 5.18+ (arm64) per #48, which excludes Debian 11, EKS AL2, and any 5.15 arm64 node — including Graviton pools on Ubuntu 22.04.

## The change

The state was already tracked and already serialised. It just wasn't consulted where it mattered.

- **`/readyz`** (new) — **503** when the probes aren't attached, with a `reason` naming what to check (kernel floor, BTF, tracefs, `CAP_BPF`/`CAP_PERFMON`).
- **`/healthz`** — still **200** when degraded, and now says which state it's in. Failing liveness would `CrashLoopBackOff` on an unsupported kernel and bury the cause; restarting cannot fix a kernel that will never load the programs.
- **`linnix_kernel_instrumentation_active`** gauge (1/0) for alerting.
- **k8s DaemonSet gains both probes** — it had none — so a degraded node shows as `0/1 Ready` instead of green.
- Dockerfile + compose HEALTHCHECKs now hit `/readyz`.
- **`api.require_kernel_instrumentation`** (default `true`) opts out for deployments intentionally running userspace-only.

## Test plan

Verified in a Linux container, not inferred from CI:

- [x] `cargo check -p cognitod --all-targets` — clean
- [x] `readyz_503_when_probes_not_attached` — asserts 503 + `ready:false` + reason, driven through the real `all_routes()` router
- [x] `healthz_stays_200_when_degraded` — asserts liveness does not flap
- [ ] CI

## Follow-ups (not here)

- `cognitod:latest` is published **amd64-only**. On Apple Silicon it runs under Rosetta, and one of my two runs died inside the translator. That undercuts the quickstart for anyone evaluating on an M-series Mac.
- It binds `127.0.0.1:3000`, so `-p` mapping silently does nothing without the compose env override — and the HEALTHCHECK can't detect that, since it curls localhost from *inside* the container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)