### PR TITLE
chore: remove the dead ILM telemetry surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Removed
+- **Dead ILM telemetry surface**: the `local_ilm` handler was deleted in `737b763` (v0.2.0 era), but its counters, exporters, and status fields survived it. Nothing has incremented them since, so they reported zero/false unconditionally.
+  - **Breaking (metrics)**: `linnix_ilm_windows_total`, `linnix_ilm_timeouts_total`, `linnix_ilm_insights_total`, `linnix_ilm_schema_errors_total`, and the `linnix_ilm_enabled` gauge are no longer exported. All were permanently `0`, so no dashboard could have been showing meaningful data; no shipped Grafana dashboard referenced them.
+  - **Breaking (API)**: `/status` no longer returns `reasoner.ilm_enabled`, `reasoner.ilm_disabled_reason`, `ilm_windows`, `ilm_timeouts`, `ilm_insights`, or `ilm_schema_errors`.
+  - Removed the `ilm-test` cargo feature (declared with zero `cfg` uses).
+
+### Fixed
+- **`linnix-cli doctor` reported "AI Analysis: Disabled" unconditionally**, including on a fully configured and working reasoner, because it read the never-set `ilm_enabled` flag. It now reads `reasoner.configured` and reports "Configured" / "Not configured".
+
 ## [0.3.0] - 2026-08-09
 
 ### Added

--- a/cognitod/Cargo.toml
+++ b/cognitod/Cargo.toml
@@ -69,7 +69,6 @@ futures = "0.3"
 
 [features]
 default = []
-ilm-test = []
 
 # Metadata for cargo-deb and cargo-generate-rpm
 [package.metadata.deb]

--- a/cognitod/src/api/mod.rs
+++ b/cognitod/src/api/mod.rs
@@ -31,12 +31,11 @@ use crate::ProcessEvent;
 use crate::ProcessEventWire;
 use crate::config::{OfflineGuard, ReasonerConfig};
 use crate::context::ContextStore;
-use cognitod::alerts::Alert;
-// use crate::handler::local_ilm::schema::insight_json_schema; // Removed (YAGNI cleanup)
 use crate::insights::{InsightRecord, InsightStore as InsightsStore};
 use crate::metrics::Metrics;
 use crate::types::ProcessAlert;
 use crate::types::SystemSnapshot;
+use cognitod::alerts::Alert;
 use cognitod::{Incident, IncidentStats, IncidentStore};
 use linnix_ai_ebpf_common::EventType;
 use sysinfo::{Pid, System};
