### PR TITLE
fix(attribution): count attribution alerts, and bound the cooldown map

### DIFF
--- a/cognitod/src/attribution.rs
+++ b/cognitod/src/attribution.rs
@@ -23,6 +23,7 @@ use tokio::sync::broadcast;
 
 use crate::alerts::{Alert, Severity};
 use crate::collectors::psi::BlameAttribution;
+use crate::metrics::Metrics;
 
 /// Minimum stall attributed to a *single* offender before we emit a JSON event
 /// or an alert for it. Distinct from the threshold that decides whether the
@@ -440,12 +441,40 @@ fn escape_label(value: &str) -> String {
         .replace('\n', "\\n")
 }
 
+/// The alert channel together with the process-wide counter that has to move
+/// with it.
+///
+/// These travel as one value on purpose: `linnix_alerts_emitted_total` counts
+/// every alert the daemon puts on the channel, so a caller that could hand over
+/// a sender without the counter would silently under-report alert volume — the
+/// exact bug this type exists to make unrepresentable.
+#[derive(Clone)]
+pub struct AlertOutput {
+    tx: broadcast::Sender<Alert>,
+    metrics: std::sync::Arc<Metrics>,
+}
+
+impl AlertOutput {
+    pub fn new(tx: broadcast::Sender<Alert>, metrics: std::sync::Arc<Metrics>) -> Self {
+        Self { tx, metrics }
+    }
+
+    /// Sends and counts. The count is unconditional, matching `RuleEngine`:
+    /// a send that fails for want of subscribers is still an alert the daemon
+    /// decided to emit, and the two paths must agree or the counter means
+    /// different things depending on which code produced the alert.
+    fn emit(&self, alert: Alert) {
+        let _ = self.tx.send(alert);
+        self.metrics.inc_alerts_emitted();
+    }
+}
+
 /// The single point where a completed attribution fans out to logs, alerts and
 /// metrics. Callers hand it the attributions for one stall event; it decides
 /// what crosses the reporting threshold.
 pub struct AttributionSink {
     metrics: std::sync::Arc<BlameMetrics>,
-    alerts: Option<broadcast::Sender<Alert>>,
+    alerts: Option<AlertOutput>,
     host: String,
     threshold_us: u64,
     cooldown: Duration,
@@ -457,7 +486,7 @@ pub struct AttributionSink {
 impl AttributionSink {
     pub fn new(
         metrics: std::sync::Arc<BlameMetrics>,
-        alerts: Option<broadcast::Sender<Alert>>,
+        alerts: Option<AlertOutput>,
         host: impl Into<String>,
     ) -> Self {
         Self {
@@ -484,6 +513,12 @@ impl AttributionSink {
 
     pub fn metrics(&self) -> &std::sync::Arc<BlameMetrics> {
         &self.metrics
+    }
+
+    /// How many offender/victim pairs are currently held in cooldown state.
+    /// Exposed so the bound on that map can be asserted rather than assumed.
+    pub fn cooldown_entries(&self) -> usize {
+        self.reported.lock().map(|m| m.len()).unwrap_or(0)
     }
 
     /// Whether this pair may be reported now, recording the report if so.
@@ -518,6 +553,23 @@ impl AttributionSink {
         if reported.len() >= DEFAULT_MAX_SERIES {
             let cooldown = self.cooldown;
             reported.retain(|_, last| now.duration_since(*last) < cooldown);
+
+            // Expiry frees nothing when every pair is still inside its
+            // cooldown — precisely the high-cardinality burst this cap exists
+            // for. Evict the oldest entry instead, so the map stays bounded.
+            // The victim is the pair closest to leaving cooldown anyway, so it
+            // is the one whose early re-report costs least. This is an O(n)
+            // scan, but only while at the cap, and only over 4096 entries.
+            while reported.len() >= DEFAULT_MAX_SERIES {
+                let Some(oldest) = reported
+                    .iter()
+                    .min_by_key(|(_, last)| **last)
+                    .map(|(k, _)| k.clone())
+                else {
+                    break;
+                };
+                reported.remove(&oldest);
+            }
         }
 
         reported.insert(key, now);
@@ -555,8 +607,8 @@ impl AttributionSink {
                 Err(e) => warn!("[attribution] failed to serialize attribution event: {}", e),
             }
 
-            if let Some(tx) = &self.alerts {
-                let _ = tx.send(Alert {
+            if let Some(alerts) = &self.alerts {
+                alerts.emit(Alert {
                     rule: "stall_attribution".to_string(),
                     severity: Severity::Medium,
                     message: event.alert_message(),
@@ -675,5 +727,25 @@ mod tests {
         assert_eq!(emitted[0].stall_ms, 250);
         // Both still contribute to the counters.
         assert_eq!(metrics.pair_series(), 2);
+    }
+
+    #[test]
+    fn cooldown_state_stays_bounded_when_nothing_has_expired() {
+        let metrics = std::sync::Arc::new(BlameMetrics::new("node-1"));
+        // An hour-long cooldown means expiry frees nothing during the test, so
+        // the cap can only hold if oldest-entry eviction is doing the work.
+        let sink =
+            AttributionSink::new(metrics, None, "node-1").with_cooldown(Duration::from_secs(3_600));
+
+        for i in 0..(DEFAULT_MAX_SERIES + 500) {
+            sink.emit(&[attribution(&format!("offender-{i}"), 250_000)]);
+        }
+
+        assert!(
+            sink.cooldown_entries() <= DEFAULT_MAX_SERIES,
+            "cooldown map grew to {} entries, past the {} cap",
+            sink.cooldown_entries(),
+            DEFAULT_MAX_SERIES
+        );
     }
 }

--- a/cognitod/src/main.rs
+++ b/cognitod/src/main.rs
@@ -850,7 +850,9 @@ async fn main() -> Result<(), Box<dyn Error>> {
         let sink = Arc::new(
             cognitod::attribution::AttributionSink::new(
                 blame_metrics.clone(),
-                alert_tx.clone(),
+                alert_tx
+                    .clone()
+                    .map(|tx| cognitod::attribution::AlertOutput::new(tx, Arc::clone(&metrics))),
                 ctx.node_name.clone(),
             )
             .with_threshold_us(config.psi.attribution_threshold_ms.saturating_mul(1_000))

--- a/cognitod/tests/attribution_eval.rs
+++ b/cognitod/tests/attribution_eval.rs
@@ -14,8 +14,9 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use cognitod::attribution::{AttributionSink, BlameMetrics, BlameReason};
+use cognitod::attribution::{AlertOutput, AttributionSink, BlameMetrics, BlameReason};
 use cognitod::collectors::psi::{CpuConsumer, StallEvent, calculate_blame_attributions};
+use cognitod::metrics::Metrics;
 
 /// What an offender is expected to look like in the emitted output.
 struct ExpectedOffender {
@@ -186,7 +187,12 @@ fn scenarios_produce_the_expected_events_alerts_and_metrics() {
     for scenario in SCENARIOS {
         let metrics = Arc::new(BlameMetrics::new("node-1"));
         let (alert_tx, mut alert_rx) = tokio::sync::broadcast::channel(64);
-        let sink = AttributionSink::new(metrics.clone(), Some(alert_tx), "node-1");
+        let daemon_metrics = Arc::new(Metrics::new());
+        let sink = AttributionSink::new(
+            metrics.clone(),
+            Some(AlertOutput::new(alert_tx, daemon_metrics.clone())),
+            "node-1",
+        );
 
         let event = build_stall_event(scenario);
         let attributions = calculate_blame_attributions(&event);
@@ -252,6 +258,15 @@ fn scenarios_produce_the_expected_events_alerts_and_metrics() {
             alerts.len(),
             scenario.expect_reported.len(),
             "[{}] alert count did not match reported offenders",
+            scenario.name
+        );
+        // ...and each of those alerts is counted, so alert-volume monitoring
+        // built on /metrics sees attribution alerts rather than silently
+        // missing them.
+        assert_eq!(
+            daemon_metrics.alerts_emitted(),
+            alerts.len() as u64,
+            "[{}] linnix_alerts_emitted_total did not count the attribution alerts",
             scenario.name
         );
         for (alert, expected) in alerts.iter().zip(scenario.expect_reported.iter()) {
@@ -382,8 +397,13 @@ fn a_flood_of_distinct_offenders_stays_bounded() {
 fn sustained_pressure_reports_once_then_goes_quiet() {
     let metrics = Arc::new(BlameMetrics::new("node-1"));
     let (alert_tx, mut alert_rx) = tokio::sync::broadcast::channel(64);
-    let sink = AttributionSink::new(metrics.clone(), Some(alert_tx), "node-1")
-        .with_cooldown(Duration::from_secs(300));
+    let daemon_metrics = Arc::new(Metrics::new());
+    let sink = AttributionSink::new(
+        metrics.clone(),
+        Some(AlertOutput::new(alert_tx, daemon_metrics.clone())),
+        "node-1",
+    )
+    .with_cooldown(Duration::from_secs(300));
 
     let attributions = calculate_blame_attributions(&build_stall_event(&SCENARIOS[0]));
 
@@ -400,6 +420,11 @@ fn sustained_pressure_reports_once_then_goes_quiet() {
         alerts += 1;
     }
     assert_eq!(alerts, 1, "one incident should page once");
+    assert_eq!(
+        daemon_metrics.alerts_emitted(),
+        1,
+        "the suppressed repeats must not be counted either"
+    );
 
     // The counters are the continuous signal and must keep climbing while
     // reporting is suppressed, otherwise the dashboard would show the problem
@@ -414,8 +439,12 @@ fn sustained_pressure_reports_once_then_goes_quiet() {
 fn a_second_offender_is_not_silenced_by_the_first() {
     let metrics = Arc::new(BlameMetrics::new("node-1"));
     let (alert_tx, mut alert_rx) = tokio::sync::broadcast::channel(64);
-    let sink = AttributionSink::new(metrics, Some(alert_tx), "node-1")
-        .with_cooldown(Duration::from_secs(300));
+    let sink = AttributionSink::new(
+        metrics,
+        Some(AlertOutput::new(alert_tx, Arc::new(Metrics::new()))),
+        "node-1",
+    )
+    .with_cooldown(Duration::from_secs(300));
 
     // The image resizer is already being reported on.
     sink.emit(&calculate_blame_attributions(&build_stall_event(


### PR DESCRIPTION
Both P2 findings from issue #55 — Codex's review of #53, flagged against code merged in #52.

## 1. Attribution alerts weren't counted
`AttributionSink` sent alerts on the same broadcast channel as `RuleEngine` but never incremented `alerts_emitted_total`, so `/metrics` and `/metrics/prometheus` under-reported alert volume whenever a stall attribution fired — enough to invalidate alert-rate monitoring downstream.

The obvious fix is an optional `Arc<Metrics>` on the sink, but an optional handle production forgets to set is exactly how this bug arose. Instead the sender and the counter now travel together as `AlertOutput`, so a counted send is the only kind available. `AlertOutput::emit` increments unconditionally after the send, matching `RuleEngine` (`alerts.rs:501`) — a send that fails for want of subscribers is still an alert the daemon decided to emit, and the two paths have to agree or the counter means different things depending on which code produced the alert.

## 2. Cooldown map could exceed its cap
`claim_report_slot` relied on expiry to bound the map. At `DEFAULT_MAX_SERIES` with every pair still inside its cooldown window, `retain` frees nothing and the insert grows past the cap — precisely the high-cardinality burst the cap exists for. It now falls back to evicting the oldest entry, which is the pair closest to leaving cooldown anyway, so its early re-report costs least. O(n) min-scan, but only while at the cap and only over 4096 entries.

Two deliberate choices:
- **Alert volume during such a burst rises slightly**, since an evicted pair can re-alert before its cooldown lapses. That's the correct trade against unbounded memory — and with fix 1 it's now visible in `linnix_alerts_emitted_total` rather than hidden.
- **Cooldown eviction does not touch `BlameMetrics::evictions`.** That's published as `linnix_blame_series_evicted_total` ("Blame series dropped because the series cap was reached") for the victim/pair counter maps; reusing it would silently redefine a shipped metric.

## Tests
- `cooldown_state_stays_bounded_when_nothing_has_expired` — an hour-long cooldown means expiry frees nothing, so the cap only holds if oldest-entry eviction works. Fails on the old code (map reaches 4596).
- The scenario eval and `sustained_pressure_reports_once_then_goes_quiet` now assert `alerts_emitted()` tracks the alerts actually received, including that suppressed repeats aren't counted.
- Full suite: 125 passed, clippy and fmt clean.

Closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EFtVtx4BiEYyKPwkdxqHgJ