### PR TITLE
chore: ignore editor workspace files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 # IDE
 .vscode/
 .idea/
+*.code-workspace
 *.swp
 *.swo
 *~


### PR DESCRIPTION
`*.code-workspace` is per-developer VS Code state — which folders someone has open, plus their local settings — so it belongs alongside the existing `.vscode/` and `.idea/` entries rather than in the tree.

Practical motivation: untracked, it makes `gh pr create` warn "1 uncommitted change" on every PR from this checkout.

Pattern rather than a literal filename, so it covers any workspace file a contributor creates. Nothing matching it is currently tracked (`git ls-files '*.code-workspace'` is empty), so this changes no existing file's status.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EFtVtx4BiEYyKPwkdxqHgJ