### PR TITLE
feat(config): honour --config, fail on malformed files, add --check-config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,16 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- **`cognitod --check-config`**: validates a config file and exits non-zero if anything is wrong — parse errors, plus any section or key the daemon does not read. Runs unprivileged, so it belongs in CI and pre-deploy checks. This is where strict validation lives; startup stays permissive so a node carrying a retired key still boots.
+- **`--config <PATH>` now works.** The flag was declared with a doc comment and a default, but never read — `Config::load()` only ever consulted `LINNIX_CONFIG` or the packaged path, so `cognitod --config /my.toml` silently loaded something else. Precedence is now `--config` > `LINNIX_CONFIG` > `/etc/linnix/linnix.toml`.
+
+### Changed
+- **A malformed config file is now fatal.** Previously "file absent" and "file present but unparseable" both returned `Config::default()` behind one `warn!`, so a typo silently swapped every setting — thresholds, endpoints, PSI paths — for defaults the operator never chose, while the daemon reported healthy. A missing file still yields defaults; an unreadable or unparseable one aborts startup. Config is also loaded before the capability check, so config errors are reported rather than hidden behind a `CAP_BPF` failure.
+
 ### Removed
+- **`[telemetry]` section** (`sample_interval_ms`, `retention_seconds`) from the shipped configs, `quickstart.sh`, the deployment examples, and the wiki generator. Neither key appears anywhere in the source; `sample_interval_ms` occurs zero times. `Troubleshooting.md` advised increasing it to fix high CPU — advice for a knob that does nothing. Surfaced by the new validator, which now runs against the shipped configs as a unit test.
+- `scripts/generate_wiki.sh` still emitted `window_seconds` and `min_eps_to_enable` rows after #58 removed them from the generated docs; regenerating the wiki would have reintroduced them.
 - **Dead ILM telemetry surface**: the `local_ilm` handler was deleted in `737b763` (v0.2.0 era), but its counters, exporters, and status fields survived it. Nothing has incremented them since, so they reported zero/false unconditionally.
   - **Breaking (metrics)**: `linnix_ilm_windows_total`, `linnix_ilm_timeouts_total`, `linnix_ilm_insights_total`, `linnix_ilm_schema_errors_total`, and the `linnix_ilm_enabled` gauge are no longer exported. All were permanently `0`, so no dashboard could have been showing meaningful data; no shipped Grafana dashboard referenced them.
   - **Breaking (API)**: `/status` no longer returns `reasoner.ilm_enabled`, `reasoner.ilm_disabled_reason`, `ilm_windows`, `ilm_timeouts`, `ilm_insights`, or `ilm_schema_errors`.

--- a/cognitod/src/config.rs
+++ b/cognitod/src/config.rs
@@ -1,9 +1,18 @@
 use serde::{Deserialize, Serialize};
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 const DEFAULT_CONFIG_PATH: &str = "/etc/linnix/linnix.toml";
 const ENV_CONFIG_PATH: &str = "LINNIX_CONFIG";
+
+/// Which config file to read: `--config` beats `LINNIX_CONFIG` beats the
+/// packaged path. The CLI flag is the most explicit signal, so it wins; it used
+/// to be declared and then never read at all.
+pub fn resolve_config_path(explicit: Option<PathBuf>) -> PathBuf {
+    explicit
+        .or_else(|| std::env::var(ENV_CONFIG_PATH).ok().map(PathBuf::from))
+        .unwrap_or_else(|| PathBuf::from(DEFAULT_CONFIG_PATH))
+}
 
 /// API server configuration
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -104,6 +113,11 @@ pub struct Config {
     pub privacy: PrivacyConfig,
     #[serde(default)]
     pub psi: PsiConfig,
+    /// Top-level sections/keys no field matches. Captured so `--check-config`
+    /// can name them; a typo'd `[reasner]` is otherwise indistinguishable from
+    /// having configured nothing.
+    #[serde(flatten)]
+    pub unknown: std::collections::BTreeMap<String, toml::Value>,
 }
 
 #[derive(Debug, Deserialize, Clone)]
