### PR TITLE
docs: reconcile overhead claims and surface v0.3.0 attribution work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.3.0] - 2026-08-09
+
+### Added
+- **Stall Attribution Emit Seam**: All completed PSI stall attributions now route through a single `AttributionSink` (`cognitod/src/attribution.rs`), fanning out to a structured JSON event, an alert on the existing broadcast channel, and pod-labeled Prometheus counters (`linnix_stall_induced_seconds_total{offender_pod, victim_pod, ...}`)
+  - New `attributed_stall_us` field splits a victim's stall proportionally across offenders by blame score, instead of duplicating the full stall duration per offender
+  - `calculate_blame_attributions` extracted as a free function for testability
+
+### Changed
+- **Degraded eBPF Visibility**: New `/readyz` endpoint returns 503 when eBPF probes fail to attach, naming likely causes (kernel floor, missing BTF, tracefs, CAP_BPF/CAP_PERFMON). Previously `/healthz` stayed `200 ok` in this state, silently falling back to PSI-only (pressure signal, no per-process attribution)
+  - New `linnix_kernel_instrumentation_active` gauge
+  - New `api.require_kernel_instrumentation` config flag (default `true`)
+  - K8s DaemonSet, Dockerfile, and compose healthchecks updated to use `/readyz`
+- **Linnix-Claw extracted**: the agent-to-agent payment/settlement subsystem moved to its own repo (`linnix-os/linnix-claw`), letting core Linnix focus solely on PSI/eBPF stall attribution
+  - eBPF object size reduced 43,096 → 27,184 bytes (-37%)
+  - Dropped the `lsm=bpf` boot-parameter requirement
+
 ## [0.2.0] - 2025-11-26
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -805,7 +805,7 @@ checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
 
 [[package]]
 name = "cognitod"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Linnix uses **eBPF** + **PSI (Pressure Stall Information)** to answer this. PSI 
 **What Linnix detects:**
 - **Noisy Neighbors**: Which container is starving others
 - **Fork Storms**: Runaway process creation before it crashes the node
-- **Stall Attribution**: "Pod X caused 300ms stall to Pod Y" — exposed as a Prometheus counter keyed on the offender/victim pair, see [prometheus-integration.md](docs/prometheus-integration.md)
+- **Stall Attribution**: "Pod X caused 300ms stall to Pod Y" — exposed as a Prometheus counter keyed on the offender/victim pair
 - **PSI Saturation**: CPU/IO/Memory pressure that doesn't show in `top`
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -17,11 +17,14 @@ Linnix uses **eBPF** + **PSI (Pressure Stall Information)** to answer this. PSI 
 **What Linnix detects:**
 - **Noisy Neighbors**: Which container is starving others
 - **Fork Storms**: Runaway process creation before it crashes the node
-- **Stall Attribution**: "Pod X caused 300ms stall to Pod Y"
+- **Stall Attribution**: "Pod X caused 300ms stall to Pod Y" — exposed as a Prometheus counter keyed on the offender/victim pair, see [prometheus-integration.md](docs/prometheus-integration.md)
 - **PSI Saturation**: CPU/IO/Memory pressure that doesn't show in `top`
 
 > [!IMPORTANT]
 > **Monitor-only by default.** Linnix detects and reports — it never takes action without explicit configuration.
+
+> [!NOTE]
+> **We tell you when attribution is degraded.** If eBPF can't attach (unsupported kernel, missing BTF), Linnix keeps serving PSI from `/proc/pressure` — pressure exists, but you lose *who caused it*, the reason you installed Linnix. `/readyz` reports 503 in that state instead of looking healthy. See [FAQ](docs/FAQ.md#how-do-i-tell-whether-linnix-is-actually-collecting).
 
 ### 🔒 Security & Privacy
 

--- a/cognitod/Cargo.toml
+++ b/cognitod/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cognitod"
-version = "0.2.0"
+version = "0.3.0"
 license = "AGPL-3.0-or-later"
 edition = "2024"
 description = "eBPF-powered Linux observability platform with AI incident detection"

--- a/cognitod/src/api/mod.rs
+++ b/cognitod/src/api/mod.rs
@@ -1608,6 +1608,9 @@ pub async fn prometheus_metrics(State(app_state): State<Arc<AppState>>) -> Respo
         );
     }
 
+    // Who is stalling, and who is stalling them.
+    app_state.blame_metrics.render_prometheus(&mut body);
+
     Response::builder()
         .status(StatusCode::OK)
         .header(
@@ -1690,6 +1693,8 @@ pub struct AppState {
     pub enforcement: Option<Arc<crate::enforcement::EnforcementQueue>>,
     pub incident_store: Option<Arc<IncidentStore>>,
     pub k8s: Option<Arc<cognitod::k8s::K8sContext>>,
+    /// Noisy-neighbour counters fed by the PSI monitor's attribution sink.
+    pub blame_metrics: Arc<cognitod::attribution::BlameMetrics>,
 }
 
 pub fn all_routes(app_state: Arc<AppState>) -> Router {
@@ -2323,6 +2328,7 @@ mod tests {
             auth_token: None,
             incident_store: None,
             k8s: None,
+            blame_metrics: Arc::new(cognitod::attribution::BlameMetrics::new("test-node")),
         })
     }
 
@@ -2390,6 +2396,7 @@ mod tests {
             auth_token: None,
             incident_store: None,
             k8s: None,
+            blame_metrics: Arc::new(cognitod::attribution::BlameMetrics::new("test-node")),
         });
         let Json(resp) = super::status_handler(State(app_state)).await;
         let val = serde_json::to_value(resp).unwrap();
@@ -2439,6 +2446,7 @@ mod tests {
             auth_token: None,
             incident_store: None,
             k8s: None,
+            blame_metrics: Arc::new(cognitod::attribution::BlameMetrics::new("test-node")),
         });
 
         let Json(resp) = super::metrics_handler(State(app_state)).await;
@@ -2471,6 +2479,7 @@ mod tests {
             auth_token: None,
             incident_store: None,
             k8s: None,
+            blame_metrics: Arc::new(cognitod::attribution::BlameMetrics::new("test-node")),
         });
         let router = super::all_routes(Arc::clone(&app_state));
         let response = router
@@ -2506,6 +2515,7 @@ mod tests {
             auth_token: None,
             incident_store: None,
             k8s: None,
+            blame_metrics: Arc::new(cognitod::attribution::BlameMetrics::new("test-node")),
         });
         let router = super::all_routes(Arc::clone(&app_state));
         let response = router
@@ -2555,6 +2565,7 @@ mod tests {
             auth_token: None,
             incident_store: None,
             k8s: None,
+            blame_metrics: Arc::new(cognitod::attribution::BlameMetrics::new("test-node")),
         });
         let router = super::all_routes(app_state);
         let response = router
@@ -2589,6 +2600,7 @@ mod tests {
             incident_store: None,
             auth_token: Some("secret123".to_string()),
             k8s: None,
+            blame_metrics: Arc::new(cognitod::attribution::BlameMetrics::new("test-node")),
         });
         let router = super::all_routes(app_state);
         let response = router
@@ -2623,6 +2635,7 @@ mod tests {
             incident_store: None,
             auth_token: Some("secret123".to_string()),
             k8s: None,
+            blame_metrics: Arc::new(cognitod::attribution::BlameMetrics::new("test-node")),
         });
         let router = super::all_routes(app_state);
         let response = router
@@ -2658,6 +2671,7 @@ mod tests {
             incident_store: None,
             auth_token: Some("secret123".to_string()),
             k8s: None,
+            blame_metrics: Arc::new(cognitod::attribution::BlameMetrics::new("test-node")),
         });
         let router = super::all_routes(app_state);
         let response = router
@@ -2693,6 +2707,7 @@ mod tests {
             incident_store: None,
             auth_token: Some("secret123".to_string()),
             k8s: None,
+            blame_metrics: Arc::new(cognitod::attribution::BlameMetrics::new("test-node")),
         });
         let router = super::all_routes(app_state);
         let response = router

