### PR TITLE
refactor(blame): score and reason share one normalisation

### DIFF
--- a/cognitod/src/attribution.rs
+++ b/cognitod/src/attribution.rs
@@ -54,9 +54,13 @@ pub enum BlameReason {
 impl BlameReason {
     /// Picks the dominant factor using the same normalisation the blame score
     /// itself uses, so the reason always names the term that contributed most.
+    ///
+    /// "The same normalisation" is enforced rather than asserted: both terms
+    /// come from the functions `calculate_blame_attributions` sums, so there is
+    /// no second copy of the arithmetic to drift out of step with the score.
     pub fn classify(cpu_share: f64, fork_count: u64, short_job_count: u64) -> Self {
-        let fork_score = (fork_count as f64 / 100.0).min(1.0);
-        let short_job_score = (short_job_count as f64 / 50.0).min(1.0);
+        let fork_score = crate::collectors::psi::fork_score(fork_count);
+        let short_job_score = crate::collectors::psi::short_job_score(short_job_count);
 
         if cpu_share >= fork_score && cpu_share >= short_job_score {
             BlameReason::HighCpuContention
@@ -654,6 +658,36 @@ mod tests {
             BlameReason::classify(0.1, 0, 100),
             BlameReason::ShortJobChurn
         );
+    }
+
+    #[test]
+    fn the_reason_names_the_largest_term_of_the_score_itself() {
+        // Checked against the very functions `calculate_blame_attributions`
+        // sums, so this fails if the reason and the score ever stop agreeing —
+        // the failure a copied normalisation constant used to allow, where an
+        // alert would name a cause the score did not actually rank first.
+        for (cpu_share, forks, short_jobs) in [
+            (0.9_f64, 10_u64, 5_u64),
+            (0.1, 200, 5),
+            (0.1, 0, 100),
+            (0.4, 50, 30),
+            (0.0, 0, 0),
+            (0.5, 50, 25),
+        ] {
+            let fork = crate::collectors::psi::fork_score(forks);
+            let short = crate::collectors::psi::short_job_score(short_jobs);
+
+            let named = match BlameReason::classify(cpu_share, forks, short_jobs) {
+                BlameReason::HighCpuContention => cpu_share,
+                BlameReason::ForkStorm => fork,
+                BlameReason::ShortJobChurn => short,
+            };
+
+            assert!(
+                named >= cpu_share && named >= fork && named >= short,
+                "cpu={cpu_share} fork={fork} short={short}: reason named the {named} term, which is not the largest"
+            );
+        }
     }
 
     #[test]

--- a/cognitod/src/collectors/psi.rs
+++ b/cognitod/src/collectors/psi.rs
@@ -124,6 +124,30 @@ fn extract_container_id(cgroup_path: &Path) -> Option<String> {
 const HISTORY_SIZE: usize = 10;
 const STALL_THRESHOLD_US: u64 = 100_000; // 100ms threshold for significant stall
 
+/// Fork count over a detection window at which an offender is considered to be
+/// forking as hard as the score can express. Beyond this the term saturates, so
+/// a fork bomb and a very busy fork bomb rank the same on this factor alone.
+const FORK_SATURATION: f64 = 100.0;
+
+/// Same idea for short-lived jobs: churn at or above this rate contributes the
+/// full weight of the term.
+const SHORT_JOB_SATURATION: f64 = 50.0;
+
+/// The fork term of the blame score, normalised to 0.0..=1.0.
+///
+/// This lives here, next to the score it feeds, and `BlameReason::classify`
+/// calls it rather than repeating the arithmetic: the reported *reason* must
+/// name whichever term actually dominated the reported *score*, and a copied
+/// literal cannot hold that invariant across a change to either side.
+pub fn fork_score(fork_count: u64) -> f64 {
+    (fork_count as f64 / FORK_SATURATION).min(1.0)
+}
+
+/// The short-job-churn term of the blame score, normalised to 0.0..=1.0.
+pub fn short_job_score(short_job_count: u64) -> f64 {
+    (short_job_count as f64 / SHORT_JOB_SATURATION).min(1.0)
+}
+
 pub struct PsiMonitor {
     k8s_ctx: Arc<K8sContext>,
     context: Arc<ContextStore>,
@@ -414,18 +438,9 @@ pub fn calculate_blame_attributions(event: &StallEvent) -> Vec<BlameAttribution>
             let short_job_count = *event.short_job_counts.get(&key).unwrap_or(&0);
 
             // Blame Score Calculation
-            // Weighted sum of normalized factors.
-            // CPU is primary, but forks/short-jobs indicate "bad behavior"
-            // Heuristic:
-            // - CPU share is 0.0-1.0
-            // - Forks: >100/15s is high. Normalize by 100?
-            // - Short Jobs: >50/15s is high. Normalize by 50?
-
-            let fork_score = (fork_count as f64 / 100.0).min(1.0);
-            let short_job_score = (short_job_count as f64 / 50.0).min(1.0);
-
-            // Composite score
-            let raw_score = cpu_share + fork_score + short_job_score;
+            // Weighted sum of normalized factors, each 0.0-1.0.
+            // CPU is primary, but forks/short-jobs indicate "bad behavior".
+            let raw_score = cpu_share + fork_score(fork_count) + short_job_score(short_job_count);
 
             // Weight by stall magnitude (in seconds)
             let blame_score = raw_score * (event.stall_delta_us as f64 / 1_000_000.0);


### PR DESCRIPTION
Audit item 8.

`BlameReason::classify` documented that it used "the same normalisation the blame score itself uses" — and then repeated the `/ 100.0` and `/ 50.0` literals to do it (`attribution.rs:58-59` vs `collectors/psi.rs:424-425`). That is exactly the kind of invariant a comment cannot hold: change either side and the emitted alert names a cause the score did not actually rank first, while every test still passes.

Both terms are now `collectors::psi::fork_score` / `short_job_score`, defined next to the sum they feed, and `classify` calls them. The `.min(1.0)` clamp was duplicated as well, so it moves with them. The bare numbers become `FORK_SATURATION` / `SHORT_JOB_SATURATION`, and the explanation of what they mean now sits on the constants instead of trailing off mid-function as `// Forks: >100/15s is high. Normalize by 100?`.

**Behaviour is unchanged** — same arithmetic on the same inputs. The attribution eval scenarios pin the resulting scores, reasons and per-offender stall splits, and pass untouched, which is the check that matters here.

New test `the_reason_names_the_largest_term_of_the_score_itself` asserts the named reason really is the largest of the three terms *as `collectors::psi` computes them*, rather than re-deriving `classify`'s own branch order. So if the two ever stop agreeing again, something fails.

Full suite green, clippy and fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EFtVtx4BiEYyKPwkdxqHgJ