@@ -284,13 +283,7 @@ struct StatusProbeState {
 struct ReasonerStatus {
     configured: bool,
     endpoint: Option<String>,
-    ilm_enabled: bool,
-    ilm_disabled_reason: Option<String>,
     timeout_ms: u64,
-    ilm_windows: u64,
-    ilm_timeouts: u64,
-    ilm_insights: u64,
-    ilm_schema_errors: u64,
 }
 
 async fn status_handler(State(app_state): State<Arc<AppState>>) -> Json<StatusResponse> {
@@ -350,13 +343,7 @@ async fn status_handler(State(app_state): State<Arc<AppState>>) -> Json<StatusRe
         } else {
             Some(reasoner_cfg.endpoint.clone())
         },
-        ilm_enabled: metrics.ilm_enabled(),
-        ilm_disabled_reason: metrics.ilm_disabled_reason(),
         timeout_ms: reasoner_cfg.timeout_ms,
-        ilm_windows: metrics.ilm_windows(),
-        ilm_timeouts: metrics.ilm_timeouts(),
-        ilm_insights: metrics.ilm_insights(),
-        ilm_schema_errors: metrics.ilm_schema_errors(),
     };
 
     let incidents_last_1h = if let Some(store) = &app_state.incident_store {
@@ -1386,12 +1373,6 @@ pub struct MetricsResponse {
     drops_by_type: Vec<DropBreakdown>,
     rss_probe_mode: String,
     kernel_btf_available: bool,
-    ilm_windows: u64,
-    ilm_timeouts: u64,
-    ilm_insights: u64,
-    ilm_schema_errors: u64,
-    pub ilm_enabled: bool,
-    pub ilm_disabled_reason: Option<String>,
     pub slack_sent: u64,
     pub slack_failed: u64,
     pub alerts_generated: u64,
@@ -1417,11 +1398,6 @@ pub async fn prometheus_metrics(State(app_state): State<Arc<AppState>>) -> Respo
     let queue_depth = app_state.context.queue_depth() as u64;
     let lineage_hits = metrics.lineage_hits();
     let lineage_misses = metrics.lineage_misses();
-    let ilm_windows = metrics.ilm_windows();
-    let ilm_timeouts = metrics.ilm_timeouts();
-    let ilm_insights = metrics.ilm_insights();
-    let ilm_schema_errors = metrics.ilm_schema_errors();
-    let ilm_enabled = metrics.ilm_enabled();
     let kernel_btf_available = if metrics.kernel_btf_available() { 1 } else { 0 };
     let rss_probe_mode = metrics.rss_probe_mode();
 
@@ -1559,45 +1535,6 @@ pub async fn prometheus_metrics(State(app_state): State<Arc<AppState>>) -> Respo
 
     let _ = writeln!(
         body,
-        "# HELP linnix_ilm_windows_total ILM evaluation windows processed."
-    );
-    let _ = writeln!(body, "# TYPE linnix_ilm_windows_total counter");
-    let _ = writeln!(body, "linnix_ilm_windows_total {}", ilm_windows);
-
-    let _ = writeln!(
-        body,
-        "# HELP linnix_ilm_timeouts_total ILM request timeouts."
-    );
-    let _ = writeln!(body, "# TYPE linnix_ilm_timeouts_total counter");
-    let _ = writeln!(body, "linnix_ilm_timeouts_total {}", ilm_timeouts);
-
-    let _ = writeln!(
-        body,
-        "# HELP linnix_ilm_insights_total Valid insights produced."
-    );
-    let _ = writeln!(body, "# TYPE linnix_ilm_insights_total counter");
-    let _ = writeln!(body, "linnix_ilm_insights_total {}", ilm_insights);
-
-    let _ = writeln!(
-        body,
-        "# HELP linnix_ilm_schema_errors_total Insight schema repair failures."
-    );
-    let _ = writeln!(body, "# TYPE linnix_ilm_schema_errors_total counter");
-    let _ = writeln!(body, "linnix_ilm_schema_errors_total {}", ilm_schema_errors);
-
-    let _ = writeln!(
-        body,
-        "# HELP linnix_ilm_enabled ILM handler state (1=enabled)."
-    );
-    let _ = writeln!(body, "# TYPE linnix_ilm_enabled gauge");
-    let _ = writeln!(
-        body,
-        "linnix_ilm_enabled {}",
-        if ilm_enabled { 1 } else { 0 }
-    );
-
-    let _ = writeln!(
-        body,
         "# HELP linnix_dropped_events_by_type_total Drops broken down by event type."
     );
     let _ = writeln!(body, "# TYPE linnix_dropped_events_by_type_total counter");
@@ -1655,12 +1592,6 @@ pub async fn metrics_handler(State(app_state): State<Arc<AppState>>) -> Json<Met
             .collect(),
         rss_probe_mode: probe_mode_label(metrics.rss_probe_mode()).to_string(),
         kernel_btf_available: metrics.kernel_btf_available(),
-        ilm_windows: metrics.ilm_windows(),
-        ilm_timeouts: metrics.ilm_timeouts(),
-        ilm_insights: metrics.ilm_insights(),
-        ilm_schema_errors: metrics.ilm_schema_errors(),
-        ilm_enabled: metrics.ilm_enabled(),
-        ilm_disabled_reason: metrics.ilm_disabled_reason(),
         slack_sent: metrics.slack_sent(),
         slack_failed: metrics.slack_failed(),
         alerts_generated: metrics.alerts_generated(),

--- a/cognitod/src/metrics.rs
+++ b/cognitod/src/metrics.rs
@@ -1,4 +1,3 @@
-use std::sync::RwLock;
 use std::sync::atomic::AtomicU32;
 use std::sync::atomic::{AtomicBool, AtomicU8, AtomicU64, AtomicUsize, Ordering};
 use std::time::SystemTime;
@@ -29,12 +28,6 @@ pub struct Metrics {
     active_rules: AtomicUsize,
     rss_probe_mode: AtomicU8,
     kernel_btf_available: AtomicBool,
-    ilm_windows: AtomicU64,
-    ilm_timeouts: AtomicU64,
-    ilm_insights: AtomicU64,
-    ilm_schema_errors: AtomicU64,
-    ilm_enabled: AtomicBool,
-    ilm_disabled_reason: RwLock<String>,
     // PSI (Pressure Stall Information) gauges - stored as f32 * 100 to use AtomicU32
     psi_cpu_some_avg10: AtomicU32, // CPU pressure (0-10000 = 0.00%-100.00%)
     psi_memory_some_avg10: AtomicU32, // Memory pressure
@@ -78,12 +71,6 @@ impl Metrics {
             active_rules: AtomicUsize::new(0),
             rss_probe_mode: AtomicU8::new(0),
             kernel_btf_available: AtomicBool::new(false),
-            ilm_windows: AtomicU64::new(0),
-            ilm_timeouts: AtomicU64::new(0),
-            ilm_insights: AtomicU64::new(0),
-            ilm_schema_errors: AtomicU64::new(0),
-            ilm_enabled: AtomicBool::new(false),
-            ilm_disabled_reason: RwLock::new(String::new()),
             psi_cpu_some_avg10: AtomicU32::new(0),
             psi_memory_some_avg10: AtomicU32::new(0),
             psi_memory_full_avg10: AtomicU32::new(0),
@@ -223,60 +210,6 @@ impl Metrics {
     fn event_index(event_type: u32) -> usize {
         let max = self::EVENT_TYPE_SLOTS as u32 - 1;
         std::cmp::min(event_type, max) as usize
-    }
-
-    pub fn inc_ilm_windows(&self) {
-        self.ilm_windows.fetch_add(1, Ordering::Relaxed);
-    }
-
-    pub fn ilm_windows(&self) -> u64 {
-        self.ilm_windows.load(Ordering::Relaxed)
-    }
-
-    pub fn inc_ilm_timeouts(&self) {
-        self.ilm_timeouts.fetch_add(1, Ordering::Relaxed);
-    }
-
-    pub fn ilm_timeouts(&self) -> u64 {
-        self.ilm_timeouts.load(Ordering::Relaxed)
-    }
-
-    pub fn inc_ilm_insights(&self) {
-        self.ilm_insights.fetch_add(1, Ordering::Relaxed);
-    }
-
-    pub fn ilm_insights(&self) -> u64 {
-        self.ilm_insights.load(Ordering::Relaxed)
-    }
-
-    pub fn inc_ilm_schema_errors(&self) {
-        self.ilm_schema_errors.fetch_add(1, Ordering::Relaxed);
-    }
-
-    pub fn ilm_schema_errors(&self) -> u64 {
-        self.ilm_schema_errors.load(Ordering::Relaxed)
-    }
-
-    pub fn set_ilm_enabled(&self, enabled: bool) {
-        self.ilm_enabled.store(enabled, Ordering::Relaxed);
-    }
-
-    pub fn ilm_enabled(&self) -> bool {
-        self.ilm_enabled.load(Ordering::Relaxed)
-    }
-
-    pub fn set_ilm_disabled_reason(&self, reason: Option<String>) {
-        let value = reason.unwrap_or_default();
-        if let Ok(mut slot) = self.ilm_disabled_reason.write() {
-            *slot = value;
-        }
-    }
-
-    pub fn ilm_disabled_reason(&self) -> Option<String> {
-        self.ilm_disabled_reason
-            .read()
-            .ok()
-            .and_then(|v| if v.is_empty() { None } else { Some(v.clone()) })
     }
 
     // PSI gauge setters/getters (stored as f32 * 100)

--- a/linnix-cli/src/doctor.rs
+++ b/linnix-cli/src/doctor.rs
@@ -45,11 +45,9 @@ struct StatusProbeState {
 
 #[derive(Deserialize, Debug)]
 struct ReasonerStatus {
-    #[allow(dead_code)]
     configured: bool,
     #[allow(dead_code)]
     endpoint: Option<String>,
-    ilm_enabled: bool,
 }
 
 #[derive(Deserialize, Debug)]
@@ -201,12 +199,14 @@ pub async fn run_doctor(url: &str) -> Result<(), Box<dyn Error>> {
         println!("{}", "Idle / Not Configured".dimmed());
     }
 
-    // 12. Check ILM Status
+    // 12. Check AI analysis status. Reads `configured`, which reflects
+    // [reasoner].enabled; the old `ilm_enabled` flag was never set by anything
+    // and so reported "Disabled" even on a working reasoner.
     print!("• AI Analysis:        ");
-    if status.reasoner.ilm_enabled {
-        println!("{}", "Enabled".green());
+    if status.reasoner.configured {
+        println!("{}", "Configured".green());
     } else {
-        println!("{}", "Disabled".dimmed());
+        println!("{}", "Not configured".dimmed());
     }
 
     println!();

--- a/linnix-cli/tests/doctor.rs
+++ b/linnix-cli/tests/doctor.rs
@@ -21,7 +21,8 @@ async fn doctor_command_checks_health() {
             when.method(GET).path("/status");
             then.status(200)
                 .header("content-type", "application/json")
-                .body(r#"{
+                .body(
+                    r#"{
                     "version": "0.2.0",
                     "uptime_s": 3600,
                     "offline": false,
@@ -33,13 +34,14 @@ async fn doctor_command_checks_health() {
                     "transport": "perf",
                     "active_rules": 5,
                     "probes": {"rss_probe": "enabled", "btf": true},
-                    "reasoner": {"configured": true, "endpoint": "http://localhost:8090", "ilm_enabled": false},
+                    "reasoner": {"configured": true, "endpoint": "http://localhost:8090"},
                     "incidents_last_1h": 2,
                     "feedback_entries": 10,
                     "slack_stats": {"sent": 5, "failed": 0, "approved": 3, "denied": 1},
                     "perf_poll_errors": 0,
                     "dropped_events_total": 0
-                }"#);
+                }"#,
+                );
         })
         .await;
 


### PR DESCRIPTION
Investigated at your request before proposing anything. The history is conclusive.

## What happened

`737b763` (2025-11-29, PR #16) deleted `cognitod/src/handler/local_ilm/` — 5 files, 1,778 lines — and with it **every** caller of `inc_ilm_windows` / `inc_ilm_timeouts` / `inc_ilm_insights` / `inc_ilm_schema_errors` / `set_ilm_enabled`. The counters, their Prometheus exporters, and the `/status` fields were left behind.

`git log -S` over `737b763..HEAD` shows deletions only — no producer has been re-added in the ~8 months since. So these are not an intentional "ILM is off, here's why" design; they are the residue of an incomplete removal. They have reported zero/false unconditionally ever since.

## Why this is more than dead weight

`linnix-cli/src/doctor.rs` check #12 read `reasoner.ilm_enabled` — an `AtomicBool::new(false)` nothing ever sets — and printed:

```
• AI Analysis:        Disabled
```

**unconditionally**, including when the reasoner is fully configured and the incident analyzer is working. An operator debugging "why isn't AI analysis running" was told it was off when it wasn't. A flat-zero counter is noise; this is a wrong answer to a diagnostic question.

So the doctor check is **repointed rather than deleted** — it now reads `reasoner.configured`, which reflects `[reasoner].enabled`. The operator signal is worth keeping, and it is now true for the first time.

## Removed

- 6 `Metrics` fields + their 12 accessors (`cognitod/src/metrics.rs`)
- 5 Prometheus `HELP`/`TYPE`/value blocks
- `ilm_*` fields on `ReasonerStatus` and `MetricsResponse`
- the `ilm-test` cargo feature — declared in `Cargo.toml` with zero `cfg` uses, and absent from CI, scripts, and the Makefile

Net −147 lines.

## Breaking changes

**Metrics**: `linnix_ilm_windows_total`, `linnix_ilm_timeouts_total`, `linnix_ilm_insights_total`, `linnix_ilm_schema_errors_total`, `linnix_ilm_enabled` are no longer exported.

**API**: `/status` no longer returns `reasoner.ilm_enabled`, `reasoner.ilm_disabled_reason`, or the four `ilm_*` counters.

Both surfaces were permanently zero/false, so nothing could have been graphing them meaningfully, and `k8s/grafana/` does not reference them. Recorded under `## [Unreleased]` in CHANGELOG.md.

## Verification

`cargo check --workspace --all-targets` clean, zero warnings. Pre-commit: fmt, clippy, **110 tests / 0 failed**, cargo-deny. `linnix-cli/tests/doctor.rs` exercises the changed `/status` contract and its fixture is updated.

## Notes

- `docs/prometheus-integration.md` references `linnix_ilm_insights_total`, but `docs/*` is gitignored and that file is untracked, so it is not part of this PR. I updated it locally; it will need a separate touch wherever those docs are actually published.
- `cargo fmt --all` reindented the raw string in `linnix-cli/tests/doctor.rs`; that churn is unrelated to the change itself.
- The local variable `notifier_ilm` in `main.rs` is live code (a Slack notifier) that merely carries the old name. Left alone as cosmetic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EFtVtx4BiEYyKPwkdxqHgJ
