### PR TITLE
feat(incidents): persist each offender's share of the stall

### DIFF
--- a/cognitod/src/collectors/psi.rs
+++ b/cognitod/src/collectors/psi.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use log::{debug, info};
+use log::{debug, info, warn};
 use std::collections::{HashMap, VecDeque};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -281,22 +281,8 @@ impl PsiMonitor {
                                 // Persist to database if available
                                 if let Some(ref store) = self.incident_store {
                                     for attr in &attributions {
-                                        if let Err(e) = store
-                                            .insert_stall_attribution(
-                                                &attr.victim_pod,
-                                                &attr.victim_namespace,
-                                                &attr.offender_pod,
-                                                &attr.offender_namespace,
-                                                attr.stall_us,
-                                                attr.blame_score,
-                                                attr.timestamp,
-                                                attr.cpu_share,
-                                                attr.fork_count,
-                                                attr.short_job_count,
-                                            )
-                                            .await
-                                        {
-                                            debug!("[psi] Failed to persist attribution: {}", e);
+                                        if let Err(e) = store.insert_stall_attribution(attr).await {
+                                            warn!("[psi] Failed to persist attribution: {}", e);
                                         }
                                     }
                                 }

--- a/cognitod/src/incidents.rs
+++ b/cognitod/src/incidents.rs
@@ -49,7 +49,13 @@ pub struct Incident {
 pub struct StallAttribution {
     pub offender_pod: String,
     pub offender_namespace: String,
+    /// The victim's total stall for the window. The same value repeats across
+    /// every offender of one event, so summing it double-counts.
     pub stall_us: u64,
+    /// This offender's share of `stall_us`, matching what
+    /// `linnix_stall_induced_seconds_total` reports. `None` on rows written
+    /// before the split existed and whose blame could not be renormalised.
+    pub attributed_stall_us: Option<u64>,
     pub blame_score: f64,
     pub timestamp: u64,
     // Detailed metrics
@@ -116,7 +122,12 @@ impl IncidentStore {
                 timestamp INTEGER NOT NULL,
                 cpu_share REAL DEFAULT 0.0,
                 fork_count INTEGER DEFAULT 0,
-                short_job_count INTEGER DEFAULT 0
+                short_job_count INTEGER DEFAULT 0,
+                -- This offender's share of stall_us. Nullable rather than
+                -- defaulted: a row written before this column existed has an
+                -- unknown share, and zero would claim the offender caused no
+                -- stall at all.
+                attributed_stall_us INTEGER
             );
             CREATE INDEX IF NOT EXISTS idx_victim_time ON stall_attributions(victim_pod, victim_namespace, timestamp);
             CREATE INDEX IF NOT EXISTS idx_offender_time ON stall_attributions(offender_pod, offender_namespace, timestamp);
@@ -140,6 +151,46 @@ impl IncidentStore {
         )
         .execute(&pool)
         .await;
+        let _ =
+            sqlx::query("ALTER TABLE stall_attributions ADD COLUMN attributed_stall_us INTEGER")
+                .execute(&pool)
+                .await;
+
+        // Rows written before the column existed stored only the victim's
+        // total stall, repeated against every offender. The share each was
+        // actually responsible for is recoverable: attributions from one event
+        // share a (victim, timestamp), so blame can be renormalised within that
+        // group. Nothing prunes this table, so old rows stay queryable and are
+        // worth reconciling rather than leaving unknown.
+        let backfilled = sqlx::query(
+            r#"
+            UPDATE stall_attributions AS a
+            SET attributed_stall_us = CAST(
+                a.stall_us * a.blame_score / (
+                    SELECT SUM(b.blame_score) FROM stall_attributions AS b
+                    WHERE b.victim_pod = a.victim_pod
+                      AND b.victim_namespace = a.victim_namespace
+                      AND b.timestamp = a.timestamp
+                ) AS INTEGER)
+            WHERE a.attributed_stall_us IS NULL
+              AND (
+                    SELECT SUM(b.blame_score) FROM stall_attributions AS b
+                    WHERE b.victim_pod = a.victim_pod
+                      AND b.victim_namespace = a.victim_namespace
+                      AND b.timestamp = a.timestamp
+                  ) > 0
+            "#,
+        )
+        .execute(&pool)
+        .await;
+        if let Ok(result) = backfilled
+            && result.rows_affected() > 0
+        {
+            info!(
+                "Backfilled attributed stall for {} historical attribution rows",
+                result.rows_affected()
+            );
+        }
 
         info!(
             "Incident store initialized at {}",
@@ -224,45 +275,47 @@ impl IncidentStore {
 
     /// Insert stall attribution event
     #[allow(clippy::too_many_arguments)]
+    /// Persists one blame attribution.
+    ///
+    /// Takes the attribution whole rather than a dozen positional arguments:
+    /// five of the columns are bare integers and transposing two of them would
+    /// compile cleanly and corrupt the record.
     pub async fn insert_stall_attribution(
         &self,
-        victim_pod: &str,
-        victim_namespace: &str,
-        offender_pod: &str,
-        offender_namespace: &str,
-        stall_us: u64,
-        blame_score: f64,
-        timestamp: u64,
-        cpu_share: f64,
-        fork_count: u64,
-        short_job_count: u64,
+        attr: &crate::collectors::psi::BlameAttribution,
     ) -> Result<i64, sqlx::Error> {
         let result = sqlx::query(
             r#"
             INSERT INTO stall_attributions (
                 victim_pod, victim_namespace, offender_pod, offender_namespace,
                 stall_us, blame_score, timestamp,
-                cpu_share, fork_count, short_job_count
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                cpu_share, fork_count, short_job_count, attributed_stall_us
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             "#,
         )
-        .bind(victim_pod)
-        .bind(victim_namespace)
-        .bind(offender_pod)
-        .bind(offender_namespace)
-        .bind(stall_us as i64)
-        .bind(blame_score)
-        .bind(timestamp as i64)
-        .bind(cpu_share)
-        .bind(fork_count as i64)
-        .bind(short_job_count as i64)
+        .bind(&attr.victim_pod)
+        .bind(&attr.victim_namespace)
+        .bind(&attr.offender_pod)
+        .bind(&attr.offender_namespace)
+        .bind(attr.stall_us as i64)
+        .bind(attr.blame_score)
+        .bind(attr.timestamp as i64)
+        .bind(attr.cpu_share)
+        .bind(attr.fork_count as i64)
+        .bind(attr.short_job_count as i64)
+        .bind(attr.attributed_stall_us as i64)
         .execute(&self.pool)
         .await?;
 
         let id = result.last_insert_rowid();
         debug!(
             "Inserted stall attribution #{}: {}/{} blamed {}/{} (score={:.2})",
-            id, victim_namespace, victim_pod, offender_namespace, offender_pod, blame_score
+            id,
+            attr.victim_namespace,
+            attr.victim_pod,
+            attr.offender_namespace,
+            attr.offender_pod,
+            attr.blame_score
         );
         Ok(id)
     }
@@ -283,7 +336,7 @@ impl IncidentStore {
         let rows = sqlx::query(
             r#"
             SELECT offender_pod, offender_namespace, stall_us, blame_score, timestamp,
-                   cpu_share, fork_count, short_job_count
+                   cpu_share, fork_count, short_job_count, attributed_stall_us
             FROM stall_attributions
             WHERE victim_pod = ? AND victim_namespace = ? AND timestamp >= ?
             ORDER BY blame_score DESC
@@ -297,15 +350,20 @@ impl IncidentStore {
 
         Ok(rows
             .into_iter()
+            // Columns are read by name: positional access silently shifts
+            // every field after any column added to the SELECT above.
             .map(|r| StallAttribution {
-                offender_pod: r.get(0),
-                offender_namespace: r.get(1),
-                stall_us: r.get::<i64, _>(2) as u64,
-                blame_score: r.get(3),
-                timestamp: r.get::<i64, _>(4) as u64,
-                cpu_share: r.get(5),
-                fork_count: r.get::<i64, _>(6) as u64,
-                short_job_count: r.get::<i64, _>(7) as u64,
+                offender_pod: r.get("offender_pod"),
+                offender_namespace: r.get("offender_namespace"),
+                stall_us: r.get::<i64, _>("stall_us") as u64,
+                blame_score: r.get("blame_score"),
+                timestamp: r.get::<i64, _>("timestamp") as u64,
+                cpu_share: r.get("cpu_share"),
+                fork_count: r.get::<i64, _>("fork_count") as u64,
+                short_job_count: r.get::<i64, _>("short_job_count") as u64,
+                attributed_stall_us: r
+                    .get::<Option<i64>, _>("attributed_stall_us")
+                    .map(|v| v as u64),
             })
             .collect())
     }

--- a/cognitod/src/incidents.rs
+++ b/cognitod/src/incidents.rs
@@ -159,9 +159,18 @@ impl IncidentStore {
         // Rows written before the column existed stored only the victim's
         // total stall, repeated against every offender. The share each was
         // actually responsible for is recoverable: attributions from one event
-        // share a (victim, timestamp), so blame can be renormalised within that
-        // group. Nothing prunes this table, so old rows stay queryable and are
-        // worth reconciling rather than leaving unknown.
+        // share a (victim, timestamp, stall_us), so blame can be renormalised
+        // within that group. Nothing prunes this table, so old rows stay
+        // queryable and are worth reconciling rather than leaving unknown.
+        //
+        // stall_us belongs in the grouping key, not just the numerator. The
+        // timestamp has one-second resolution and a single victim can produce
+        // two events within one second — a pod's containers are scanned
+        // separately, and they collapse to the same pod key. Grouping on victim
+        // and timestamp alone would pool both events' blame into one
+        // denominator while each numerator kept its own stall, leaving shares
+        // that reconcile to neither event. stall_us is a microsecond delta, so
+        // it separates them.
         let backfilled = sqlx::query(
             r#"
             UPDATE stall_attributions AS a
@@ -171,6 +180,7 @@ impl IncidentStore {
                     WHERE b.victim_pod = a.victim_pod
                       AND b.victim_namespace = a.victim_namespace
                       AND b.timestamp = a.timestamp
+                      AND b.stall_us = a.stall_us
                 ) AS INTEGER)
             WHERE a.attributed_stall_us IS NULL
               AND (
@@ -178,6 +188,7 @@ impl IncidentStore {
                     WHERE b.victim_pod = a.victim_pod
                       AND b.victim_namespace = a.victim_namespace
                       AND b.timestamp = a.timestamp
+                      AND b.stall_us = a.stall_us
                   ) > 0
             "#,
         )

--- a/cognitod/tests/attribution_store_eval.rs
+++ b/cognitod/tests/attribution_store_eval.rs
@@ -151,6 +151,86 @@ async fn upgrading_an_old_database_backfills_the_offender_share() {
 }
 
 #[tokio::test]
+async fn two_events_in_one_second_are_backfilled_separately() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("incidents.db");
+    let db_url = format!("sqlite://{}?mode=rwc", db_path.display());
+
+    {
+        let pool = SqlitePoolOptions::new().connect(&db_url).await.unwrap();
+        sqlx::query(
+            r#"
+            CREATE TABLE stall_attributions (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                victim_pod TEXT NOT NULL,
+                victim_namespace TEXT NOT NULL,
+                offender_pod TEXT NOT NULL,
+                offender_namespace TEXT NOT NULL,
+                stall_us INTEGER NOT NULL,
+                blame_score REAL NOT NULL,
+                timestamp INTEGER NOT NULL
+            )
+            "#,
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        // Timestamps have one-second resolution, and one victim can stall twice
+        // within a second — its containers are scanned separately and collapse
+        // to the same pod key. These two events must not pool their blame.
+        //
+        // Event A: 400ms stall, blamed 3:1. Event B: 800ms stall, blamed 1:1.
+        for (offender, stall, blame) in [
+            ("hog-a", 400_000, 3.0),
+            ("hog-b", 400_000, 1.0),
+            ("hog-c", 800_000, 1.0),
+            ("hog-d", 800_000, 1.0),
+        ] {
+            sqlx::query(
+                "INSERT INTO stall_attributions (victim_pod, victim_namespace, offender_pod,
+                 offender_namespace, stall_us, blame_score, timestamp)
+                 VALUES ('payment-api', 'prod', ?, 'prod', ?, ?, 1700000000)",
+            )
+            .bind(offender)
+            .bind(stall as i64)
+            .bind(blame)
+            .execute(&pool)
+            .await
+            .unwrap();
+        }
+        pool.close().await;
+    }
+
+    let store = IncidentStore::new(&db_path).await.unwrap();
+    let window = (now_secs() - 1_700_000_000 + 60) as i64;
+    let rows = store
+        .query_attributions("payment-api", "prod", window)
+        .await
+        .unwrap();
+
+    let share = |pod: &str| {
+        rows.iter()
+            .find(|r| r.offender_pod == pod)
+            .unwrap()
+            .attributed_stall_us
+    };
+
+    // Each event renormalises within itself: 3:1 of 400ms, and 1:1 of 800ms.
+    assert_eq!(share("hog-a"), Some(300_000));
+    assert_eq!(share("hog-b"), Some(100_000));
+    assert_eq!(share("hog-c"), Some(400_000));
+    assert_eq!(share("hog-d"), Some(400_000));
+
+    // Pooling the denominators would leave each event's shares reconciling to
+    // neither stall; here both add up exactly.
+    let event_a: u64 = [share("hog-a"), share("hog-b")].iter().flatten().sum();
+    let event_b: u64 = [share("hog-c"), share("hog-d")].iter().flatten().sum();
+    assert_eq!(event_a, 400_000);
+    assert_eq!(event_b, 800_000);
+}
+
+#[tokio::test]
 async fn a_row_with_no_recoverable_blame_stays_unknown_rather_than_zero() {
     let dir = tempfile::tempdir().unwrap();
     let db_path = dir.path().join("incidents.db");

--- a/cognitod/tests/attribution_store_eval.rs
+++ b/cognitod/tests/attribution_store_eval.rs
@@ -1,0 +1,205 @@
+//! Eval suite for persisted stall attributions.
+//!
+//! The `/attribution` endpoint and the Prometheus villain counter must agree on
+//! what "stall attributed to this offender" means. These cases cover the
+//! storage path that feeds the endpoint — fresh installs, upgrades from a
+//! database written before the split existed, and the round trip an SRE sees
+//! when they query a victim.
+
+use cognitod::collectors::psi::BlameAttribution;
+use cognitod::incidents::IncidentStore;
+use sqlx::sqlite::SqlitePoolOptions;
+
+fn attribution(offender: &str, blame: f64, attributed_us: u64) -> BlameAttribution {
+    BlameAttribution {
+        victim_pod: "payment-api".to_string(),
+        victim_namespace: "prod".to_string(),
+        offender_pod: offender.to_string(),
+        offender_namespace: "prod".to_string(),
+        blame_score: blame,
+        stall_us: 900_000,
+        attributed_stall_us: attributed_us,
+        timestamp: now_secs(),
+        cpu_share: 0.8,
+        fork_count: 12,
+        short_job_count: 3,
+    }
+}
+
+fn now_secs() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs()
+}
+
+#[tokio::test]
+async fn a_stored_attribution_reports_the_offender_share_not_the_victim_total() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = IncidentStore::new(dir.path().join("incidents.db"))
+        .await
+        .expect("fresh database should initialise");
+
+    // One 900ms stall split 2:1 between two offenders.
+    store
+        .insert_stall_attribution(&attribution("image-resize-worker", 2.0, 600_000))
+        .await
+        .expect("insert should succeed on a fresh schema");
+    store
+        .insert_stall_attribution(&attribution("batch-etl", 1.0, 300_000))
+        .await
+        .expect("insert should succeed on a fresh schema");
+
+    let rows = store
+        .query_attributions("payment-api", "prod", 300)
+        .await
+        .unwrap();
+
+    assert_eq!(rows.len(), 2);
+    assert_eq!(rows[0].offender_pod, "image-resize-worker");
+    assert_eq!(rows[0].attributed_stall_us, Some(600_000));
+    assert_eq!(rows[1].attributed_stall_us, Some(300_000));
+
+    // The victim total is still reported, and still the same on both rows —
+    // which is exactly why the endpoint needs the attributed figure too.
+    assert_eq!(rows[0].stall_us, 900_000);
+    assert_eq!(rows[1].stall_us, 900_000);
+
+    // The shares must not sum past the stall that actually happened.
+    let attributed: u64 = rows.iter().filter_map(|r| r.attributed_stall_us).sum();
+    assert!(attributed <= rows[0].stall_us);
+}
+
+#[tokio::test]
+async fn upgrading_an_old_database_backfills_the_offender_share() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("incidents.db");
+    let db_url = format!("sqlite://{}?mode=rwc", db_path.display());
+
+    // A database as written before the attributed share existed: no such
+    // column, and every offender row carrying the victim's whole stall.
+    {
+        let pool = SqlitePoolOptions::new().connect(&db_url).await.unwrap();
+        sqlx::query(
+            r#"
+            CREATE TABLE stall_attributions (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                victim_pod TEXT NOT NULL,
+                victim_namespace TEXT NOT NULL,
+                offender_pod TEXT NOT NULL,
+                offender_namespace TEXT NOT NULL,
+                stall_us INTEGER NOT NULL,
+                blame_score REAL NOT NULL,
+                timestamp INTEGER NOT NULL,
+                cpu_share REAL DEFAULT 0.0,
+                fork_count INTEGER DEFAULT 0,
+                short_job_count INTEGER DEFAULT 0
+            )
+            "#,
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        // Two offenders of one 900ms event, blamed 3:1.
+        for (offender, blame) in [("noisy-neighbour", 3.0), ("quiet-neighbour", 1.0)] {
+            sqlx::query(
+                "INSERT INTO stall_attributions (victim_pod, victim_namespace, offender_pod,
+                 offender_namespace, stall_us, blame_score, timestamp)
+                 VALUES ('payment-api', 'prod', ?, 'prod', 900000, ?, 1700000000)",
+            )
+            .bind(offender)
+            .bind(blame)
+            .execute(&pool)
+            .await
+            .unwrap();
+        }
+        pool.close().await;
+    }
+
+    // Opening the store must migrate the schema and reconcile the old rows
+    // rather than leaving them claiming the full stall each.
+    let store = IncidentStore::new(&db_path)
+        .await
+        .expect("opening an older database should migrate it");
+
+    let window = (now_secs() - 1_700_000_000 + 60) as i64;
+    let rows = store
+        .query_attributions("payment-api", "prod", window)
+        .await
+        .unwrap();
+
+    assert_eq!(rows.len(), 2);
+    assert_eq!(rows[0].offender_pod, "noisy-neighbour");
+    assert_eq!(
+        rows[0].attributed_stall_us,
+        Some(675_000),
+        "3/4 of the 900ms stall"
+    );
+    assert_eq!(
+        rows[1].attributed_stall_us,
+        Some(225_000),
+        "1/4 of the 900ms stall"
+    );
+
+    // Inserting after the migration must still work, which is the check that
+    // the ALTER path and the CREATE path produce the same schema.
+    store
+        .insert_stall_attribution(&attribution("late-arrival", 1.0, 100_000))
+        .await
+        .expect("insert should succeed after migration");
+}
+
+#[tokio::test]
+async fn a_row_with_no_recoverable_blame_stays_unknown_rather_than_zero() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("incidents.db");
+    let db_url = format!("sqlite://{}?mode=rwc", db_path.display());
+
+    {
+        let pool = SqlitePoolOptions::new().connect(&db_url).await.unwrap();
+        sqlx::query(
+            r#"
+            CREATE TABLE stall_attributions (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                victim_pod TEXT NOT NULL,
+                victim_namespace TEXT NOT NULL,
+                offender_pod TEXT NOT NULL,
+                offender_namespace TEXT NOT NULL,
+                stall_us INTEGER NOT NULL,
+                blame_score REAL NOT NULL,
+                timestamp INTEGER NOT NULL
+            )
+            "#,
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        // Zero blame: there is nothing to renormalise against, so the share is
+        // genuinely unknown. Reporting 0 would assert the offender caused no
+        // stall, which is a different and false claim.
+        sqlx::query(
+            "INSERT INTO stall_attributions (victim_pod, victim_namespace, offender_pod,
+             offender_namespace, stall_us, blame_score, timestamp)
+             VALUES ('payment-api', 'prod', 'mystery-pod', 'prod', 900000, 0.0, 1700000000)",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+        pool.close().await;
+    }
+
+    let store = IncidentStore::new(&db_path).await.unwrap();
+    let window = (now_secs() - 1_700_000_000 + 60) as i64;
+    let rows = store
+        .query_attributions("payment-api", "prod", window)
+        .await
+        .unwrap();
+
+    assert_eq!(rows.len(), 1);
+    assert_eq!(
+        rows[0].attributed_stall_us, None,
+        "an unrecoverable share must read as unknown, not as zero stall caused"
+    );
+}


### PR DESCRIPTION
Closes #26.

The two metric families #26 asked for shipped in #52. This closes the loop it left open: `/attribution` and `linnix_stall_induced_seconds_total` disagreed about what "stall attributed to this offender" means.

The metric reports each offender's proportional share. The database stored only `stall_us` — the victim's *whole* stall, repeated against every offender — so summing the endpoint's output claimed several times the stall that actually happened, while the metric claimed the correct total. Same question, two answers.

## The nullable-vs-zero decision

`attributed_stall_us` is nullable rather than `DEFAULT 0`. A row written before the split existed has an *unknown* share; storing zero would assert the offender caused no stall, which is a different and false claim, and one that would quietly skew any historical query.

Where the share is recoverable it's backfilled instead. Attributions from a single event share a `(victim_pod, victim_namespace, timestamp)`, so blame renormalises within that group and the original proportions come back exactly. Nothing prunes `stall_attributions` — there is no retention logic anywhere in the codebase — so old rows stay queryable indefinitely and are worth reconciling rather than leaving unknown. Rows with zero total blame stay `NULL`, because there is genuinely nothing to renormalise against.

The column is added in **both** the `CREATE TABLE` and as an ignored-error `ALTER TABLE`, matching the existing pattern for `cpu_share`/`fork_count`/`short_job_count`. Adding it to only one breaks either fresh installs or upgrades at INSERT time.

## Two hazards removed while here

`insert_stall_attribution` took eleven positional arguments, five of them bare integers sitting next to each other (`stall_us`, `timestamp`, `fork_count`, `short_job_count`, and now the share). Transposing two would compile cleanly and corrupt the record. It takes the `&BlameAttribution` directly now — the caller already had one and was destructuring it field by field.

`query_attributions` mapped rows by position (`r.get(0)`, `r.get(1)`, …). Adding a column mid-SELECT shifts every subsequent field with no compile error and no test failure — just wrong numbers in the API response. Now read by name.

Also: persist failures were logged at `debug!`, so a schema mismatch would have been silent. They're warnings now.

## Tests

`cognitod/tests/attribution_store_eval.rs` — the storage path had **no coverage at all**; every `PsiMonitor` in the existing eval suite passes `None` for the incident store, so neither `insert_stall_attribution` nor `query_attributions` had ever been executed by a test.

- A stored attribution reports the offender share, not the victim total, and the shares don't sum past the observed stall
- Upgrading a pre-column database migrates the schema and backfills 3:1 blame into 675ms/225ms of a 900ms stall — then still accepts new inserts, which is what proves the ALTER and CREATE paths agree
- A row with zero blame stays `None` rather than becoming a false zero

Verified the backfill assertion bites by disabling the UPDATE and watching it fail.

Local: fmt clean, zero clippy warnings, 107 tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)