### PR TITLE
test(metrics): pin the exposed Prometheus text against a fixture

### DIFF
--- a/cognitod/src/api/mod.rs
+++ b/cognitod/src/api/mod.rs
@@ -2703,6 +2703,167 @@ mod tests {
         assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
     }
 
+    /// The exposed `/metrics/prometheus` text, byte for byte, for a known
+    /// state.
+    ///
+    /// This is a contract test, not a unit test. The metric names, labels,
+    /// `# TYPE` lines and ordering here are what the shipped Grafana dashboard
+    /// (`k8s/grafana/linnix-noisy-neighbor.json`) queries by name; renaming a
+    /// metric or dropping a label is a breaking change that no other test in
+    /// this repo would notice, and that surfaces as blank panels in someone
+    /// else's cluster rather than as a red build.
+    ///
+    /// Three values are volatile by nature — uptime and this process's own CPU
+    /// and RSS — so they are scrubbed to `<volatile>` before comparison. The
+    /// *lines* still have to be present and correctly named; only the numbers
+    /// are free to move.
+    ///
+    /// If this fails and the change was deliberate, re-record with:
+    /// `UPDATE_METRICS_FIXTURE=1 cargo test -p cognitod --bin cognitod metrics_prometheus`
+    #[tokio::test]
+    async fn metrics_prometheus_matches_the_recorded_contract() {
+        let ctx = Arc::new(ContextStore::new(Duration::from_secs(60), 10, None));
+
+        let metrics = Arc::new(Metrics::new());
+        metrics.events_total.fetch_add(4_242, Ordering::Relaxed);
+        metrics
+            .dropped_events_total
+            .fetch_add(17, Ordering::Relaxed);
+        metrics.subscribers.fetch_add(3, Ordering::Relaxed);
+        metrics.alerts_active.fetch_add(2, Ordering::Relaxed);
+        metrics.inc_alerts_emitted();
+        metrics.inc_rb_overflow();
+        metrics.inc_lineage_hit();
+        metrics.inc_lineage_miss();
+        metrics.inc_perf_poll_error();
+        metrics.set_kernel_btf_available(true);
+        metrics.set_psi_cpu(75.2);
+        metrics.set_psi_memory_some(3.1);
+
+        // One victim and one offender pair, deliberately: these render out of
+        // `HashMap`s, so several series would order differently run to run and
+        // the fixture would flap for reasons that have nothing to do with the
+        // contract.
+        let blame = Arc::new(cognitod::attribution::BlameMetrics::new("test-node"));
+        blame.record_victim_pressure("payments", "payment-api", "container-1", 900_000);
+        blame.record_attribution(&cognitod::collectors::psi::BlameAttribution {
+            victim_pod: "payment-api".to_string(),
+            victim_namespace: "payments".to_string(),
+            offender_pod: "image-resizer".to_string(),
+            offender_namespace: "media".to_string(),
+            blame_score: 1.5,
+            stall_us: 900_000,
+            attributed_stall_us: 684_000,
+            timestamp: 1_700_000_000,
+            cpu_share: 0.71,
+            fork_count: 186,
+            short_job_count: 42,
+        });
+
+        let app_state = Arc::new(AppState {
+            context: Arc::clone(&ctx),
+            metrics: Arc::clone(&metrics),
+            alerts: None,
+            insights: Arc::new(InsightStore::new(16, None)),
+            offline: Arc::new(OfflineGuard::new(false)),
+            transport: "perf",
+            probe_state: ProbeState::disabled(),
+            require_kernel_instrumentation: true,
+            enforcement: None,
+            reasoner: ReasonerConfig::default(),
+            prometheus_enabled: true,
+            alert_history: Arc::new(AlertHistory::new(16)),
+            auth_token: None,
+            incident_store: None,
+            k8s: None,
+            blame_metrics: Arc::clone(&blame),
+        });
+
+        let response = super::all_routes(app_state)
+            .oneshot(
+                Request::builder()
+                    .uri("/metrics/prometheus")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let scrubbed = scrub_volatile(std::str::from_utf8(&body).unwrap());
+
+        let fixture_path = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/tests/fixtures/metrics_prometheus.txt"
+        );
+
+        if std::env::var("UPDATE_METRICS_FIXTURE").is_ok() {
+            std::fs::write(fixture_path, &scrubbed).unwrap();
+            return;
+        }
+
+        let expected = std::fs::read_to_string(fixture_path).unwrap();
+        if scrubbed != expected {
+            // Deliberately not `assert_eq!`: on a 73-line body that prints two
+            // full copies of the text and leaves the reader to spot the
+            // difference. What a person needs here is the lines that moved.
+            panic!(
+                "the exposed metric text changed.\n\n{}\n\nIf this was deliberate, re-record with \
+                 UPDATE_METRICS_FIXTURE=1 and review the fixture diff as a change to a public \
+                 contract — the shipped Grafana dashboard queries these names.",
+                line_diff(&expected, &scrubbed)
+            );
+        }
+    }
+
+    /// The differing lines between two metric bodies, as `-expected/+actual`.
+    fn line_diff(expected: &str, actual: &str) -> String {
+        let expected_lines: Vec<&str> = expected.lines().collect();
+        let actual_lines: Vec<&str> = actual.lines().collect();
+
+        let mut out = Vec::new();
+        for idx in 0..expected_lines.len().max(actual_lines.len()) {
+            let e = expected_lines.get(idx).copied();
+            let a = actual_lines.get(idx).copied();
+            if e != a {
+                if let Some(e) = e {
+                    out.push(format!("  line {}: -{e}", idx + 1));
+                }
+                if let Some(a) = a {
+                    out.push(format!("  line {}: +{a}", idx + 1));
+                }
+            }
+        }
+        out.join("\n")
+    }
+
+    /// Replaces the value of every metric whose number cannot be held fixed,
+    /// leaving the name and the rest of the line intact.
+    fn scrub_volatile(body: &str) -> String {
+        const VOLATILE: [&str; 3] = [
+            "linnix_uptime_seconds",
+            "linnix_process_cpu_percent",
+            "linnix_process_rss_bytes",
+        ];
+
+        body.lines()
+            .map(|line| {
+                match VOLATILE
+                    .iter()
+                    .find(|name| line.starts_with(*name) && line.contains(' '))
+                {
+                    Some(name) => format!("{name} <volatile>"),
+                    None => line.to_string(),
+                }
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+            + "\n"
+    }
+
     /// The one intended difference between the two listeners, pinned: same
     /// route, same state, token required over TCP and not over the socket.
     /// The route sets themselves no longer need a test — both listeners build

--- a/cognitod/src/api/mod.rs
+++ b/cognitod/src/api/mod.rs
@@ -2819,6 +2819,37 @@ mod tests {
         }
     }
 
+    #[test]
+    fn scrubbing_hides_values_without_hiding_contract_changes() {
+        let scrubbed = scrub_volatile(
+            "# HELP linnix_uptime_seconds Cognitod uptime in seconds.\n\
+             # TYPE linnix_uptime_seconds gauge\n\
+             linnix_uptime_seconds 4210\n\
+             linnix_process_cpu_percent{pid=\"7\"} 1.5\n\
+             linnix_uptime_seconds_total 9\n\
+             linnix_events_total 4242\n",
+        );
+
+        let lines: Vec<&str> = scrubbed.lines().collect();
+
+        // Help and type text is contract, not value: never touched.
+        assert_eq!(
+            lines[0],
+            "# HELP linnix_uptime_seconds Cognitod uptime in seconds."
+        );
+        assert_eq!(lines[2], "linnix_uptime_seconds <volatile>");
+
+        // A label added to a volatile metric is itself a contract change, so
+        // it has to survive scrubbing and fail the comparison.
+        assert_eq!(lines[3], "linnix_process_cpu_percent{pid=\"7\"} <volatile>");
+
+        // A different metric that merely starts with a volatile name keeps its
+        // value: prefix matching would have swallowed it.
+        assert_eq!(lines[4], "linnix_uptime_seconds_total 9");
+
+        assert_eq!(lines[5], "linnix_events_total 4242");
+    }
+
     /// The differing lines between two metric bodies, as `-expected/+actual`.
     fn line_diff(expected: &str, actual: &str) -> String {
         let expected_lines: Vec<&str> = expected.lines().collect();
@@ -2851,12 +2882,25 @@ mod tests {
 
         body.lines()
             .map(|line| {
-                match VOLATILE
-                    .iter()
-                    .find(|name| line.starts_with(*name) && line.contains(' '))
-                {
-                    Some(name) => format!("{name} <volatile>"),
-                    None => line.to_string(),
+                // Only the value is replaced, and only when the metric *name*
+                // matches exactly. Rebuilding the line from the name alone
+                // would erase whatever sits between it and the value, so a
+                // label added to one of these — or a longer name sharing the
+                // prefix — would be scrubbed out of existence and the fixture
+                // would keep passing through the very change it exists to
+                // catch.
+                let Some((series, _value)) = line.rsplit_once(' ') else {
+                    return line.to_string();
+                };
+                let name = series
+                    .split_once('{')
+                    .map(|(name, _labels)| name)
+                    .unwrap_or(series);
+
+                if VOLATILE.contains(&name) {
+                    format!("{series} <volatile>")
+                } else {
+                    line.to_string()
                 }
             })
             .collect::<Vec<_>>()

--- a/cognitod/tests/fixtures/metrics_prometheus.txt
+++ b/cognitod/tests/fixtures/metrics_prometheus.txt
@@ -1,0 +1,73 @@
+# HELP linnix_kernel_instrumentation_active 1 if the eBPF probes are attached, 0 if running userspace-only.
+# TYPE linnix_kernel_instrumentation_active gauge
+linnix_kernel_instrumentation_active 1
+# HELP linnix_events_total Total process events received.
+# TYPE linnix_events_total counter
+linnix_events_total 4242
+# HELP linnix_events_per_second Approximate events per second over the last second.
+# TYPE linnix_events_per_second gauge
+linnix_events_per_second 0
+# HELP linnix_alerts_active Current active alerts.
+# TYPE linnix_alerts_active gauge
+linnix_alerts_active 2
+# HELP linnix_alerts_emitted_total Total alerts emitted.
+# TYPE linnix_alerts_emitted_total counter
+linnix_alerts_emitted_total 1
+# HELP linnix_dropped_events_total Total events dropped (sampling/backpressure).
+# TYPE linnix_dropped_events_total counter
+linnix_dropped_events_total 17
+# HELP linnix_ringbuf_overflows_total Total ring buffer overflows observed.
+# TYPE linnix_ringbuf_overflows_total counter
+linnix_ringbuf_overflows_total 1
+# HELP linnix_rate_limited_total Events skipped due to configured rate caps.
+# TYPE linnix_rate_limited_total counter
+linnix_rate_limited_total 0
+# HELP linnix_perf_poll_errors_total Perf buffer polling errors.
+# TYPE linnix_perf_poll_errors_total counter
+linnix_perf_poll_errors_total 1
+# HELP linnix_lineage_hits_total Lineage cache hits.
+# TYPE linnix_lineage_hits_total counter
+linnix_lineage_hits_total 1
+# HELP linnix_lineage_misses_total Lineage cache misses.
+# TYPE linnix_lineage_misses_total counter
+linnix_lineage_misses_total 1
+# HELP linnix_context_queue_depth Current context queue backlog.
+# TYPE linnix_context_queue_depth gauge
+linnix_context_queue_depth 0
+# HELP linnix_subscribers Number of SSE subscribers.
+# TYPE linnix_subscribers gauge
+linnix_subscribers 3
+# HELP linnix_uptime_seconds Cognitod uptime in seconds.
+# TYPE linnix_uptime_seconds gauge
+linnix_uptime_seconds <volatile>
+# HELP linnix_kernel_btf_available Kernel BTF availability (1=yes).
+# TYPE linnix_kernel_btf_available gauge
+linnix_kernel_btf_available 1
+# HELP linnix_rss_probe_mode RSS probe operating mode (numeric enum).
+# TYPE linnix_rss_probe_mode gauge
+linnix_rss_probe_mode 0
+# HELP linnix_process_cpu_percent Cognitod process CPU usage percentage.
+# TYPE linnix_process_cpu_percent gauge
+linnix_process_cpu_percent <volatile>
+# HELP linnix_process_rss_bytes Cognitod process RSS in bytes.
+# TYPE linnix_process_rss_bytes gauge
+linnix_process_rss_bytes <volatile>
+# HELP linnix_dropped_events_by_type_total Drops broken down by event type.
+# TYPE linnix_dropped_events_by_type_total counter
+linnix_dropped_events_by_type_total{event_type="0"} 0
+linnix_dropped_events_by_type_total{event_type="1"} 0
+linnix_dropped_events_by_type_total{event_type="2"} 0
+linnix_dropped_events_by_type_total{event_type="3"} 0
+linnix_dropped_events_by_type_total{event_type="4"} 0
+linnix_dropped_events_by_type_total{event_type="5"} 0
+linnix_dropped_events_by_type_total{event_type="6"} 0
+linnix_dropped_events_by_type_total{event_type="7"} 0
+# HELP linnix_pod_psi_pressure_total Cumulative CPU pressure stall time per pod, in microseconds.
+# TYPE linnix_pod_psi_pressure_total counter
+linnix_pod_psi_pressure_total{victim_namespace="payments",victim_pod="payment-api",node="test-node"} 900000
+# HELP linnix_stall_induced_seconds_total Stall time attributed to an offending pod, in seconds.
+# TYPE linnix_stall_induced_seconds_total counter
+linnix_stall_induced_seconds_total{offender_pod="image-resizer",offender_namespace="media",victim_pod="payment-api",victim_namespace="payments"} 0.684000
+# HELP linnix_blame_series_evicted_total Blame series dropped because the series cap was reached.
+# TYPE linnix_blame_series_evicted_total counter
+linnix_blame_series_evicted_total 0


### PR DESCRIPTION
Step 1 of #72, on its own. The registry refactor is what that issue is really about, but this is the part that makes it safe — and it's worth having whether or not the rest ever happens.

## The gap
Nothing asserted what `/metrics/prometheus` actually emits. `prometheus_endpoint_returns_metrics_when_enabled` checks the status code and content type, so every metric name, label and `# TYPE` line could change without a single test noticing — against a contract the shipped Grafana dashboard (`k8s/grafana/linnix-noisy-neighbor.json`) queries **by name**. That failure shows up as blank panels in someone else's cluster days later, not as a red build.

## The fixture
`cognitod/tests/fixtures/metrics_prometheus.txt` records the full scrape for a known state — 22 metric families, including the three attribution series added in #52/#56 — and the test compares byte for byte.

Two things had to be handled for it to be stable rather than annoying:

- **Volatile values.** Uptime and this process's own CPU and RSS can't be held fixed, so those three are scrubbed to `<volatile>`. The lines still have to be present and correctly named; only the numbers are free to move.
- **Map ordering.** Blame metrics render out of `HashMap`s, so the fixture seeds exactly one victim and one offender pair. Several series would order differently between runs and the test would flap for reasons that have nothing to do with the contract.

## Failure output
`assert_eq!` on a 73-line body prints two full copies and leaves you to spot the difference, so failure prints the differing lines instead:

```
the exposed metric text changed.

  line 70: -linnix_stall_induced_seconds_total{offender_pod="image-resizer",...} 0.684000
  line 70: +linnix_stall_induced_seconds_total{offending_pod="image-resizer",...} 0.684000

If this was deliberate, re-record with UPDATE_METRICS_FIXTURE=1 and review the fixture diff
as a change to a public contract — the shipped Grafana dashboard queries these names.
```

## Verification
Not just "the test passes": I broke it on purpose. Renaming the `offender_pod` label produced exactly the failure above, pointing at line 70. Ran three times to confirm it doesn't flap, then reverted the deliberate break.

172 tests pass; clippy and fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EFtVtx4BiEYyKPwkdxqHgJ