--- a/cognitod/src/attribution.rs
+++ b/cognitod/src/attribution.rs
@@ -1,0 +1,573 @@
+//! The stall-attribution emit seam.
+//!
+//! `PsiMonitor` detects that a pod is stalling and works out which neighbours
+//! are to blame. Everything downstream of that conclusion funnels through
+//! [`AttributionSink`]: a structured JSON log line for log-based tooling, an
+//! [`Alert`] on the usual broadcast channel, and counters that
+//! `/metrics/prometheus` renders.
+//!
+//! Attribution is a *split* of one victim's stall across several offenders, so
+//! each offender is credited with its share of the stall rather than the whole
+//! thing. Emitting the victim's total against every offender would make the
+//! counters sum to several times the stall that actually happened.
+
+use std::collections::HashMap;
+use std::fmt::Write as _;
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use log::{info, warn};
+use serde::{Deserialize, Serialize};
+use tokio::sync::broadcast;
+
+use crate::alerts::{Alert, Severity};
+use crate::collectors::psi::BlameAttribution;
+
+/// Minimum stall attributed to a *single* offender before we emit a JSON event
+/// or an alert for it. Distinct from the threshold that decides whether the
+/// victim is stalling at all: one 500ms stall split across six neighbours is
+/// not six noisy neighbours.
+pub const DEFAULT_ATTRIBUTED_STALL_THRESHOLD_US: u64 = 100_000; // 100ms
+
+/// Upper bound on distinct series held per counter family. Generous on purpose:
+/// eviction breaks `rate()` continuity for the evicted series, so the cap is a
+/// backstop against unbounded growth, not a sampling strategy.
+pub const DEFAULT_MAX_SERIES: usize = 4096;
+
+/// Why an offender was blamed, derived from whichever signal dominated its
+/// blame score. Surfaced in the JSON event so logs can be faceted by cause.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BlameReason {
+    HighCpuContention,
+    ForkStorm,
+    ShortJobChurn,
+}
+
+impl BlameReason {
+    /// Picks the dominant factor using the same normalisation the blame score
+    /// itself uses, so the reason always names the term that contributed most.
+    pub fn classify(cpu_share: f64, fork_count: u64, short_job_count: u64) -> Self {
+        let fork_score = (fork_count as f64 / 100.0).min(1.0);
+        let short_job_score = (short_job_count as f64 / 50.0).min(1.0);
+
+        if cpu_share >= fork_score && cpu_share >= short_job_score {
+            BlameReason::HighCpuContention
+        } else if fork_score >= short_job_score {
+            BlameReason::ForkStorm
+        } else {
+            BlameReason::ShortJobChurn
+        }
+    }
+
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            BlameReason::HighCpuContention => "high_cpu_contention",
+            BlameReason::ForkStorm => "fork_storm",
+            BlameReason::ShortJobChurn => "short_job_churn",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct VictimRef {
+    pub pod: String,
+    pub namespace: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct OffenderRef {
+    pub pod: String,
+    pub namespace: String,
+    pub reason: BlameReason,
+}
+
+/// One machine-readable stall attribution, serialised as a single JSON line.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct AttributionEvent {
+    pub event_type: String,
+    pub severity: String,
+    /// Stall attributed to *this* offender, in milliseconds.
+    pub stall_ms: u64,
+    /// Same figure at microsecond resolution, which is how PSI reports it.
+    pub attributed_stall_us: u64,
+    /// The victim's total stall for this window, across all offenders.
+    pub victim_stall_us: u64,
+    pub blame_score: f64,
+    pub timestamp: u64,
+    pub victim: VictimRef,
+    pub offender: OffenderRef,
+}
+
+impl AttributionEvent {
+    pub const EVENT_TYPE: &'static str = "linnix.stall_attribution";
+
+    fn from_attribution(attr: &BlameAttribution) -> Self {
+        Self {
+            event_type: Self::EVENT_TYPE.to_string(),
+            severity: "warn".to_string(),
+            stall_ms: attr.attributed_stall_us / 1_000,
+            attributed_stall_us: attr.attributed_stall_us,
+            victim_stall_us: attr.stall_us,
+            blame_score: attr.blame_score,
+            timestamp: attr.timestamp,
+            victim: VictimRef {
+                pod: attr.victim_pod.clone(),
+                namespace: attr.victim_namespace.clone(),
+            },
+            offender: OffenderRef {
+                pod: attr.offender_pod.clone(),
+                namespace: attr.offender_namespace.clone(),
+                reason: BlameReason::classify(
+                    attr.cpu_share,
+                    attr.fork_count,
+                    attr.short_job_count,
+                ),
+            },
+        }
+    }
+
+    fn alert_message(&self) -> String {
+        format!(
+            "{}/{} stalled {}ms attributed to {}/{} ({})",
+            self.victim.namespace,
+            self.victim.pod,
+            self.stall_ms,
+            self.offender.namespace,
+            self.offender.pod,
+            self.offender.reason.as_str()
+        )
+    }
+}
+
+/// A counter map with a hard series cap.
+///
+/// When the cap is hit the smallest counter is evicted, and its value is kept
+/// aside so that if the same key shows up again it resumes rather than
+/// restarting at zero — a restart reads as a counter reset to Prometheus and
+/// silently loses the history. The carry map is capped the same way.
+struct CappedCounters {
+    values: HashMap<String, u64>,
+    carry: HashMap<String, u64>,
+    cap: usize,
+}
+
+impl CappedCounters {
+    fn new(cap: usize) -> Self {
+        Self {
+            values: HashMap::new(),
+            carry: HashMap::new(),
+            cap: cap.max(1),
+        }
+    }
+
+    /// Evicts the lowest-valued entry, parking its value in `carry`.
+    fn evict_one(&mut self) -> Option<String> {
+        let victim = self
+            .values
+            .iter()
+            .min_by_key(|(_, v)| **v)
+            .map(|(k, v)| (k.clone(), *v))?;
+
+        self.values.remove(&victim.0);
+
+        if self.carry.len() >= self.cap
+            && let Some(drop_key) = self
+                .carry
+                .iter()
+                .min_by_key(|(_, v)| **v)
+                .map(|(k, _)| k.clone())
+        {
+            self.carry.remove(&drop_key);
+        }
+        self.carry.insert(victim.0.clone(), victim.1);
+
+        Some(victim.0)
+    }
+
+    /// Returns true if an eviction was needed to make room.
+    fn ensure_room_for(&mut self, key: &str) -> bool {
+        if self.values.contains_key(key) || self.values.len() < self.cap {
+            return false;
+        }
+        self.evict_one().is_some()
+    }
+
+    fn add(&mut self, key: &str, delta: u64) -> bool {
+        let evicted = self.ensure_room_for(key);
+        if let Some(existing) = self.values.get_mut(key) {
+            *existing = existing.saturating_add(delta);
+        } else {
+            let resumed = self.carry.remove(key).unwrap_or(0);
+            self.values.insert(key.to_string(), resumed + delta);
+        }
+        evicted
+    }
+
+    fn len(&self) -> usize {
+        self.values.len()
+    }
+}
+
+/// Last cumulative PSI reading seen for each container cgroup, so that the
+/// per-pod counter can be advanced by deltas.
+///
+/// Bounded like the counter maps. Losing an entry costs one over-count when
+/// that container is next seen — the same cost as a genuine cgroup replacement,
+/// which is the conservative direction.
+struct LastSeen {
+    values: HashMap<String, u64>,
+    cap: usize,
+}
+
+impl LastSeen {
+    fn new(cap: usize) -> Self {
+        Self {
+            values: HashMap::new(),
+            cap: cap.max(1),
+        }
+    }
+
+    /// Returns how much this container's stall counter advanced since the last
+    /// reading. A counter that moved backwards means the cgroup was replaced
+    /// (container restart), in which case the whole new value is the advance.
+    fn advance(&mut self, container_id: &str, cumulative: u64) -> u64 {
+        let delta = match self.values.get(container_id) {
+            Some(&previous) if cumulative >= previous => cumulative - previous,
+            Some(_) => cumulative,
+            None => cumulative,
+        };
+
+        if !self.values.contains_key(container_id)
+            && self.values.len() >= self.cap
+            && let Some(drop_key) = self
+                .values
+                .iter()
+                .min_by_key(|(_, v)| **v)
+                .map(|(k, _)| k.clone())
+        {
+            self.values.remove(&drop_key);
+        }
+        self.values.insert(container_id.to_string(), cumulative);
+
+        delta
+    }
+}
+
+/// Per-pod and per-offender/victim-pair counters backing the "noisy neighbour"
+/// metrics. Keys are pre-rendered Prometheus label sets so rendering a scrape
+/// is a string concatenation and never touches the incident database.
+pub struct BlameMetrics {
+    /// `linnix_pod_psi_pressure_total` — PSI stall accumulated per victim pod.
+    victims: Mutex<CappedCounters>,
+    /// Per-container cursors feeding `victims`. A pod's cgroups are per
+    /// *container instance*: a sidecar means several, and a restart replaces
+    /// one with a counter that starts back at zero. Both are folded into a
+    /// single per-pod series by accumulating deltas here rather than exporting
+    /// the kernel's figure directly.
+    last_seen: Mutex<LastSeen>,
+    /// `linnix_stall_induced_seconds_total` — stall microseconds attributed to
+    /// an (offender, victim) pair.
+    pairs: Mutex<CappedCounters>,
+    evictions: AtomicU64,
+    node: String,
+}
+
+impl BlameMetrics {
+    pub fn new(node: impl Into<String>) -> Self {
+        Self::with_cap(node, DEFAULT_MAX_SERIES)
+    }
+
+    pub fn with_cap(node: impl Into<String>, cap: usize) -> Self {
+        Self {
+            victims: Mutex::new(CappedCounters::new(cap)),
+            last_seen: Mutex::new(LastSeen::new(cap)),
+            pairs: Mutex::new(CappedCounters::new(cap)),
+            evictions: AtomicU64::new(0),
+            node: node.into(),
+        }
+    }
+
+    fn note_eviction(&self, family: &str) {
+        let total = self.evictions.fetch_add(1, Ordering::Relaxed) + 1;
+        // Loud on the first eviction, then every 1000th: the cap being reached
+        // at all usually means it is set wrong for this cluster.
+        if total == 1 || total.is_multiple_of(1000) {
+            warn!(
+                "[attribution] {} series cap reached, evicting lowest counter \
+                 (total evictions: {}); rate() continuity is lost for evicted series",
+                family, total
+            );
+        }
+    }
+
+    /// Records one container cgroup's cumulative PSI stall, advancing the
+    /// owning pod's counter by however much it moved since the last reading.
+    pub fn record_victim_pressure(
+        &self,
+        namespace: &str,
+        pod: &str,
+        container_id: &str,
+        some_total_us: u64,
+    ) {
+        let delta = match self.last_seen.lock() {
+            Ok(mut seen) => seen.advance(container_id, some_total_us),
+            Err(_) => return,
+        };
+        if delta == 0 {
+            return;
+        }
+
+        let key = format!(
+            "namespace=\"{}\",pod=\"{}\",node=\"{}\"",
+            escape_label(namespace),
+            escape_label(pod),
+            escape_label(&self.node)
+        );
+        let evicted = self
+            .victims
+            .lock()
+            .map(|mut m| m.add(&key, delta))
+            .unwrap_or(false);
+        if evicted {
+            self.note_eviction("linnix_pod_psi_pressure_total");
+        }
+    }
+
+    /// Credits an offender with its share of a victim's stall.
+    pub fn record_attribution(&self, attr: &BlameAttribution) {
+        if attr.attributed_stall_us == 0 {
+            return;
+        }
+        let key = format!(
+            "offender_pod=\"{}\",offender_namespace=\"{}\",victim_pod=\"{}\",victim_namespace=\"{}\"",
+            escape_label(&attr.offender_pod),
+            escape_label(&attr.offender_namespace),
+            escape_label(&attr.victim_pod),
+            escape_label(&attr.victim_namespace)
+        );
+        let evicted = self
+            .pairs
+            .lock()
+            .map(|mut m| m.add(&key, attr.attributed_stall_us))
+            .unwrap_or(false);
+        if evicted {
+            self.note_eviction("linnix_stall_induced_seconds_total");
+        }
+    }
+
+    /// Appends both metric families in Prometheus text exposition format.
+    pub fn render_prometheus(&self, body: &mut String) {
+        let _ = writeln!(
+            body,
+            "# HELP linnix_pod_psi_pressure_total Cumulative CPU pressure stall time per pod, in microseconds."
+        );
+        let _ = writeln!(body, "# TYPE linnix_pod_psi_pressure_total counter");
+        if let Ok(victims) = self.victims.lock() {
+            for (labels, value) in victims.values.iter() {
+                let _ = writeln!(
+                    body,
+                    "linnix_pod_psi_pressure_total{{{}}} {}",
+                    labels, value
+                );
+            }
+        }
+
+        let _ = writeln!(
+            body,
+            "# HELP linnix_stall_induced_seconds_total Stall time attributed to an offending pod, in seconds."
+        );
+        let _ = writeln!(body, "# TYPE linnix_stall_induced_seconds_total counter");
+        if let Ok(pairs) = self.pairs.lock() {
+            for (labels, value) in pairs.values.iter() {
+                let _ = writeln!(
+                    body,
+                    "linnix_stall_induced_seconds_total{{{}}} {:.6}",
+                    labels,
+                    *value as f64 / 1_000_000.0
+                );
+            }
+        }
+
+        let _ = writeln!(
+            body,
+            "# HELP linnix_blame_series_evicted_total Blame series dropped because the series cap was reached."
+        );
+        let _ = writeln!(body, "# TYPE linnix_blame_series_evicted_total counter");
+        let _ = writeln!(
+            body,
+            "linnix_blame_series_evicted_total {}",
+            self.evictions.load(Ordering::Relaxed)
+        );
+    }
+
+    pub fn victim_series(&self) -> usize {
+        self.victims.lock().map(|m| m.len()).unwrap_or(0)
+    }
+
+    pub fn pair_series(&self) -> usize {
+        self.pairs.lock().map(|m| m.len()).unwrap_or(0)
+    }
+
+    pub fn evictions(&self) -> u64 {
+        self.evictions.load(Ordering::Relaxed)
+    }
+}
+
+fn escape_label(value: &str) -> String {
+    value
+        .replace('\\', "\\\\")
+        .replace('"', "\\\"")
+        .replace('\n', "\\n")
+}
+
+/// The single point where a completed attribution fans out to logs, alerts and
+/// metrics. Callers hand it the attributions for one stall event; it decides
+/// what crosses the reporting threshold.
+pub struct AttributionSink {
+    metrics: std::sync::Arc<BlameMetrics>,
+    alerts: Option<broadcast::Sender<Alert>>,
+    host: String,
+    threshold_us: u64,
+}
+
+impl AttributionSink {
+    pub fn new(
+        metrics: std::sync::Arc<BlameMetrics>,
+        alerts: Option<broadcast::Sender<Alert>>,
+        host: impl Into<String>,
+    ) -> Self {
+        Self {
+            metrics,
+            alerts,
+            host: host.into(),
+            threshold_us: DEFAULT_ATTRIBUTED_STALL_THRESHOLD_US,
+        }
+    }
+
+    pub fn with_threshold_us(mut self, threshold_us: u64) -> Self {
+        self.threshold_us = threshold_us;
+        self
+    }
+
+    pub fn metrics(&self) -> &std::sync::Arc<BlameMetrics> {
+        &self.metrics
+    }
+
+    /// Every attribution updates the counters; only those over the threshold
+    /// produce a JSON line and an alert. Returns the events that were emitted
+    /// so callers (and tests) can see exactly what a user would observe.
+    pub fn emit(&self, attributions: &[BlameAttribution]) -> Vec<AttributionEvent> {
+        let mut emitted = Vec::new();
+
+        for attr in attributions {
+            self.metrics.record_attribution(attr);
+
+            if attr.attributed_stall_us < self.threshold_us {
+                continue;
+            }
+
+            let event = AttributionEvent::from_attribution(attr);
+
+            match serde_json::to_string(&event) {
+                Ok(line) => info!("{}", line),
+                Err(e) => warn!("[attribution] failed to serialize attribution event: {}", e),
+            }
+
+            if let Some(tx) = &self.alerts {
+                let _ = tx.send(Alert {
+                    rule: "stall_attribution".to_string(),
+                    severity: Severity::Medium,
+                    message: event.alert_message(),
+                    host: self.host.clone(),
+                });
+            }
+
+            emitted.push(event);
+        }
+
+        emitted
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn attribution(offender: &str, attributed_us: u64) -> BlameAttribution {
+        BlameAttribution {
+            victim_pod: "payment-api".to_string(),
+            victim_namespace: "prod".to_string(),
+            offender_pod: offender.to_string(),
+            offender_namespace: "prod".to_string(),
+            blame_score: 1.0,
+            stall_us: 1_000_000,
+            attributed_stall_us: attributed_us,
+            timestamp: 1_700_000_000,
+            cpu_share: 0.9,
+            fork_count: 0,
+            short_job_count: 0,
+        }
+    }
+
+    #[test]
+    fn blame_reason_picks_dominant_factor() {
+        assert_eq!(
+            BlameReason::classify(0.9, 10, 5),
+            BlameReason::HighCpuContention
+        );
+        assert_eq!(BlameReason::classify(0.1, 200, 5), BlameReason::ForkStorm);
+        assert_eq!(
+            BlameReason::classify(0.1, 0, 100),
+            BlameReason::ShortJobChurn
+        );
+    }
+
+    #[test]
+    fn counters_resume_after_eviction_instead_of_resetting() {
+        let mut counters = CappedCounters::new(2);
+        counters.add("a", 500);
+        counters.add("b", 10);
+        // "b" is the smallest, so adding "c" evicts it.
+        assert!(counters.add("c", 300));
+        assert_eq!(counters.len(), 2);
+        assert!(!counters.values.contains_key("b"));
+
+        // "b" comes back and resumes from where it left off rather than zero.
+        counters.add("b", 5);
+        assert_eq!(counters.values.get("b"), Some(&15));
+    }
+
+    #[test]
+    fn a_replaced_cgroup_contributes_its_whole_counter() {
+        let mut seen = LastSeen::new(8);
+        assert_eq!(seen.advance("c1", 1_000), 1_000);
+        assert_eq!(seen.advance("c1", 1_500), 500);
+        // Container restarted: the kernel counter starts over, so the reading
+        // is itself the advance rather than a negative delta.
+        assert_eq!(seen.advance("c1", 200), 200);
+    }
+
+    #[test]
+    fn label_values_are_escaped() {
+        let metrics = BlameMetrics::new("node-1");
+        metrics.record_victim_pressure("prod", "we\"ird\\pod", "container-1", 42);
+        let mut body = String::new();
+        metrics.render_prometheus(&mut body);
+        assert!(body.contains(r#"pod="we\"ird\\pod""#), "body was: {}", body);
+    }
+
+    #[test]
+    fn sink_counts_everything_but_only_reports_over_threshold() {
+        let metrics = std::sync::Arc::new(BlameMetrics::new("node-1"));
+        let sink = AttributionSink::new(metrics.clone(), None, "node-1");
+
+        let emitted = sink.emit(&[attribution("loud", 250_000), attribution("quiet", 1_000)]);
+
+        assert_eq!(emitted.len(), 1);
+        assert_eq!(emitted[0].offender.pod, "loud");
+        assert_eq!(emitted[0].stall_ms, 250);
+        // Both still contribute to the counters.
+        assert_eq!(metrics.pair_series(), 2);
+    }
+}

--- a/cognitod/src/attribution.rs
+++ b/cognitod/src/attribution.rs
@@ -15,6 +15,7 @@ use std::collections::HashMap;
 use std::fmt::Write as _;
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{Duration, Instant};
 
 use log::warn;
 use serde::{Deserialize, Serialize};
@@ -28,6 +29,11 @@ use crate::collectors::psi::BlameAttribution;
 /// victim is stalling at all: one 500ms stall split across six neighbours is
 /// not six noisy neighbours.
 pub const DEFAULT_ATTRIBUTED_STALL_THRESHOLD_US: u64 = 100_000; // 100ms
+
+/// How long an offender/victim pair stays quiet after being reported. Without
+/// this, sustained pressure re-reports every detection window for as long as it
+/// lasts — the alert channel feeds Slack and Apprise, so that is a pager storm.
+pub const DEFAULT_COOLDOWN_SECONDS: u64 = 300; // 5 minutes
 
 /// Upper bound on distinct series held per counter family. Generous on purpose:
 /// eviction breaks `rate()` continuity for the evicted series, so the cap is a
@@ -435,6 +441,10 @@ pub struct AttributionSink {
     alerts: Option<broadcast::Sender<Alert>>,
     host: String,
     threshold_us: u64,
+    cooldown: Duration,
+    /// When each offender/victim pair was last reported, so a stall that lasts
+    /// an hour does not report every `sustained_pressure_seconds` for an hour.
+    reported: Mutex<HashMap<String, Instant>>,
 }
 
 impl AttributionSink {
@@ -448,6 +458,8 @@ impl AttributionSink {
             alerts,
             host: host.into(),
             threshold_us: DEFAULT_ATTRIBUTED_STALL_THRESHOLD_US,
+            cooldown: Duration::from_secs(DEFAULT_COOLDOWN_SECONDS),
+            reported: Mutex::new(HashMap::new()),
         }
     }
 
@@ -456,13 +468,59 @@ impl AttributionSink {
         self
     }
 
+    /// Sets how long the same offender/victim pair stays quiet after being
+    /// reported. Zero reports every occurrence.
+    pub fn with_cooldown(mut self, cooldown: Duration) -> Self {
+        self.cooldown = cooldown;
+        self
+    }
+
     pub fn metrics(&self) -> &std::sync::Arc<BlameMetrics> {
         &self.metrics
     }
 
-    /// Every attribution updates the counters; only those over the threshold
-    /// produce a JSON line and an alert. Returns the events that were emitted
-    /// so callers (and tests) can see exactly what a user would observe.
+    /// Whether this pair may be reported now, recording the report if so.
+    ///
+    /// Suppression is per pair rather than per rule: a second, unrelated noisy
+    /// neighbour appearing during an ongoing incident is news and must not be
+    /// swallowed by the first one's cooldown.
+    fn claim_report_slot(&self, attr: &BlameAttribution) -> bool {
+        if self.cooldown.is_zero() {
+            return true;
+        }
+
+        let key = format!(
+            "{}/{}->{}/{}",
+            attr.offender_namespace, attr.offender_pod, attr.victim_namespace, attr.victim_pod
+        );
+        let now = Instant::now();
+
+        let Ok(mut reported) = self.reported.lock() else {
+            // A poisoned lock must not silence alerting.
+            return true;
+        };
+
+        if let Some(last) = reported.get(&key)
+            && now.duration_since(*last) < self.cooldown
+        {
+            return false;
+        }
+
+        // Drop pairs that have gone quiet, so a cluster that churns through
+        // many short-lived offenders does not grow this map without bound.
+        if reported.len() >= DEFAULT_MAX_SERIES {
+            let cooldown = self.cooldown;
+            reported.retain(|_, last| now.duration_since(*last) < cooldown);
+        }
+
+        reported.insert(key, now);
+        true
+    }
+
+    /// Every attribution updates the counters; only those over the threshold,
+    /// and not already reported within the cooldown, produce a JSON line and an
+    /// alert. Returns the events that were emitted so callers (and tests) can
+    /// see exactly what a user would observe.
     pub fn emit(&self, attributions: &[BlameAttribution]) -> Vec<AttributionEvent> {
         let mut emitted = Vec::new();
 
@@ -470,6 +528,12 @@ impl AttributionSink {
             self.metrics.record_attribution(attr);
 
             if attr.attributed_stall_us < self.threshold_us {
+                continue;
+            }
+
+            // Counters above are updated unconditionally: they stay the
+            // continuous signal while reporting is throttled.
+            if !self.claim_report_slot(attr) {
                 continue;
             }
 

--- a/cognitod/src/attribution.rs
+++ b/cognitod/src/attribution.rs
@@ -16,7 +16,7 @@ use std::fmt::Write as _;
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicU64, Ordering};
 
-use log::{info, warn};
+use log::warn;
 use serde::{Deserialize, Serialize};
 use tokio::sync::broadcast;
 
@@ -162,7 +162,12 @@ impl CappedCounters {
     }
 
     /// Evicts the lowest-valued entry, parking its value in `carry`.
-    fn evict_one(&mut self) -> Option<String> {
+    ///
+    /// `incoming` is the key being made room for. It is never chosen as the
+    /// carry entry to discard: dropping the carried total of the very series
+    /// about to be re-inserted would restart it from zero, which is the counter
+    /// reset this carry mechanism exists to prevent.
+    fn evict_one(&mut self, incoming: &str) -> Option<String> {
         let victim = self
             .values
             .iter()
@@ -175,6 +180,7 @@ impl CappedCounters {
             && let Some(drop_key) = self
                 .carry
                 .iter()
+                .filter(|(k, _)| k.as_str() != incoming)
                 .min_by_key(|(_, v)| **v)
                 .map(|(k, _)| k.clone())
         {
@@ -190,7 +196,7 @@ impl CappedCounters {
         if self.values.contains_key(key) || self.values.len() < self.cap {
             return false;
         }
-        self.evict_one().is_some()
+        self.evict_one(key).is_some()
     }
 
     fn add(&mut self, key: &str, delta: u64) -> bool {
@@ -469,8 +475,12 @@ impl AttributionSink {
 
             let event = AttributionEvent::from_attribution(attr);
 
+            // Logged at warn to match the severity the event declares: these
+            // would otherwise vanish under RUST_LOG=warn, which is exactly the
+            // filter an operator sets when they only want the events that
+            // matter.
             match serde_json::to_string(&event) {
-                Ok(line) => info!("{}", line),
+                Ok(line) => warn!("{}", line),
                 Err(e) => warn!("[attribution] failed to serialize attribution event: {}", e),
             }
 
@@ -536,6 +546,27 @@ mod tests {
         // "b" comes back and resumes from where it left off rather than zero.
         counters.add("b", 5);
         assert_eq!(counters.values.get("b"), Some(&15));
+    }
+
+    #[test]
+    fn a_returning_series_keeps_its_carry_when_both_maps_are_full() {
+        let mut counters = CappedCounters::new(2);
+        counters.add("a", 100);
+        counters.add("b", 200);
+
+        // Push "a" and "b" out, filling carry with both.
+        counters.add("c", 900);
+        counters.add("d", 900);
+        assert_eq!(counters.carry.len(), 2);
+
+        // "a" holds the smallest carried value, so a naive eviction would
+        // discard it while making room for "a" itself.
+        counters.add("a", 50);
+        assert_eq!(
+            counters.values.get("a"),
+            Some(&150),
+            "the returning series should resume from its carried total"
+        );
     }
 
     #[test]

--- a/cognitod/src/collectors/psi.rs
+++ b/cognitod/src/collectors/psi.rs
@@ -7,6 +7,7 @@ use std::time::{Duration, Instant};
 use tokio::time::sleep;
 use walkdir::WalkDir;
 
+use crate::attribution::AttributionSink;
 use crate::context::ContextStore;
 use crate::k8s::K8sContext;
 
@@ -49,7 +50,12 @@ pub struct BlameAttribution {
     pub offender_pod: String,
     pub offender_namespace: String,
     pub blame_score: f64,
+    /// The victim's total stall for this window. Identical across every
+    /// attribution for the same event, so summing it double-counts.
     pub stall_us: u64,
+    /// This offender's share of `stall_us`, split by blame score. Summing this
+    /// across an event's attributions stays within the stall that happened.
+    pub attributed_stall_us: u64,
     pub timestamp: u64,
     pub cpu_share: f64,
     pub fork_count: u64,
@@ -122,9 +128,13 @@ pub struct PsiMonitor {
     k8s_ctx: Arc<K8sContext>,
     context: Arc<ContextStore>,
     incident_store: Option<Arc<crate::incidents::IncidentStore>>,
+    sink: Arc<AttributionSink>,
     history: HashMap<String, VecDeque<PsiSnapshot>>,
     pressure_start_time: HashMap<String, Instant>,
     sustained_pressure_duration: Duration,
+    cgroup_root: PathBuf,
+    /// When set, `run` stops after this many scans instead of looping forever.
+    max_iterations: Option<u64>,
 }
 
 impl PsiMonitor {
@@ -133,23 +143,41 @@ impl PsiMonitor {
         context: Arc<ContextStore>,
         incident_store: Option<Arc<crate::incidents::IncidentStore>>,
         sustained_pressure_seconds: u64,
+        sink: Arc<AttributionSink>,
     ) -> Self {
         Self {
             k8s_ctx,
             context,
             incident_store,
+            sink,
             history: HashMap::new(),
             pressure_start_time: HashMap::new(),
             sustained_pressure_duration: Duration::from_secs(sustained_pressure_seconds),
+            cgroup_root: PathBuf::from("/sys/fs/cgroup"),
+            max_iterations: None,
         }
+    }
+
+    /// Points the monitor at a different cgroup hierarchy. Exists so the scan
+    /// loop can be driven against a fixture tree rather than the live kernel.
+    pub fn with_cgroup_root(mut self, root: impl Into<PathBuf>) -> Self {
+        self.cgroup_root = root.into();
+        self
+    }
+
+    /// Bounds the scan loop so it terminates. Only useful for tests.
+    pub fn with_max_iterations(mut self, iterations: u64) -> Self {
+        self.max_iterations = Some(iterations);
+        self
     }
 
     pub async fn run(mut self) {
         info!("[psi] starting PSI monitor");
-        let base_path = Path::new("/sys/fs/cgroup");
+        let base_path = self.cgroup_root.clone();
+        let mut iterations = 0u64;
 
         loop {
-            let psi_files = find_psi_files(base_path);
+            let psi_files = find_psi_files(&base_path);
             debug!("[psi] scanning {} cgroups", psi_files.len());
 
             for path in psi_files {
@@ -159,6 +187,13 @@ impl PsiMonitor {
                     && let Ok(snapshot) = parse_psi_file(&content)
                 {
                     let key = format!("{}/{}", meta.namespace, meta.pod_name);
+
+                    self.sink.metrics().record_victim_pressure(
+                        &meta.namespace,
+                        &meta.pod_name,
+                        &container_id,
+                        snapshot.some_total,
+                    );
 
                     // Get or create history for this pod
                     let hist = self.history.entry(key.clone()).or_default();
@@ -223,7 +258,7 @@ impl PsiMonitor {
                                 );
 
                                 // Calculate blame attributions
-                                let attributions = self.calculate_blame_attributions(&stall_event);
+                                let attributions = calculate_blame_attributions(&stall_event);
 
                                 // Log top 3 attributions
                                 for (i, attr) in attributions.iter().take(3).enumerate() {
@@ -238,6 +273,10 @@ impl PsiMonitor {
                                         attr.short_job_count
                                     );
                                 }
+
+                                // Structured events, alerts and metrics all
+                                // leave through here.
+                                self.sink.emit(&attributions);
 
                                 // Persist to database if available
                                 if let Some(ref store) = self.incident_store {
@@ -279,6 +318,12 @@ impl PsiMonitor {
                 }
             }
 
+            iterations += 1;
+            if self.max_iterations.is_some_and(|max| iterations >= max) {
+                info!("[psi] scan limit reached, stopping PSI monitor");
+                return;
+            }
+
             sleep(Duration::from_secs(1)).await;
         }
     }
@@ -308,8 +353,15 @@ impl PsiMonitor {
         });
         consumers
     }
+}
 
-    fn calculate_blame_attributions(&self, event: &StallEvent) -> Vec<BlameAttribution> {
+/// Splits a victim's stall across the pods that plausibly caused it.
+///
+/// Free-standing because it is pure: it needs the stall event and nothing from
+/// the monitor's own state, which also means it can be exercised without a
+/// Kubernetes API to talk to.
+pub fn calculate_blame_attributions(event: &StallEvent) -> Vec<BlameAttribution> {
+    {
         let total_cpu: f32 = event
             .concurrent_consumers
             .iter()
@@ -387,11 +439,24 @@ impl PsiMonitor {
                     offender_namespace: ns,
                     blame_score,
                     stall_us: event.stall_delta_us,
+                    // Filled in below, once the total blame is known.
+                    attributed_stall_us: 0,
                     timestamp,
                     cpu_share,
                     fork_count,
                     short_job_count,
                 });
+            }
+        }
+
+        // Split the observed stall proportionally to blame. Truncating each
+        // share keeps the sum at or below the stall that actually occurred, so
+        // the derived counters can never claim more stall than the kernel saw.
+        let total_blame: f64 = attributions.iter().map(|a| a.blame_score).sum();
+        if total_blame > 0.0 {
+            for attr in &mut attributions {
+                attr.attributed_stall_us =
+                    ((attr.blame_score / total_blame) * event.stall_delta_us as f64) as u64;
             }
         }
 
@@ -433,24 +498,6 @@ mod tests {
 
     #[test]
     fn test_calculate_blame_attributions_with_forks() {
-        // Set env vars to force K8sContext creation
-        unsafe {
-            std::env::set_var("K8S_API_URL", "http://localhost:8001");
-            std::env::set_var("K8S_TOKEN", "dummy");
-        }
-
-        let k8s_ctx = K8sContext::new().expect("Failed to create K8sContext");
-        let monitor = PsiMonitor::new(
-            k8s_ctx.clone(),
-            Arc::new(ContextStore::new(
-                Duration::from_secs(60),
-                1000,
-                Some(k8s_ctx),
-            )),
-            None,
-            15,
-        );
-
         let mut fork_counts = HashMap::new();
         fork_counts.insert("default/fork-bomb".to_string(), 200);
 
@@ -478,7 +525,7 @@ mod tests {
             short_job_counts,
         };
 
-        let attributions = monitor.calculate_blame_attributions(&event);
+        let attributions = calculate_blame_attributions(&event);
 
         // We expect 3 offenders: cpu-hog, fork-bomb, short-job-pod
         assert_eq!(attributions.len(), 3);

--- a/cognitod/src/collectors/psi.rs
+++ b/cognitod/src/collectors/psi.rs
@@ -362,31 +362,50 @@ impl PsiMonitor {
 /// Kubernetes API to talk to.
 pub fn calculate_blame_attributions(event: &StallEvent) -> Vec<BlameAttribution> {
     {
-        let total_cpu: f32 = event
-            .concurrent_consumers
-            .iter()
-            .map(|c| c.cpu_percent)
-            .sum();
-
         let timestamp = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap()
             .as_secs();
 
+        // A pod cannot be its own noisy neighbour. CPU-bound victims show up in
+        // their own consumer list, and left in they would absorb most of their
+        // own stall and alert about themselves.
+        let victim_key = format!("{}/{}", event.victim_namespace, event.victim_pod);
+
+        // Consumers arrive per process, so a pod with several busy processes
+        // appears several times. Fold them together before scoring: comparing
+        // one process's CPU against every process's total would under-credit
+        // exactly the multi-process pods most likely to be causing the stall.
+        let mut cpu_by_pod: HashMap<String, f32> = HashMap::new();
+        for c in &event.concurrent_consumers {
+            let key = format!("{}/{}", c.namespace, c.pod);
+            if key == victim_key {
+                continue;
+            }
+            *cpu_by_pod.entry(key).or_insert(0.0) += c.cpu_percent;
+        }
+
+        let total_cpu: f32 = cpu_by_pod.values().sum();
+
         // Collect all potential offenders (CPU consumers + forkers + short-job creators)
         let mut offenders: HashMap<String, (String, String)> = HashMap::new(); // key -> (ns, pod)
 
-        for c in &event.concurrent_consumers {
-            let key = format!("{}/{}", c.namespace, c.pod);
-            offenders.insert(key, (c.namespace.clone(), c.pod.clone()));
-        }
-        for key in event.fork_counts.keys() {
+        for key in cpu_by_pod.keys() {
             if let Some((ns, pod)) = key.split_once('/') {
                 offenders.insert(key.clone(), (ns.to_string(), pod.to_string()));
             }
         }
+        for key in event.fork_counts.keys() {
+            if let Some((ns, pod)) = key.split_once('/')
+                && key != &victim_key
+            {
+                offenders.insert(key.clone(), (ns.to_string(), pod.to_string()));
+            }
+        }
         for key in event.short_job_counts.keys() {
-            if let Some((ns, pod)) = key.split_once('/') {
+            if let Some((ns, pod)) = key.split_once('/')
+                && key != &victim_key
+            {
                 offenders.insert(key.clone(), (ns.to_string(), pod.to_string()));
             }
         }
@@ -394,13 +413,7 @@ pub fn calculate_blame_attributions(event: &StallEvent) -> Vec<BlameAttribution>
         let mut attributions = Vec::new();
 
         for (key, (ns, pod)) in offenders {
-            // CPU Share
-            let cpu_percent = event
-                .concurrent_consumers
-                .iter()
-                .find(|c| c.namespace == ns && c.pod == pod)
-                .map(|c| c.cpu_percent)
-                .unwrap_or(0.0);
+            let cpu_percent = cpu_by_pod.get(&key).copied().unwrap_or(0.0);
 
             let cpu_share = if total_cpu > 0.0 {
                 (cpu_percent / total_cpu) as f64

--- a/cognitod/src/config.rs
+++ b/cognitod/src/config.rs
@@ -337,18 +337,41 @@ pub struct PsiConfig {
     /// Duration in seconds of sustained pressure required to trigger attribution
     #[serde(default = "default_psi_sustained_pressure_seconds")]
     pub sustained_pressure_seconds: u64,
+    /// Stall attributed to a single offender, in milliseconds, before it is
+    /// reported. A large stall split across many neighbours is not a noisy
+    /// neighbour, so this is deliberately separate from the threshold that
+    /// decides whether the victim is stalling at all.
+    #[serde(default = "default_attribution_threshold_ms")]
+    pub attribution_threshold_ms: u64,
+    /// How long to wait before reporting the same offender/victim pair again.
+    /// Pressure lasting an hour would otherwise re-alert every
+    /// `sustained_pressure_seconds` for that whole hour. Set to 0 to report
+    /// every occurrence. The Prometheus counters are unaffected either way —
+    /// they remain the continuous signal.
+    #[serde(default = "default_attribution_cooldown_seconds")]
+    pub attribution_cooldown_seconds: u64,
 }
 
 impl Default for PsiConfig {
     fn default() -> Self {
         Self {
             sustained_pressure_seconds: default_psi_sustained_pressure_seconds(),
+            attribution_threshold_ms: default_attribution_threshold_ms(),
+            attribution_cooldown_seconds: default_attribution_cooldown_seconds(),
         }
     }
 }
 
 fn default_psi_sustained_pressure_seconds() -> u64 {
     15
+}
+
+fn default_attribution_threshold_ms() -> u64 {
+    100
+}
+
+fn default_attribution_cooldown_seconds() -> u64 {
+    300
 }
 #[derive(Debug, Deserialize, Clone, Default)]
 pub struct ProbesConfig {

--- a/cognitod/src/k8s.rs
+++ b/cognitod/src/k8s.rs
@@ -226,6 +226,16 @@ impl K8sContext {
         let map = self.container_map.read().unwrap();
         map.get(container_id).cloned()
     }
+
+    /// Inserts container metadata directly, bypassing the API watcher.
+    ///
+    /// Lets callers that already know a container's identity — notably tests
+    /// driving the collectors against a fixture cgroup tree — populate the
+    /// cache without a reachable Kubernetes API.
+    pub fn insert_metadata(&self, container_id: impl Into<String>, metadata: K8sMetadata) {
+        let mut map = self.container_map.write().unwrap();
+        map.insert(container_id.into(), metadata);
+    }
 }
 
 #[derive(Deserialize)]

--- a/cognitod/src/lib.rs
+++ b/cognitod/src/lib.rs
@@ -2,6 +2,7 @@
 // Both local stable and Docker stable support it without feature flags
 
 pub mod alerts;
+pub mod attribution;
 pub mod bpf_config;
 pub mod collectors;
 pub mod config;

--- a/cognitod/src/main.rs
+++ b/cognitod/src/main.rs
@@ -794,11 +794,17 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     // Start PSI monitor (after incident store is ready)
     if let Some(ctx) = &k8s_context {
-        let sink = Arc::new(cognitod::attribution::AttributionSink::new(
-            blame_metrics.clone(),
-            alert_tx.clone(),
-            ctx.node_name.clone(),
-        ));
+        let sink = Arc::new(
+            cognitod::attribution::AttributionSink::new(
+                blame_metrics.clone(),
+                alert_tx.clone(),
+                ctx.node_name.clone(),
+            )
+            .with_threshold_us(config.psi.attribution_threshold_ms.saturating_mul(1_000))
+            .with_cooldown(std::time::Duration::from_secs(
+                config.psi.attribution_cooldown_seconds,
+            )),
+        );
         let psi_monitor = cognitod::collectors::psi::PsiMonitor::new(
             ctx.clone(),
             context.clone(),

--- a/cognitod/src/main.rs
+++ b/cognitod/src/main.rs
@@ -782,13 +782,29 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     // KB Index removed (YAGNI cleanup)
 
+    // Blame metrics live for the process lifetime: the PSI monitor writes to
+    // them and /metrics/prometheus reads them, so a scrape never has to query
+    // the incident database.
+    let blame_metrics = Arc::new(cognitod::attribution::BlameMetrics::new(
+        k8s_context
+            .as_ref()
+            .map(|ctx| ctx.node_name.clone())
+            .unwrap_or_else(|| "unknown".to_string()),
+    ));
+
     // Start PSI monitor (after incident store is ready)
     if let Some(ctx) = &k8s_context {
+        let sink = Arc::new(cognitod::attribution::AttributionSink::new(
+            blame_metrics.clone(),
+            alert_tx.clone(),
+            ctx.node_name.clone(),
+        ));
         let psi_monitor = cognitod::collectors::psi::PsiMonitor::new(
             ctx.clone(),
             context.clone(),
             incident_store.clone(),
             config.psi.sustained_pressure_seconds,
+            sink,
         );
         tokio::spawn(async move {
             psi_monitor.run().await;
@@ -1151,6 +1167,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         enforcement: enforcement_queue.clone(),
         incident_store: incident_store.clone(),
         k8s: k8s_context.clone(),
+        blame_metrics: blame_metrics.clone(),
     });
 
     let api = all_routes(app_state.clone());

--- a/cognitod/tests/attribution_eval.rs
+++ b/cognitod/tests/attribution_eval.rs
@@ -1,0 +1,501 @@
+//! Eval suite for the stall-attribution emit seam.
+//!
+//! These are not assertions about internal helpers. Each case describes a
+//! cluster situation an SRE would recognise — a CPU hog next door, a fork bomb,
+//! a stall too small to care about — and checks the three things a user
+//! actually observes when it happens: the JSON log event, the alert, and the
+//! Prometheus counters.
+//!
+//! Scenarios live in one table so adding a case is a data change, not a code
+//! change, and so a regression names the situation it broke rather than a
+//! function.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use cognitod::attribution::{AttributionSink, BlameMetrics, BlameReason};
+use cognitod::collectors::psi::{CpuConsumer, StallEvent, calculate_blame_attributions};
+
+/// What an offender is expected to look like in the emitted output.
+struct ExpectedOffender {
+    pod: &'static str,
+    reason: BlameReason,
+    /// Inclusive bounds on the stall credited to this offender, in
+    /// milliseconds. A range rather than a point because the split is
+    /// proportional to a heuristic score we expect to keep tuning.
+    stall_ms: (u64, u64),
+}
+
+struct Scenario {
+    /// What is happening in the cluster, in the words a user would use.
+    name: &'static str,
+    victim_stall_us: u64,
+    consumers: &'static [(&'static str, f32)],
+    forks: &'static [(&'static str, u64)],
+    short_jobs: &'static [(&'static str, u64)],
+    /// Offenders expected to produce a JSON event and an alert, in rank order.
+    expect_reported: &'static [ExpectedOffender],
+    /// Offenders expected to be counted but stay below the reporting bar.
+    expect_counted_only: &'static [&'static str],
+}
+
+const SCENARIOS: &[Scenario] = &[
+    Scenario {
+        name: "a single CPU hog monopolises the node and stalls the payment API",
+        victim_stall_us: 800_000,
+        consumers: &[("image-resize-worker", 90.0), ("sidecar-proxy", 1.0)],
+        forks: &[],
+        short_jobs: &[],
+        expect_reported: &[ExpectedOffender {
+            pod: "image-resize-worker",
+            reason: BlameReason::HighCpuContention,
+            stall_ms: (700, 800),
+        }],
+        expect_counted_only: &["sidecar-proxy"],
+    },
+    Scenario {
+        name: "a fork bomb is blamed even though its CPU share looks modest",
+        victim_stall_us: 1_000_000,
+        consumers: &[("fork-bomb", 10.0), ("steady-worker", 20.0)],
+        forks: &[("prod/fork-bomb", 400)],
+        short_jobs: &[],
+        expect_reported: &[
+            ExpectedOffender {
+                pod: "fork-bomb",
+                reason: BlameReason::ForkStorm,
+                stall_ms: (600, 900),
+            },
+            ExpectedOffender {
+                pod: "steady-worker",
+                reason: BlameReason::HighCpuContention,
+                stall_ms: (100, 400),
+            },
+        ],
+        expect_counted_only: &[],
+    },
+    Scenario {
+        name: "a CI runner churning short-lived jobs is named as the offender",
+        victim_stall_us: 600_000,
+        consumers: &[],
+        forks: &[],
+        short_jobs: &[("prod/ci-runner", 120)],
+        expect_reported: &[ExpectedOffender {
+            pod: "ci-runner",
+            reason: BlameReason::ShortJobChurn,
+            stall_ms: (500, 600),
+        }],
+        expect_counted_only: &[],
+    },
+    Scenario {
+        name: "a stall split thinly across many neighbours reports nobody",
+        victim_stall_us: 300_000,
+        consumers: &[
+            ("neighbour-a", 25.0),
+            ("neighbour-b", 25.0),
+            ("neighbour-c", 25.0),
+            ("neighbour-d", 25.0),
+        ],
+        forks: &[],
+        short_jobs: &[],
+        // 300ms over four equal neighbours is 75ms each: real, but not a noisy
+        // neighbour worth waking anyone for.
+        expect_reported: &[],
+        expect_counted_only: &["neighbour-a", "neighbour-b", "neighbour-c", "neighbour-d"],
+    },
+];
+
+const VICTIM_POD: &str = "payment-api";
+const VICTIM_NS: &str = "prod";
+
+fn build_stall_event(scenario: &Scenario) -> StallEvent {
+    StallEvent {
+        victim_pod: VICTIM_POD.to_string(),
+        victim_namespace: VICTIM_NS.to_string(),
+        stall_delta_us: scenario.victim_stall_us,
+        timestamp: Instant::now(),
+        concurrent_consumers: scenario
+            .consumers
+            .iter()
+            .map(|(pod, cpu)| CpuConsumer {
+                pod: (*pod).to_string(),
+                namespace: VICTIM_NS.to_string(),
+                cpu_percent: *cpu,
+            })
+            .collect(),
+        fork_counts: scenario
+            .forks
+            .iter()
+            .map(|(key, count)| ((*key).to_string(), *count))
+            .collect(),
+        short_job_counts: scenario
+            .short_jobs
+            .iter()
+            .map(|(key, count)| ((*key).to_string(), *count))
+            .collect(),
+    }
+}
+
+#[test]
+fn scenarios_produce_the_expected_events_alerts_and_metrics() {
+    for scenario in SCENARIOS {
+        let metrics = Arc::new(BlameMetrics::new("node-1"));
+        let (alert_tx, mut alert_rx) = tokio::sync::broadcast::channel(64);
+        let sink = AttributionSink::new(metrics.clone(), Some(alert_tx), "node-1");
+
+        let event = build_stall_event(scenario);
+        let attributions = calculate_blame_attributions(&event);
+        let emitted = sink.emit(&attributions);
+
+        // The split must never invent stall time that the kernel did not report.
+        let total_attributed: u64 = attributions.iter().map(|a| a.attributed_stall_us).sum();
+        assert!(
+            total_attributed <= scenario.victim_stall_us,
+            "[{}] attributed {}us exceeds the observed stall of {}us",
+            scenario.name,
+            total_attributed,
+            scenario.victim_stall_us
+        );
+
+        assert_eq!(
+            emitted.len(),
+            scenario.expect_reported.len(),
+            "[{}] expected {} reported offender(s), got {:?}",
+            scenario.name,
+            scenario.expect_reported.len(),
+            emitted
+                .iter()
+                .map(|e| e.offender.pod.as_str())
+                .collect::<Vec<_>>()
+        );
+
+        for (expected, actual) in scenario.expect_reported.iter().zip(emitted.iter()) {
+            assert_eq!(
+                actual.offender.pod, expected.pod,
+                "[{}] wrong offender ranked",
+                scenario.name
+            );
+            assert_eq!(
+                actual.offender.reason, expected.reason,
+                "[{}] wrong reason for {}",
+                scenario.name, expected.pod
+            );
+            assert!(
+                actual.stall_ms >= expected.stall_ms.0 && actual.stall_ms <= expected.stall_ms.1,
+                "[{}] {} credited {}ms, expected {}..={}ms",
+                scenario.name,
+                expected.pod,
+                actual.stall_ms,
+                expected.stall_ms.0,
+                expected.stall_ms.1
+            );
+
+            // The victim must be identifiable, otherwise the event is useless
+            // for the person being paged.
+            assert_eq!(actual.victim.pod, VICTIM_POD);
+            assert_eq!(actual.victim.namespace, VICTIM_NS);
+            assert_eq!(actual.event_type, "linnix.stall_attribution");
+        }
+
+        // Every reported offender produces exactly one alert on the same
+        // channel the rest of the daemon already uses.
+        let mut alerts = Vec::new();
+        while let Ok(alert) = alert_rx.try_recv() {
+            alerts.push(alert);
+        }
+        assert_eq!(
+            alerts.len(),
+            scenario.expect_reported.len(),
+            "[{}] alert count did not match reported offenders",
+            scenario.name
+        );
+        for (alert, expected) in alerts.iter().zip(scenario.expect_reported.iter()) {
+            assert_eq!(alert.rule, "stall_attribution");
+            assert!(
+                alert.message.contains(expected.pod) && alert.message.contains(VICTIM_POD),
+                "[{}] alert should name both parties, got: {}",
+                scenario.name,
+                alert.message
+            );
+        }
+
+        // Offenders below the reporting bar are still counted — the dashboard
+        // shows the full picture even when nothing was worth alerting on.
+        let mut body = String::new();
+        metrics.render_prometheus(&mut body);
+        for pod in scenario.expect_counted_only {
+            assert!(
+                body.contains(&format!("offender_pod=\"{}\"", pod)),
+                "[{}] {} should still appear in the counters:\n{}",
+                scenario.name,
+                pod,
+                body
+            );
+        }
+    }
+}
+
+#[test]
+fn json_event_matches_the_documented_schema() {
+    let metrics = Arc::new(BlameMetrics::new("node-1"));
+    let sink = AttributionSink::new(metrics, None, "node-1");
+
+    let event = build_stall_event(&SCENARIOS[0]);
+    let emitted = sink.emit(&calculate_blame_attributions(&event));
+    let json: serde_json::Value = serde_json::to_value(&emitted[0]).unwrap();
+
+    // Log pipelines facet on these paths; renaming one is a breaking change for
+    // every saved Datadog/Splunk query.
+    assert_eq!(json["event_type"], "linnix.stall_attribution");
+    assert_eq!(json["severity"], "warn");
+    assert!(json["stall_ms"].is_u64());
+    assert_eq!(json["victim"]["pod"], VICTIM_POD);
+    assert_eq!(json["victim"]["namespace"], VICTIM_NS);
+    assert_eq!(json["offender"]["pod"], "image-resize-worker");
+    assert_eq!(json["offender"]["namespace"], VICTIM_NS);
+    assert_eq!(json["offender"]["reason"], "high_cpu_contention");
+}
+
+#[test]
+fn repeated_stalls_accumulate_monotonically() {
+    let metrics = Arc::new(BlameMetrics::new("node-1"));
+    let sink = AttributionSink::new(metrics.clone(), None, "node-1");
+
+    let event = build_stall_event(&SCENARIOS[0]);
+    let attributions = calculate_blame_attributions(&event);
+
+    let mut previous = 0.0_f64;
+    for round in 1..=5 {
+        sink.emit(&attributions);
+        let value = scrape_pair_seconds(&metrics, "image-resize-worker", VICTIM_POD);
+        assert!(
+            value > previous,
+            "round {}: counter went from {} to {}, which reads as a reset",
+            round,
+            previous,
+            value
+        );
+        previous = value;
+    }
+}
+
+#[test]
+fn a_flood_of_distinct_offenders_stays_bounded() {
+    const CAP: usize = 32;
+    let metrics = Arc::new(BlameMetrics::with_cap("node-1", CAP));
+    let sink = AttributionSink::new(metrics.clone(), None, "node-1");
+
+    // A cluster-wide event where hundreds of pods each take a sliver of blame
+    // must not let the metrics endpoint grow without limit.
+    for batch in 0..200 {
+        let consumers: Vec<CpuConsumer> = (0..5)
+            .map(|i| CpuConsumer {
+                pod: format!("batch-{}-pod-{}", batch, i),
+                namespace: VICTIM_NS.to_string(),
+                cpu_percent: 10.0,
+            })
+            .collect();
+
+        let event = StallEvent {
+            victim_pod: format!("victim-{}", batch),
+            victim_namespace: VICTIM_NS.to_string(),
+            stall_delta_us: 500_000,
+            timestamp: Instant::now(),
+            concurrent_consumers: consumers,
+            fork_counts: HashMap::new(),
+            short_job_counts: HashMap::new(),
+        };
+        sink.emit(&calculate_blame_attributions(&event));
+    }
+
+    assert!(
+        metrics.pair_series() <= CAP,
+        "pair series grew to {}, above the cap of {}",
+        metrics.pair_series(),
+        CAP
+    );
+    assert!(
+        metrics.evictions() > 0,
+        "eviction should be recorded so an operator can tell the cap was hit"
+    );
+
+    let mut body = String::new();
+    metrics.render_prometheus(&mut body);
+    assert!(body.contains("linnix_blame_series_evicted_total"));
+}
+
+#[test]
+fn a_crashlooping_pod_keeps_accumulating_across_restarts() {
+    let metrics = BlameMetrics::new("node-1");
+
+    // The container stalls, then is OOMKilled and replaced. The new cgroup's
+    // counter starts from zero, but the pod's series must keep climbing —
+    // freezing it would make a crashlooping pod look healthy.
+    metrics.record_victim_pressure("prod", "checkout-api", "container-a", 900_000);
+    metrics.record_victim_pressure("prod", "checkout-api", "container-b", 150_000);
+    metrics.record_victim_pressure("prod", "checkout-api", "container-b", 400_000);
+
+    assert_eq!(
+        scrape_victim_us(&metrics, "checkout-api"),
+        1_300_000,
+        "restarts should add to the pod counter, not reset or freeze it"
+    );
+}
+
+#[test]
+fn every_container_in_a_pod_counts_towards_its_pressure() {
+    let metrics = BlameMetrics::new("node-1");
+
+    // A pod with a sidecar has one cgroup per container. Reporting only the
+    // noisiest one would undercount every meshed workload in the cluster.
+    metrics.record_victim_pressure("prod", "checkout-api", "app-container", 600_000);
+    metrics.record_victim_pressure("prod", "checkout-api", "proxy-sidecar", 250_000);
+
+    assert_eq!(scrape_victim_us(&metrics, "checkout-api"), 850_000);
+}
+
+/// Reads one victim counter back out of the Prometheus exposition.
+fn scrape_victim_us(metrics: &BlameMetrics, pod: &str) -> u64 {
+    let mut body = String::new();
+    metrics.render_prometheus(&mut body);
+
+    let needle = format!("pod=\"{}\"", pod);
+    body.lines()
+        .find(|line| line.starts_with("linnix_pod_psi_pressure_total{") && line.contains(&needle))
+        .and_then(|line| line.rsplit(' ').next())
+        .and_then(|value| value.parse().ok())
+        .unwrap_or_else(|| panic!("no pressure counter for {} in:\n{}", pod, body))
+}
+
+/// Reads one pair counter back out of the Prometheus exposition, which is the
+/// only view of it a user ever gets.
+fn scrape_pair_seconds(metrics: &BlameMetrics, offender: &str, victim: &str) -> f64 {
+    let mut body = String::new();
+    metrics.render_prometheus(&mut body);
+
+    let needle_offender = format!("offender_pod=\"{}\"", offender);
+    let needle_victim = format!("victim_pod=\"{}\"", victim);
+
+    body.lines()
+        .find(|line| {
+            line.starts_with("linnix_stall_induced_seconds_total{")
+                && line.contains(&needle_offender)
+                && line.contains(&needle_victim)
+        })
+        .and_then(|line| line.rsplit(' ').next())
+        .and_then(|value| value.parse().ok())
+        .unwrap_or_else(|| panic!("no counter for {} -> {} in:\n{}", offender, victim, body))
+}
+
+// --- Full loop: fixture cgroup tree through PsiMonitor -----------------------
+
+/// Drives the real scan loop against a fake cgroup hierarchy and checks that a
+/// stalling pod shows up on the metrics endpoint. This covers the path from
+/// "the kernel wrote a number into cpu.pressure" to "an SRE can see it", which
+/// the scenario table above deliberately does not touch.
+///
+/// Offender attribution needs a populated live-process map that the loop builds
+/// from eBPF events, so this test asserts the victim half only; the offender
+/// half is covered by the scenarios above.
+#[tokio::test]
+async fn scan_loop_surfaces_a_stalling_pod_on_the_metrics_endpoint() {
+    use cognitod::collectors::psi::PsiMonitor;
+    use cognitod::context::ContextStore;
+    use cognitod::k8s::{K8sContext, K8sMetadata, Priority};
+
+    // K8sContext::new reads its endpoint from the environment; the watcher is
+    // never started, so nothing is actually dialled.
+    unsafe {
+        std::env::set_var("K8S_API_URL", "http://127.0.0.1:1");
+        std::env::set_var("K8S_TOKEN", "dummy");
+    }
+    let k8s_ctx = K8sContext::new().expect("K8sContext should build from env");
+
+    let container_id = "a".repeat(64);
+    k8s_ctx.insert_metadata(
+        container_id.clone(),
+        K8sMetadata {
+            pod_name: "checkout-api".to_string(),
+            namespace: "prod".to_string(),
+            container_name: "server".to_string(),
+            owner_kind: None,
+            owner_name: None,
+            priority: Priority::default(),
+            slo_tier: None,
+        },
+    );
+
+    let tmp = tempfile::tempdir().unwrap();
+    let cgroup_dir = tmp.path().join("kubepods.slice").join(format!(
+        "kubepods-burstable-pod1.slice/cri-containerd-{}.scope",
+        container_id
+    ));
+    std::fs::create_dir_all(&cgroup_dir).unwrap();
+    let pressure_file = cgroup_dir.join("cpu.pressure");
+
+    let write_pressure = |total: u64| {
+        std::fs::write(
+            &pressure_file,
+            format!(
+                "some avg10=10.00 avg60=5.00 avg300=1.00 total={}\n\
+                 full avg10=0.00 avg60=0.00 avg300=0.00 total=0\n",
+                total
+            ),
+        )
+        .unwrap();
+    };
+    write_pressure(1_000_000);
+
+    let metrics = Arc::new(BlameMetrics::new("node-1"));
+    let sink = Arc::new(AttributionSink::new(metrics.clone(), None, "node-1"));
+    let context = Arc::new(ContextStore::new(
+        Duration::from_secs(60),
+        1000,
+        Some(k8s_ctx.clone()),
+    ));
+
+    // Generous iteration budget: the loop is stopped by aborting the task once
+    // the expected reading lands, so a slow runner delays the test rather than
+    // ending the scan before the assertion can be made.
+    let monitor = PsiMonitor::new(k8s_ctx, context, None, 0, sink)
+        .with_cgroup_root(tmp.path())
+        .with_max_iterations(60);
+    let handle = tokio::spawn(monitor.run());
+
+    // The pod keeps stalling while the monitor scans.
+    tokio::time::sleep(Duration::from_millis(1_200)).await;
+    write_pressure(2_500_000);
+
+    // Wait for the second reading to be picked up rather than assuming a scan
+    // landed within a fixed window.
+    let line = poll_until(Duration::from_secs(30), || {
+        let mut body = String::new();
+        metrics.render_prometheus(&mut body);
+        body.lines()
+            .find(|l| l.starts_with("linnix_pod_psi_pressure_total{") && l.ends_with(" 2500000"))
+            .map(str::to_string)
+    })
+    .await
+    .expect("victim pressure never reached the second reading");
+    handle.abort();
+
+    assert!(line.contains(r#"pod="checkout-api""#), "line was: {}", line);
+    assert!(line.contains(r#"namespace="prod""#), "line was: {}", line);
+    assert!(line.contains(r#"node="node-1""#), "line was: {}", line);
+}
+
+/// Retries `check` on a short interval until it yields a value or the deadline
+/// passes, so timing-sensitive assertions do not depend on a scan landing
+/// inside a fixed sleep.
+async fn poll_until<T>(timeout: Duration, mut check: impl FnMut() -> Option<T>) -> Option<T> {
+    let deadline = Instant::now() + timeout;
+    loop {
+        if let Some(value) = check() {
+            return Some(value);
+        }
+        if Instant::now() >= deadline {
+            return None;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+}

--- a/cognitod/tests/attribution_eval.rs
+++ b/cognitod/tests/attribution_eval.rs
@@ -88,6 +88,51 @@ const SCENARIOS: &[Scenario] = &[
         expect_counted_only: &[],
     },
     Scenario {
+        name: "a CPU-bound victim is never blamed for stalling itself",
+        victim_stall_us: 900_000,
+        // The victim burns more CPU than anyone: it is busy *because* it is
+        // being starved. Blaming it would both mis-name the culprit and eat
+        // most of the stall budget.
+        consumers: &[("payment-api", 70.0), ("image-resize-worker", 30.0)],
+        forks: &[("prod/payment-api", 300)],
+        short_jobs: &[],
+        expect_reported: &[ExpectedOffender {
+            pod: "image-resize-worker",
+            reason: BlameReason::HighCpuContention,
+            stall_ms: (890, 900),
+        }],
+        expect_counted_only: &[],
+    },
+    Scenario {
+        name: "a pod busy across many processes is credited for all of them",
+        victim_stall_us: 1_000_000,
+        // Consumers arrive per process: the worker has four busy processes at
+        // 20% each, the single-process neighbour has one at 30%. The worker is
+        // the bigger consumer and must rank first.
+        consumers: &[
+            ("multi-proc-worker", 20.0),
+            ("multi-proc-worker", 20.0),
+            ("multi-proc-worker", 20.0),
+            ("multi-proc-worker", 20.0),
+            ("single-proc-neighbour", 30.0),
+        ],
+        forks: &[],
+        short_jobs: &[],
+        expect_reported: &[
+            ExpectedOffender {
+                pod: "multi-proc-worker",
+                reason: BlameReason::HighCpuContention,
+                stall_ms: (700, 730),
+            },
+            ExpectedOffender {
+                pod: "single-proc-neighbour",
+                reason: BlameReason::HighCpuContention,
+                stall_ms: (260, 280),
+            },
+        ],
+        expect_counted_only: &[],
+    },
+    Scenario {
         name: "a stall split thinly across many neighbours reports nobody",
         victim_stall_us: 300_000,
         consumers: &[
@@ -223,6 +268,15 @@ fn scenarios_produce_the_expected_events_alerts_and_metrics() {
         // shows the full picture even when nothing was worth alerting on.
         let mut body = String::new();
         metrics.render_prometheus(&mut body);
+
+        // No scenario has the victim genuinely stalling itself, so it must
+        // never appear as its own offender in any output.
+        assert!(
+            !body.contains(&format!("offender_pod=\"{}\"", VICTIM_POD)),
+            "[{}] the victim was blamed for its own stall:\n{}",
+            scenario.name,
+            body
+        );
         for pod in scenario.expect_counted_only {
             assert!(
                 body.contains(&format!("offender_pod=\"{}\"", pod)),

--- a/cognitod/tests/attribution_eval.rs
+++ b/cognitod/tests/attribution_eval.rs
@@ -379,6 +379,112 @@ fn a_flood_of_distinct_offenders_stays_bounded() {
 }
 
 #[test]
+fn sustained_pressure_reports_once_then_goes_quiet() {
+    let metrics = Arc::new(BlameMetrics::new("node-1"));
+    let (alert_tx, mut alert_rx) = tokio::sync::broadcast::channel(64);
+    let sink = AttributionSink::new(metrics.clone(), Some(alert_tx), "node-1")
+        .with_cooldown(Duration::from_secs(300));
+
+    let attributions = calculate_blame_attributions(&build_stall_event(&SCENARIOS[0]));
+
+    // A noisy neighbour that keeps going is detected once per detection window.
+    // Reporting all twelve would page someone twelve times for one incident.
+    let mut reported = 0;
+    for _ in 0..12 {
+        reported += sink.emit(&attributions).len();
+    }
+
+    assert_eq!(reported, 1, "one incident should report once");
+    let mut alerts = 0;
+    while alert_rx.try_recv().is_ok() {
+        alerts += 1;
+    }
+    assert_eq!(alerts, 1, "one incident should page once");
+
+    // The counters are the continuous signal and must keep climbing while
+    // reporting is suppressed, otherwise the dashboard would show the problem
+    // ending when it merely stopped being announced.
+    assert!(
+        scrape_pair_seconds(&metrics, "image-resize-worker", VICTIM_POD) > 8.0,
+        "counters should reflect all twelve windows, not just the reported one"
+    );
+}
+
+#[test]
+fn a_second_offender_is_not_silenced_by_the_first() {
+    let metrics = Arc::new(BlameMetrics::new("node-1"));
+    let (alert_tx, mut alert_rx) = tokio::sync::broadcast::channel(64);
+    let sink = AttributionSink::new(metrics, Some(alert_tx), "node-1")
+        .with_cooldown(Duration::from_secs(300));
+
+    // The image resizer is already being reported on.
+    sink.emit(&calculate_blame_attributions(&build_stall_event(
+        &SCENARIOS[0],
+    )));
+    while alert_rx.try_recv().is_ok() {}
+
+    // A different offender starts hurting the same victim. This is new
+    // information: suppressing it because an unrelated pair is in cooldown
+    // would hide the second half of a spreading incident.
+    let second = StallEvent {
+        victim_pod: VICTIM_POD.to_string(),
+        victim_namespace: VICTIM_NS.to_string(),
+        stall_delta_us: 800_000,
+        timestamp: Instant::now(),
+        concurrent_consumers: vec![CpuConsumer {
+            pod: "batch-etl".to_string(),
+            namespace: VICTIM_NS.to_string(),
+            cpu_percent: 95.0,
+        }],
+        fork_counts: HashMap::new(),
+        short_job_counts: HashMap::new(),
+    };
+
+    let emitted = sink.emit(&calculate_blame_attributions(&second));
+    assert_eq!(emitted.len(), 1, "a new offender must still be reported");
+    assert_eq!(emitted[0].offender.pod, "batch-etl");
+    assert!(
+        alert_rx.try_recv().is_ok(),
+        "a new offender must still page"
+    );
+}
+
+#[test]
+fn an_ongoing_offender_reports_again_once_the_cooldown_lapses() {
+    let metrics = Arc::new(BlameMetrics::new("node-1"));
+    let sink =
+        AttributionSink::new(metrics, None, "node-1").with_cooldown(Duration::from_millis(150));
+
+    let attributions = calculate_blame_attributions(&build_stall_event(&SCENARIOS[0]));
+
+    assert_eq!(sink.emit(&attributions).len(), 1);
+    assert_eq!(sink.emit(&attributions).len(), 0, "still within cooldown");
+
+    // A problem that is still happening after the quiet period re-announces
+    // itself, rather than being silenced permanently by its first report.
+    std::thread::sleep(Duration::from_millis(200));
+    assert_eq!(
+        sink.emit(&attributions).len(),
+        1,
+        "an ongoing problem should re-announce after the cooldown"
+    );
+}
+
+#[test]
+fn a_zero_cooldown_reports_every_occurrence() {
+    let metrics = Arc::new(BlameMetrics::new("node-1"));
+    let sink = AttributionSink::new(metrics, None, "node-1").with_cooldown(Duration::from_secs(0));
+
+    let attributions = calculate_blame_attributions(&build_stall_event(&SCENARIOS[0]));
+    let reported: usize = (0..5).map(|_| sink.emit(&attributions).len()).sum();
+
+    assert_eq!(
+        reported, 5,
+        "opting out of throttling should report each time"
+    );
+}
+
+#[test]
 fn a_crashlooping_pod_keeps_accumulating_across_restarts() {
     let metrics = BlameMetrics::new("node-1");
 

--- a/configs/linnix.toml
+++ b/configs/linnix.toml
@@ -45,3 +45,11 @@ enabled = true
 [psi]
 # Duration in seconds of sustained pressure required to trigger attribution
 sustained_pressure_seconds = 15
+# Stall attributed to a single offender, in milliseconds, before it is reported.
+# A large stall spread thinly across many neighbours is not a noisy neighbour.
+attribution_threshold_ms = 100
+# How long before the same offender/victim pair is reported again. Pressure
+# lasting an hour would otherwise alert every sustained_pressure_seconds for the
+# whole hour. Set to 0 to report every occurrence; the Prometheus counters are
+# unaffected either way.
+attribution_cooldown_seconds = 300

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -28,12 +28,13 @@ Deployments that intentionally run without kernel instrumentation can set
 `require_kernel_instrumentation = false` under `[api]` in `linnix.toml`.
 
 ## How much overhead should I expect?
-- The end-to-end pipeline (eBPF + cognitod) stays under **1% CPU and 10–20 MB RAM** on typical hosts.
+- The in-kernel eBPF probes add **under 1% CPU** (see [performance-proof.md](performance-proof.md)) — event-driven tracepoints, not polling.
+- The full `cognitod` userspace daemon (PSI polling, attribution, API) runs **~3.6-4.1% of one core** and 10-20 MB RAM on typical hosts (see [OVERHEAD.md](OVERHEAD.md)).
 - Reasons it is lightweight:
   1. Tracepoints fire only when the kernel already handles fork/exec/exit events (event-driven, no polling).
   2. Per-CPU buffers and lock-free maps avoid contention.
   3. Binary payloads (~200 bytes) minimize copies between kernel and userspace.
-- If you see sustained >1% CPU, check for debug builds, noisy workloads during benchmarking, or missing BTF (which forces slower fallback paths). Run `sudo ./test_ebpf_overhead.sh` to capture a reproducible report.
+- If you see overhead well above these figures, check for debug builds, noisy workloads during benchmarking, or missing BTF (which forces slower fallback paths). Run `sudo ./test_ebpf_overhead.sh` to capture a reproducible report.
 
 ## How does Linnix handle data privacy?
 - **On-host processing**: All capture, reasoning, and dashboards run on your infrastructure. There is no mandatory SaaS ingestion or remote control plane.

--- a/docs/OVERHEAD.md
+++ b/docs/OVERHEAD.md
@@ -17,7 +17,7 @@ Linnix is designed to be lightweight and unobtrusive. We continuously benchmark 
 | **CPU Stress** | 3.63% | 69.7 MB | System under 100% CPU load |
 | **Fork Stress** | 4.10% | 69.9 MB | High process churn (stress-ng --fork 4) |
 
-> **Note:** These numbers represent the userspace daemon overhead. The eBPF probes running in kernel space add negligible overhead (<1%) due to the JIT-compiled, event-driven nature of eBPF.
+> **Note:** These numbers represent the userspace daemon overhead only (BPF disabled for benchmark isolation, per Configuration above) — this is the ~4% figure cited elsewhere as "full daemon overhead." The in-kernel eBPF probes themselves add <1% CPU, measured separately (see [performance-proof.md](performance-proof.md)), due to the JIT-compiled, event-driven, per-CPU-buffered nature of eBPF versus polling-based collection. Quote both numbers together: **<1% eBPF (kernel-side), ~4% full userspace daemon**.
 
 ## Methodology
 


### PR DESCRIPTION
## Summary
- Overhead claims were inconsistent across README/FAQ/OVERHEAD.md/CHANGELOG (some stated <1% for the full daemon, others ~4%). Now consistently scoped: <1% kernel-side eBPF, ~4% full userspace daemon.
- CHANGELOG and cognitod's Cargo.toml were still at 0.2.0 despite the AttributionSink emit seam, /readyz degraded-eBPF visibility, and Linnix-Claw extraction landing on main — bumped to 0.3.0 with changelog entries documenting those changes.
- Cargo.lock synced to match the version bump.

## Test plan
- [x] `cargo fmt`, `clippy`, and the 104-test suite pass via pre-commit hooks
- [x] Confirmed no remaining contradicting overhead percentage via grep across README.md, docs/FAQ.md, docs/OVERHEAD.md, CHANGELOG.md, and the whitepaper
- [x] Confirmed `cognitod/Cargo.toml` version matches the new CHANGELOG entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)