### PR TITLE
fix(reasoner): read model from config, and drop config keys nothing parses

### DIFF
--- a/cognitod/src/api/mod.rs
+++ b/cognitod/src/api/mod.rs
@@ -1074,7 +1074,7 @@ pub async fn get_insights(
 
     // Call LLM - supports both local models and OpenAI
     // Default to local Linnix model if available
-    let model = std::env::var("LLM_MODEL").unwrap_or_else(|_| "linnix-3b-distilled".to_string());
+    let model = std::env::var("LLM_MODEL").unwrap_or_else(|_| app_state.reasoner.model.clone());
     // Falls back to [reasoner].endpoint so linnix.toml actually controls where
     // insights are generated; the env var stays as an explicit override.
     let llm_endpoint =

--- a/cognitod/src/api/mod.rs
+++ b/cognitod/src/api/mod.rs
@@ -1072,13 +1072,12 @@ pub async fn get_insights(
         alert_summary
     );
 
-    // Call LLM - supports both local models and OpenAI
-    // Default to local Linnix model if available
-    let model = std::env::var("LLM_MODEL").unwrap_or_else(|_| app_state.reasoner.model.clone());
-    // Falls back to [reasoner].endpoint so linnix.toml actually controls where
-    // insights are generated; the env var stays as an explicit override.
-    let llm_endpoint =
-        std::env::var("LLM_ENDPOINT").unwrap_or_else(|_| app_state.reasoner.endpoint.clone());
+    // Call LLM - supports both local models and OpenAI.
+    // LLM_ENDPOINT/LLM_MODEL are already folded into [reasoner] at startup, so
+    // read the resolved config rather than the environment: consulting env here
+    // too is what let this path and the incident analyzer target different models.
+    let model = app_state.reasoner.model.clone();
+    let llm_endpoint = app_state.reasoner.endpoint.clone();
 
     // API key is optional for local models
     let api_key =

--- a/cognitod/src/config.rs
+++ b/cognitod/src/config.rs
@@ -307,6 +307,8 @@ pub struct ReasonerConfig {
     pub enabled: bool,
     #[serde(default = "default_reasoner_endpoint")]
     pub endpoint: String,
+    #[serde(default = "default_reasoner_model")]
+    pub model: String,
     #[serde(default = "default_reasoner_timeout")]
     pub timeout_ms: u64,
 }
@@ -316,6 +318,7 @@ impl Default for ReasonerConfig {
         Self {
             enabled: default_reasoner_enabled(),
             endpoint: default_reasoner_endpoint(),
+            model: default_reasoner_model(),
             timeout_ms: default_reasoner_timeout(),
         }
     }
@@ -331,6 +334,12 @@ fn default_reasoner_endpoint() -> String {
     // ships — linnix.toml, the systemd unit, docker-compose, k8s/configmap.yaml,
     // quickstart.sh — uses 8090; nothing listens on the 8087 this used to name.
     "http://localhost:8090/v1/chat/completions".to_string()
+}
+
+fn default_reasoner_model() -> String {
+    // Matches the model name both LLM call sites previously hardcoded, and the
+    // `model` key both shipped configs already set.
+    "linnix-3b-distilled".to_string()
 }
 
 fn default_reasoner_timeout() -> u64 {

--- a/cognitod/src/incidents/analyzer.rs
+++ b/cognitod/src/incidents/analyzer.rs
@@ -33,15 +33,20 @@ pub struct PodContribution {
 /// Incident analyzer using local LLM
 pub struct IncidentAnalyzer {
     endpoint: String,
+    model: String,
     client: reqwest::Client,
 }
 
 impl IncidentAnalyzer {
     /// Create a new incident analyzer
-    pub fn new(endpoint: String, timeout: Duration) -> Result<Self, reqwest::Error> {
+    pub fn new(endpoint: String, model: String, timeout: Duration) -> Result<Self, reqwest::Error> {
         let client = reqwest::Client::builder().timeout(timeout).build()?;
 
-        Ok(Self { endpoint, client })
+        Ok(Self {
+            endpoint,
+            model,
+            client,
+        })
     }
 
     /// Analyze an incident using the LLM
@@ -52,7 +57,7 @@ impl IncidentAnalyzer {
         let prompt = self.build_analysis_prompt(incident);
 
         let request_body = json!({
-            "model": "linnix-3b-distilled",
+            "model": self.model,
             "messages": [
                 {
                     "role": "system",
@@ -246,6 +251,7 @@ Here is the analysis:
 
         let analyzer = IncidentAnalyzer::new(
             "http://localhost:8090/v1/chat/completions".to_string(),
+            "linnix-3b-distilled".to_string(),
             Duration::from_secs(30),
         )
         .unwrap();

--- a/cognitod/src/main.rs
+++ b/cognitod/src/main.rs
@@ -613,6 +613,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let incident_analyzer = if config.reasoner.enabled && !config.reasoner.endpoint.is_empty() {
         match cognitod::IncidentAnalyzer::new(
             config.reasoner.endpoint.clone(),
+            config.reasoner.model.clone(),
             Duration::from_millis(config.reasoner.timeout_ms),
         ) {
             Ok(analyzer) => {

--- a/cognitod/src/main.rs
+++ b/cognitod/src/main.rs
@@ -398,7 +398,21 @@ async fn main() -> Result<(), Box<dyn Error>> {
     ensure_environment()?;
 
     // Load configuration
-    let config = Config::load();
+    let mut config = Config::load();
+
+    // Resolve the LLM env overrides once, here, so every consumer sees the same
+    // effective values. Applying them per-call-site let the two LLM paths drift:
+    // the shipped systemd unit sets LLM_MODEL=linnix-qwen-v1 while linnix.toml
+    // says linnix-3b-distilled, so /insights and the incident analyzer were
+    // asking one server for two different models. Precedence is env > TOML >
+    // default, matching LINNIX_LISTEN_ADDR and LINNIX_API_TOKEN below.
+    if let Ok(endpoint) = std::env::var("LLM_ENDPOINT") {
+        config.reasoner.endpoint = endpoint;
+    }
+    if let Ok(model) = std::env::var("LLM_MODEL") {
+        config.reasoner.model = model;
+    }
+    let config = config;
     let offline_guard = Arc::new(OfflineGuard::new(config.runtime.offline));
 
     // Initialize metrics and spawn background reporting tasks

--- a/configs/linnix.darwin.toml
+++ b/configs/linnix.darwin.toml
@@ -21,9 +21,7 @@ retention_seconds = 60
 enabled = true
 endpoint = "http://llama-server:8090/v1/chat/completions"  # Use service name for bridge network
 model = "linnix-3b-distilled"
-window_seconds = 10
 timeout_ms = 30000
-min_eps_to_enable = 10  # Enable for testing
 
 [outputs]
 # Serve the Prometheus text exposition at /metrics/prometheus

--- a/configs/linnix.toml
+++ b/configs/linnix.toml
@@ -20,9 +20,7 @@ retention_seconds = 60
 enabled = true
 endpoint = "http://localhost:8090/v1/chat/completions"
 model = "linnix-3b-distilled"
-window_seconds = 10
 timeout_ms = 30000
-min_eps_to_enable = 10  # Enable for testing
 
 [outputs]
 # Serve the Prometheus text exposition at /metrics/prometheus

--- a/docs/wiki/Configuration-Guide.md
+++ b/docs/wiki/Configuration-Guide.md
@@ -32,9 +32,7 @@ retention_seconds = 60
 enabled = true
 endpoint = "http://localhost:8090/v1/chat/completions"
 model = "linnix-3b-distilled"
-window_seconds = 10
 timeout_ms = 30000
-min_eps_to_enable = 10  # Enable for testing
 
 [prometheus]
 # Prometheus metrics endpoint
@@ -80,9 +78,7 @@ enabled = true
 | `enabled` | bool | true | Enable AI reasoning |
 | `endpoint` | string | "http://localhost:8090/v1/chat/completions" | LLM endpoint URL |
 | `model` | string | "linnix-3b-distilled" | Model name |
-| `window_seconds` | u64 | 10 | Analysis window |
 | `timeout_ms` | u64 | 30000 | Request timeout |
-| `min_eps_to_enable` | u64 | 10 | Minimum events/sec threshold |
 
 ### [prometheus]
 | Field | Type | Default | Description |

--- a/docs/wiki/Troubleshooting.md
+++ b/docs/wiki/Troubleshooting.md
@@ -28,9 +28,9 @@
 
 **Solutions**:
 1. Check LLM server: `curl localhost:8090/health`
-2. Verify reasoner config in linnix.toml
-3. Check `min_eps_to_enable` threshold
-4. Generate some activity: `stress --cpu 1 --timeout 10`
+2. Verify reasoner config in linnix.toml — `endpoint` and `model` are both read
+   from `[reasoner]`, and `LLM_ENDPOINT` / `LLM_MODEL` override them if set
+3. Generate some activity: `stress --cpu 1 --timeout 10`
 
 ### High CPU Usage
 

--- a/quickstart.sh
+++ b/quickstart.sh
@@ -213,9 +213,7 @@ enable_page_faults = false
 enabled = true
 endpoint = "http://llama-server:8090/v1/chat/completions"
 model = "linnix-3b-distilled"
-window_seconds = 30
 timeout_ms = 30000
-min_eps_to_enable = 0
 [prometheus]
 enabled = true
 EOF


### PR DESCRIPTION
Follow-up to #57, which wired `[reasoner].endpoint` into `/insights` and flagged that `model` was still dead config.

## `model` was hardcoded at both LLM call sites

Both shipped configs set `model = "linnix-3b-distilled"` under `[reasoner]`, but `ReasonerConfig` declared no such field — serde discarded it silently. Meanwhile both call sites hardcoded the same string:

- `incidents/analyzer.rs:60` — literal in the request body
- `api/mod.rs:1077` — literal as the `LLM_MODEL` fallback

Added `model` to `ReasonerConfig` and threaded it through `IncidentAnalyzer::new`. Setting it in `linnix.toml` now works.

**Wired at both sites deliberately.** `IncidentAnalyzer::new` took no model parameter, so fixing only `/insights` would have left the analyzer on its hardcode — repeating exactly the half-fix review caught on the endpoint in #57.

## `window_seconds` and `min_eps_to_enable` configured nothing

Both are set in `configs/linnix.toml`, `configs/linnix.darwin.toml`, the config `quickstart.sh` generates, and documented in the Configuration-Guide table *with defaults* — but neither string appears in any `.rs` file in the repo. They configured the local-ILM handler, removed earlier (see the "YAGNI cleanup" notes at `main.rs:857` and `api/mod.rs:35`).

Removed from configs, quickstart, and docs. No parser ever read them, so no deployment can depend on them.

## Invariant now enforced by inspection

Every `[reasoner]` key in every shipped config, in `quickstart.sh`, and in the docs table maps to a real `ReasonerConfig` field — and vice versa:

```
struct fields: enabled endpoint model timeout_ms

configs/linnix.toml              -> keys not in struct: NONE
configs/linnix.darwin.toml       -> keys not in struct: NONE
quickstart.sh                    -> keys not in struct: NONE
docs/wiki/Configuration-Guide.md -> keys not in struct: NONE
```

This is the same failure mode `apply_prometheus_compat()` already exists for — a shipped key that deserializes silently and does nothing.

## Verification

`cargo check --workspace --all-targets` clean. Pre-commit: fmt, clippy, **110 tests / 0 failed**, cargo-deny. The compiler caught the one stale `IncidentAnalyzer::new` call site (a test), which is updated.

Not exercised against a live model server — no test covers either handler's model selection.

## Deliberately not included

**`deny_unknown_fields`.** It would stop the next orphaned key from failing quietly, but it changes the compatibility contract: any deployment with a stray `[reasoner]` key would go from silently ignoring it to failing config load. Wanted a maintainer decision rather than shipping it here.

**The ILM metrics surface.** `linnix_ilm_windows_total`, `_timeouts_total`, `_insights_total`, `_schema_errors_total` and `linnix_ilm_enabled` are exported to `/metrics/prometheus` and `/status`, and consumed by `linnix-cli doctor` — but nothing calls `inc_ilm_*` or `set_ilm_enabled` anywhere, so they are permanently zero/false. Raised separately; not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EFtVtx4BiEYyKPwkdxqHgJ