@@ -153,31 +167,84 @@ fn default_noise_budget_enabled() -> bool {
 }
 
 impl Config {
-    /// Load configuration from file. The path can be overridden
-    /// with the `LINNIX_CONFIG` environment variable. If the file
-    /// is missing or fails to parse, defaults are returned.
-    pub fn load() -> Self {
-        let path =
-            std::env::var(ENV_CONFIG_PATH).unwrap_or_else(|_| DEFAULT_CONFIG_PATH.to_string());
-        let path = PathBuf::from(path);
-        match fs::read_to_string(&path) {
-            Ok(contents) => match toml::from_str::<Config>(&contents) {
-                Ok(mut config) => {
-                    config.warn_unknown_keys();
-                    config.apply_prometheus_compat();
-                    config
-                }
-                Err(e) => {
-                    log::warn!(
-                        "Failed to parse config file at {}: {}. Using defaults.",
-                        path.display(),
-                        e
-                    );
-                    Config::default()
-                }
-            },
-            Err(_) => Config::default(),
+    /// Load configuration, resolving the path as `--config` > `LINNIX_CONFIG` >
+    /// the packaged default. A missing file yields defaults; a malformed one is
+    /// an error. See [`Config::load_from`].
+    pub fn load(explicit: Option<PathBuf>) -> anyhow::Result<Self> {
+        Self::load_from(&resolve_config_path(explicit))
+    }
+
+    /// Load from a specific path.
+    ///
+    /// A **missing** file yields defaults — that is a legitimate way to run.
+    /// A file that exists but cannot be read or parsed is a hard error.
+    ///
+    /// Both cases used to return `Config::default()` with a single `warn!`, so a
+    /// typo in `linnix.toml` silently swapped every setting for a default the
+    /// operator never chose — different thresholds, endpoints and PSI paths,
+    /// with the daemon reporting healthy throughout. Failing loudly is the point
+    /// of this function.
+    pub fn load_from(path: &Path) -> anyhow::Result<Self> {
+        let contents = match fs::read_to_string(path) {
+            Ok(contents) => contents,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                log::info!(
+                    "[config] no config file at {}; using built-in defaults",
+                    path.display()
+                );
+                return Ok(Config::default());
+            }
+            // Permission denied and friends: the file is there and we were meant
+            // to read it. Do not pretend it is absent.
+            Err(e) => {
+                return Err(anyhow::anyhow!(
+                    "config file at {} exists but could not be read: {e}",
+                    path.display()
+                ));
+            }
+        };
+
+        let mut config: Config = toml::from_str(&contents).map_err(|e| {
+            anyhow::anyhow!("config file at {} could not be parsed: {e}", path.display())
+        })?;
+
+        config.warn_unknown_keys();
+        config.apply_prometheus_compat();
+        Ok(config)
+    }
+
+    /// Strict validation for `--check-config`. Returns every problem found,
+    /// empty when the file is clean.
+    ///
+    /// This is where `deny_unknown_fields`-style strictness belongs: failing
+    /// here costs nothing, whereas failing at startup would strand a fleet whose
+    /// configs still carry a retired key.
+    pub fn check(path: &Path) -> Vec<String> {
+        let contents = match fs::read_to_string(path) {
+            Ok(contents) => contents,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                return vec![format!("no config file at {}", path.display())];
+            }
+            Err(e) => return vec![format!("cannot read {}: {e}", path.display())],
+        };
+
+        let config: Config = match toml::from_str(&contents) {
+            Ok(config) => config,
+            Err(e) => return vec![format!("parse error: {e}")],
+        };
+
+        let mut problems = Vec::new();
+        for key in config.unknown.keys() {
+            problems.push(format!(
+                "unrecognised top-level section or key `{key}` (not read by the daemon)"
+            ));
         }
+        for key in config.reasoner.unknown.keys() {
+            problems.push(format!(
+                "unrecognised key `{key}` in [reasoner] (not read by the daemon)"
+            ));
+        }
+        problems
     }
 
     /// Names any `[reasoner]` key that no field matches.
@@ -190,15 +257,24 @@ impl Config {
     /// load that `apply_prometheus_compat` was also written to preserve, while
     /// making the orphan visible at startup instead of never.
     fn warn_unknown_keys(&self) {
-        if self.reasoner.unknown.is_empty() {
-            return;
+        if !self.unknown.is_empty() {
+            let keys: Vec<&str> = self.unknown.keys().map(String::as_str).collect();
+            log::warn!(
+                "[config] ignoring unrecognised top-level section(s)/key(s): {}. \
+                 These are not read by the daemon and have no effect. \
+                 Run `cognitod --check-config` to validate.",
+                keys.join(", ")
+            );
         }
-        let keys: Vec<&str> = self.reasoner.unknown.keys().map(String::as_str).collect();
-        log::warn!(
-            "[config] ignoring unrecognised key(s) in [reasoner]: {}. \
-             These are not read by the daemon and have no effect.",
-            keys.join(", ")
-        );
+        if !self.reasoner.unknown.is_empty() {
+            let keys: Vec<&str> = self.reasoner.unknown.keys().map(String::as_str).collect();
+            log::warn!(
+                "[config] ignoring unrecognised key(s) in [reasoner]: {}. \
+                 These are not read by the daemon and have no effect. \
+                 Run `cognitod --check-config` to validate.",
+                keys.join(", ")
+            );
+        }
     }
 
     /// Honours the legacy `[prometheus] enabled` spelling.
@@ -673,7 +749,7 @@ auth_token = "secret123"
         unsafe {
             std::env::set_var(ENV_CONFIG_PATH, file.path());
         }
-        let cfg = Config::load();
+        let cfg = Config::load(None).expect("valid config must load");
         assert!(!cfg.runtime.offline);
         unsafe {
             std::env::remove_var(ENV_CONFIG_PATH);
@@ -747,5 +823,88 @@ timeout_ms = 30000
             cfg.reasoner.unknown.is_empty(),
             "shipped config must be clean"
         );
+    }
+
+    #[test]
+    fn an_explicit_path_beats_the_env_var_and_the_default() {
+        // `--config` used to be declared and never read. Whatever the
+        // environment says, the explicit path wins.
+        let explicit = PathBuf::from("/tmp/explicit-linnix.toml");
+        assert_eq!(
+            resolve_config_path(Some(explicit.clone())),
+            explicit,
+            "--config must take precedence"
+        );
+    }
+
+    #[test]
+    fn no_config_file_still_yields_defaults() {
+        let missing = PathBuf::from("/nonexistent/linnix/does-not-exist.toml");
+        let cfg = Config::load_from(&missing).expect("a missing file is not an error");
+        assert_eq!(cfg.api.listen_addr, default_listen_addr());
+    }
+
+    #[test]
+    fn a_malformed_file_is_an_error_rather_than_a_silent_reset() {
+        // The regression this whole change exists to prevent: a typo used to
+        // swap every setting for a default the operator never chose, announced
+        // by one warn! line.
+        let mut file = NamedTempFile::new().unwrap();
+        writeln!(file, "[api]\nlisten_addr = = broken").unwrap();
+
+        let err = Config::load_from(file.path()).expect_err("malformed config must fail");
+        assert!(
+            err.to_string().contains("could not be parsed"),
+            "error should name the problem, got: {err}"
+        );
+    }
+
+    #[test]
+    fn a_wrong_type_is_also_fatal() {
+        let mut file = NamedTempFile::new().unwrap();
+        writeln!(file, "[reasoner]\ntimeout_ms = \"thirty seconds\"").unwrap();
+        assert!(
+            Config::load_from(file.path()).is_err(),
+            "a string where u64 is expected must not silently become the default"
+        );
+    }
+
+    #[test]
+    fn check_names_unknown_sections_and_keys() {
+        let mut file = NamedTempFile::new().unwrap();
+        writeln!(
+            file,
+            "[reasner]\nendpoint = \"typo\"\n\n[reasoner]\nwindow_seconds = 10"
+        )
+        .unwrap();
+
+        let problems = Config::check(file.path());
+        assert_eq!(problems.len(), 2, "got: {problems:?}");
+        assert!(problems.iter().any(|p| p.contains("reasner")));
+        assert!(problems.iter().any(|p| p.contains("window_seconds")));
+    }
+
+    #[test]
+    fn check_passes_on_a_clean_file() {
+        let mut file = NamedTempFile::new().unwrap();
+        writeln!(
+            file,
+            "[reasoner]\nenabled = true\nmodel = \"linnix-3b-distilled\""
+        )
+        .unwrap();
+        assert!(Config::check(file.path()).is_empty());
+    }
+
+    #[test]
+    fn the_shipped_configs_pass_their_own_validator() {
+        // Guards the bug class directly: if anyone adds a key to a shipped
+        // config that no field reads, this fails in CI instead of shipping.
+        for name in ["linnix.toml", "linnix.darwin.toml"] {
+            let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+                .join("../configs")
+                .join(name);
+            let problems = Config::check(&path);
+            assert!(problems.is_empty(), "{name} has problems: {problems:?}");
+        }
     }
 }

--- a/cognitod/src/main.rs
+++ b/cognitod/src/main.rs
@@ -137,9 +137,16 @@ fn spawn_metrics_tasks(metrics: Arc<Metrics>) {
 #[command(name = "cognitod")]
 #[command(about = "Linnix Cognition Daemon")]
 struct Args {
-    /// Path to config file
-    #[arg(long, value_name = "PATH", default_value = "/etc/linnix/linnix.toml")]
-    config: PathBuf,
+    /// Path to config file. Overrides LINNIX_CONFIG; defaults to
+    /// /etc/linnix/linnix.toml. Optional (not `default_value`) so that an
+    /// unset flag stays distinguishable from one pointing at the default path,
+    /// which is what lets LINNIX_CONFIG keep working.
+    #[arg(long, value_name = "PATH")]
+    config: Option<PathBuf>,
+    /// Validate the config file and exit. Reports parse errors and any key the
+    /// daemon does not read; exits non-zero if anything is wrong.
+    #[arg(long)]
+    check_config: bool,
     #[arg(long)]
     handler: Vec<String>,
     #[arg(long)]
@@ -384,6 +391,23 @@ fn parse_kernel_version(raw: &str) -> Option<(u32, u32)> {
 async fn main() -> Result<(), Box<dyn Error>> {
     env_logger::init();
     let args = Args::parse();
+
+    // Before ensure_environment(): validating a config file needs no
+    // capabilities, so this must work as an unprivileged user in CI.
+    if args.check_config {
+        let path = config::resolve_config_path(args.config.clone());
+        let problems = Config::check(&path);
+        if problems.is_empty() {
+            println!("[cognitod] config OK: {}", path.display());
+            return Ok(());
+        }
+        eprintln!("[cognitod] config has {} problem(s):", problems.len());
+        for problem in &problems {
+            eprintln!("  - {problem}");
+        }
+        std::process::exit(1);
+    }
+
     let handler = args.handler.clone();
     let detach = args.detach;
     if detach {
@@ -395,10 +419,20 @@ async fn main() -> Result<(), Box<dyn Error>> {
     }
     println!("[cognitod] Starting Cognition Daemon...");
 
-    ensure_environment()?;
+    // Load configuration before the capability check. A malformed file is now
+    // fatal rather than silently swapped for defaults, so the daemon can no
+    // longer run with settings the operator never chose — and a config error is
+    // diagnosable without privileges, so reporting it first is more useful than
+    // failing on CAP_BPF and hiding it.
+    let mut config = Config::load(args.config.clone()).inspect_err(|e| {
+        log::error!("[cognitod] {e:#}");
+        log::error!(
+            "[cognitod] refusing to start with defaults; fix the file or run \
+             `cognitod --check-config` to see what is wrong"
+        );
+    })?;
 
-    // Load configuration
-    let mut config = Config::load();
+    ensure_environment()?;
 
     // Resolve the LLM env overrides once, here, so every consumer sees the same
     // effective values. Applying them per-call-site let the two LLM paths drift:

--- a/configs/linnix.darwin.toml
+++ b/configs/linnix.darwin.toml
@@ -9,13 +9,6 @@ listen_addr = "0.0.0.0:3000"  # Bind to all interfaces for macOS bridge network
 [runtime]
 offline = false
 
-[telemetry]
-# Sample interval for CPU/memory metrics (milliseconds)
-sample_interval_ms = 1000
-
-# Event retention window (seconds)
-retention_seconds = 60
-
 [reasoner]
 # AI-powered incident detection
 enabled = true

--- a/configs/linnix.toml
+++ b/configs/linnix.toml
@@ -8,13 +8,6 @@ listen_addr = "127.0.0.1:3000"
 [runtime]
 offline = false
 
-[telemetry]
-# Sample interval for CPU/memory metrics (milliseconds)
-sample_interval_ms = 1000
-
-# Event retention window (seconds)
-retention_seconds = 60
-
 [reasoner]
 # AI-powered incident detection
 enabled = true

--- a/docs/AWS_EC2_DEPLOYMENT.md
+++ b/docs/AWS_EC2_DEPLOYMENT.md
@@ -443,9 +443,6 @@ Key settings to configure:
 [runtime]
 offline = true  # Set to false if you need external HTTP
 
-[telemetry]
-sample_interval_ms = 1000  # Adjust sampling rate
-
 [api]
 listen_addr = "0.0.0.0:3000"  # API server binding
 

--- a/docs/examples/install-ec2.sh
+++ b/docs/examples/install-ec2.sh
@@ -366,10 +366,6 @@ install_config() {
 # Disable external HTTP requests in isolated environments
 offline = true
 
-[telemetry]
-# Sampling interval for CPU/memory metrics (milliseconds)
-sample_interval_ms = 1000
-
 [probes]
 # Enable high-overhead page fault tracing (disable for production)
 enable_page_faults = false

--- a/docs/wiki/Configuration-Guide.md
+++ b/docs/wiki/Configuration-Guide.md
@@ -20,13 +20,6 @@ listen_addr = "127.0.0.1:3000"
 [runtime]
 offline = false
 
-[telemetry]
-# Sample interval for CPU/memory metrics (milliseconds)
-sample_interval_ms = 1000
-
-# Event retention window (seconds)
-retention_seconds = 60
-
 [reasoner]
 # AI-powered incident detection
 enabled = true
@@ -65,12 +58,6 @@ enabled = true
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `offline` | bool | false | Disable all external HTTP egress |
-
-### [telemetry]
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `sample_interval_ms` | u64 | 1000 | CPU/memory sampling interval |
-| `retention_seconds` | u64 | 60 | Event retention window |
 
 ### [reasoner]
 | Field | Type | Default | Description |

--- a/docs/wiki/Troubleshooting.md
+++ b/docs/wiki/Troubleshooting.md
@@ -37,10 +37,9 @@
 **Symptom**: cognitod using >5% CPU
 
 **Solutions**:
-1. Increase `sample_interval_ms`
-2. Disable optional probes
-3. Check for fork storms on host
-4. Review event rate: `curl localhost:3000/metrics | jq .events_per_second`
+1. Disable optional probes
+2. Check for fork storms on host
+3. Review event rate: `curl localhost:3000/metrics | jq .events_per_second`
 
 ## Diagnostic Commands
 

--- a/quickstart.sh
+++ b/quickstart.sh
@@ -204,9 +204,6 @@ setup_config() {
 # Linnix Configuration
 [runtime]
 offline = false
-[telemetry]
-sample_interval_ms = 1000
-retention_seconds = 60
 [probes]
 enable_page_faults = false
 [reasoner]

--- a/scripts/generate_wiki.sh
+++ b/scripts/generate_wiki.sh
@@ -245,21 +245,13 @@ cat >> "$WIKI_DIR/Configuration-Guide.md" << 'EOF'
 |-------|------|---------|-------------|
 | `offline` | bool | false | Disable all external HTTP egress |
 
-### [telemetry]
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `sample_interval_ms` | u64 | 1000 | CPU/memory sampling interval |
-| `retention_seconds` | u64 | 60 | Event retention window |
-
 ### [reasoner]
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `enabled` | bool | true | Enable AI reasoning |
 | `endpoint` | string | "http://localhost:8090/v1/chat/completions" | LLM endpoint URL |
 | `model` | string | "linnix-3b-distilled" | Model name |
-| `window_seconds` | u64 | 10 | Analysis window |
 | `timeout_ms` | u64 | 30000 | Request timeout |
-| `min_eps_to_enable` | u64 | 10 | Minimum events/sec threshold |
 
 ### [prometheus]
 | Field | Type | Default | Description |
@@ -698,17 +690,16 @@ cat > "$WIKI_DIR/Troubleshooting.md" << 'EOF'
 
 **Solutions**:
 1. Check LLM server: `curl localhost:8090/health`
-2. Verify reasoner config in linnix.toml
-3. Check `min_eps_to_enable` threshold
-4. Generate some activity: `stress --cpu 1 --timeout 10`
+2. Verify reasoner config in linnix.toml — `endpoint` and `model` are both
+   read from `[reasoner]`; `LLM_ENDPOINT` / `LLM_MODEL` override them
+3. Generate some activity: `stress --cpu 1 --timeout 10`
 
 ### High CPU Usage
 
 **Symptom**: cognitod using >5% CPU
 
 **Solutions**:
-1. Increase `sample_interval_ms`
-2. Disable optional probes
+1. Disable optional probes
 3. Check for fork storms on host
 4. Review event rate: `curl localhost:3000/metrics | jq .events_per_second`
 


### PR DESCRIPTION
This is the answer to "what would you do for `deny_unknown_fields`". Short version: **don't add it to the runtime path — fix the two things it was standing in for, and put the strictness where failing is free.**

## 1. `--config` was dead

`Args` declared it at `main.rs` with a doc comment and a default path, but `Config::load()` took no argument and consulted only `LINNIX_CONFIG` or the packaged path. The only `args` fields ever read were `handler`, `detach`, `probe_only`, `dry_run`. So `cognitod --config /my/linnix.toml` silently loaded something else.

Precedence is now `--config` > `LINNIX_CONFIG` > `/etc/linnix/linnix.toml`. The flag became `Option<PathBuf>` rather than carrying a `default_value`, so "unset" stays distinguishable from "set to the default" — that's what lets `LINNIX_CONFIG` keep working.

## 2. A malformed config was silently swallowed

`load()` treated *file absent* and *file present but unparseable* identically: both returned `Config::default()` behind a single `warn!`. A typo in `linnix.toml` therefore swapped **every** setting — thresholds, endpoints, PSI paths — for defaults the operator never chose, while the daemon came up reporting healthy.

Now: absent → defaults (still legitimate). Unreadable or unparseable → abort with the parse error.

Config also loads **before** `ensure_environment()`. A config error is diagnosable without privileges and shouldn't hide behind a `CAP_BPF` failure.

> Blast radius check before calling this urgent: `mode` defaults to `"monitor"` and `require_human_approval` to `true`, so a silent reset could never have enabled process-killing. The safety interlocks held. It was still running unconfigured.

## 3. `--check-config` — strictness where it's free

```
$ cognitod --check-config --config configs/linnix.toml
[cognitod] config OK: configs/linnix.toml                      # exit 0

$ cognitod --check-config --config bad.toml
[cognitod] config has 2 problem(s):                            # exit 1
  - unrecognised top-level section or key `reasner` (not read by the daemon)
  - unrecognised key `window_seconds` in [reasoner] (not read by the daemon)
```

This is the `deny_unknown_fields` the config kept asking for, placed where it cannot hurt. **Not** on the startup path: `cognitod` is a fleet agent and keys get retired — `window_seconds` and `min_eps_to_enable` just were in #58. Denying at startup means any node still carrying an old `linnix.toml` refuses to boot after an upgrade, which is a worse failure than the one it prevents and lands on exactly the deployments mid-migration. Permissive at runtime (warn), strict in CI.

Runs unprivileged, so it belongs in your pipeline and pre-deploy checks.

## What the validator found immediately

The new test running `Config::check` over the shipped configs **failed on first run**:

```
linnix.toml has problems: ["unrecognised top-level section or key `telemetry`"]
```

`[telemetry]` — `sample_interval_ms`, `retention_seconds` — appears in both shipped configs, `quickstart.sh`, the deployment examples, and the Configuration-Guide table with documented defaults. Neither key appears anywhere in the source; `sample_interval_ms` has **zero** occurrences. `Troubleshooting.md` advised increasing it to fix high CPU — advice for a knob that does nothing.

Removed from all of the above. **If `[telemetry]` was meant to be implemented, this PR is telling you it never was** — say so and I'll wire it instead of deleting it.

Also caught: `scripts/generate_wiki.sh` still emitted the `window_seconds` and `min_eps_to_enable` rows that #58 removed from the generated docs. Regenerating the wiki would have silently reintroduced them.

That test is the durable part of this PR — it turns "someone notices while reading the struct" into a CI failure.

## Verification

Unit tests (120 total, 0 failed) plus **end-to-end against the built binary**, not just the library:

| Case | Result |
|---|---|
| shipped config | `config OK`, exit 0 |
| unknown section + unknown key | both named, exit 1 |
| syntax error | parse error with line/column, exit 1 |
| missing file | named, exit 1 |
| malformed config at startup | aborts with the parse error |
| `--config <path>` | honoured |
| `LINNIX_CONFIG` with no `--config` | still honoured |

`cargo clippy --workspace --all-targets` clean.

## Suggested follow-up

Add `cognitod --check-config` to CI as a pipeline step so config regressions fail before merge rather than at deploy. Not included here since it touches workflow files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EFtVtx4BiEYyKPwkdxqHgJ
