### PR TITLE
chore(psi): drop two dead_code allows, and keep the PSI parsers separate

### DIFF
--- a/cognitod/src/utils/psi.rs
+++ b/cognitod/src/utils/psi.rs
@@ -25,7 +25,6 @@ fn get_psi_path(metric: &str) -> String {
 
 /// PSI metrics for the entire system
 #[derive(Debug, Clone, Default)]
-#[allow(dead_code)]
 pub struct PsiMetrics {
     /// CPU pressure: % time at least one task stalled waiting for CPU (10s avg)
     pub cpu_some_avg10: f32,
@@ -43,7 +42,6 @@ pub struct PsiMetrics {
     pub io_full_avg10: f32,
 }
 
-#[allow(dead_code)]
 impl PsiMetrics {
     /// Read PSI metrics from /proc/pressure/*
     ///


### PR DESCRIPTION
Audit item §4.7, resolved — but only half of it as written, and the other half deliberately not done.

## Done: the stale allows
`PsiMetrics` (`utils/psi.rs:28`) and its `impl` block (`:46`) both carried `#[allow(dead_code)]` while being live — `context.rs:361` calls `PsiMetrics::read()` and reads all five fields into `SystemSnapshot`.

Removing both produces no warnings (`cargo check --all-targets` and clippy clean), and the reason is worth stating: these are `pub` items in a library crate, so they were never going to be flagged. The attributes never did anything. The cost of leaving them is that they'd silently cover whatever *does* go dead under them later.

## Not done: "unify the two PSI parsers"
The audit called these duplicate parsers of the same format. They parse the same *file format* but different *fields*, for different consumers, in different units:

| | `utils/psi.rs::parse_avg10` | `collectors/psi.rs::parse_psi_file` |
|---|---|---|
| Source | `/proc/pressure/{cpu,memory,io}` (system-wide) | cgroup `cpu.pressure` (per-pod) |
| Field | `avg10=` | `total=` |
| Unit | `f32` percentage | `u64` microseconds |
| Consumer | `SystemSnapshot` for the dashboard | stall deltas for blame attribution |

Merging them means one parser returning the whole PSI line (some/full × avg10/avg60/avg300/total) with each caller projecting a disjoint half. That is a wider type with two partial users — more surface, not less — and it puts the attribution hot path behind a parser that also has to satisfy the dashboard's needs. The overlap here is roughly `split_whitespace` and `split_once('=')`.

So the finding stands as an observation and is being closed as "correct, not worth acting on." If a third consumer ever needs a different field, that's the point to revisit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EFtVtx4BiEYyKPwkdxqHgJ