### PR TITLE
feat(attribution): shareable evidence links for a fixed window

### DIFF
--- a/cognitod/src/api/mod.rs
+++ b/cognitod/src/api/mod.rs
@@ -1283,6 +1283,11 @@ struct AttributionQuery {
     namespace: String,
     #[serde(default = "default_window")]
     window: i64, // minutes
+    /// Absolute unix-second bounds. When both are given they replace `window`,
+    /// which is what turns a query into something citable: `window` answers
+    /// "lately" and means something different every time it is asked.
+    from: Option<i64>,
+    to: Option<i64>,
 }
 
 fn default_window() -> i64 {
@@ -1321,8 +1326,13 @@ async fn get_attributions(
 ) -> Result<Json<serde_json::Value>, StatusCode> {
     match &app_state.incident_store {
         Some(store) => {
+            // Resolved once, then used for both the query and the link. Asking
+            // the clock twice would hand back a permalink to a window that is
+            // not quite the one just answered.
+            let (from, to) = query.resolve_bounds();
+
             let attributions = store
-                .query_attributions(&query.pod, &query.namespace, query.window * 60)
+                .query_attributions_between(&query.pod, &query.namespace, from, to)
                 .await
                 .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
 
@@ -1335,11 +1345,67 @@ async fn get_attributions(
                     "namespace": query.namespace
                 },
                 "window_minutes": query.window,
+                // The bounds actually queried, always absolute — a caller that
+                // asked for "the last 15 minutes" can cite what that turned
+                // out to mean instead of re-asking and getting a later answer.
+                "from": from,
+                "to": to,
+                "permalink": query.permalink(from, to),
                 "attributions": attributions
             })))
         }
         None => Err(StatusCode::SERVICE_UNAVAILABLE),
     }
+}
+
+impl AttributionQuery {
+    /// The absolute bounds this query means right now.
+    ///
+    /// Explicit `from`/`to` win. A half-specified range is treated as the open
+    /// side being unbounded rather than as an error: `from` alone reads as
+    /// "since then", which is what someone pasting a start time intends.
+    fn resolve_bounds(&self) -> (i64, i64) {
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs() as i64)
+            .unwrap_or(0);
+
+        match (self.from, self.to) {
+            (Some(from), Some(to)) => (from, to),
+            (Some(from), None) => (from, now),
+            (None, Some(to)) => (to - self.window * 60, to),
+            (None, None) => (now - self.window * 60, now),
+        }
+    }
+
+    /// A query string that returns these exact rows whenever it is opened.
+    fn permalink(&self, from: i64, to: i64) -> String {
+        format!(
+            "/attribution?pod={}&namespace={}&from={}&to={}",
+            urlencode(&self.pod),
+            urlencode(&self.namespace),
+            from,
+            to
+        )
+    }
+}
+
+/// Percent-encodes the characters that can appear in a Kubernetes name and
+/// still break a query string. Names are restricted to lowercase alphanumerics,
+/// `-` and `.`, so this is a guard against malformed input reaching a link
+/// rather than a general-purpose encoder.
+fn urlencode(value: &str) -> String {
+    value
+        .chars()
+        .map(|c| match c {
+            'a'..='z' | 'A'..='Z' | '0'..='9' | '-' | '.' | '_' | '~' => c.to_string(),
+            other => other
+                .to_string()
+                .bytes()
+                .map(|b| format!("%{b:02X}"))
+                .collect(),
+        })
+        .collect()
 }
 
 #[derive(Deserialize)]
@@ -2906,6 +2972,90 @@ mod tests {
             .collect::<Vec<_>>()
             .join("\n")
             + "\n"
+    }
+
+    #[test]
+    fn explicit_bounds_are_used_verbatim_and_echoed_as_a_link() {
+        let query = super::AttributionQuery {
+            pod: "payment-api".to_string(),
+            namespace: "payments".to_string(),
+            window: 5,
+            from: Some(1_700_000_000),
+            to: Some(1_700_000_900),
+        };
+
+        // The whole point: the same request tomorrow returns the same rows, so
+        // `window` must not quietly re-enter the calculation.
+        assert_eq!(query.resolve_bounds(), (1_700_000_000, 1_700_000_900));
+        assert_eq!(
+            query.permalink(1_700_000_000, 1_700_000_900),
+            "/attribution?pod=payment-api&namespace=payments&from=1700000000&to=1700000900"
+        );
+    }
+
+    #[test]
+    fn a_relative_window_resolves_to_absolute_bounds() {
+        let query = super::AttributionQuery {
+            pod: "payment-api".to_string(),
+            namespace: "payments".to_string(),
+            window: 15,
+            from: None,
+            to: None,
+        };
+
+        let (from, to) = query.resolve_bounds();
+        assert_eq!(to - from, 15 * 60, "the window must survive resolution");
+
+        // A caller who asked for "the last 15 minutes" gets back the fixed
+        // range that turned out to be, which is the thing they can cite.
+        let link = query.permalink(from, to);
+        assert!(link.contains(&format!("from={from}")), "{link}");
+        assert!(link.contains(&format!("to={to}")), "{link}");
+        assert!(
+            !link.contains("window="),
+            "a link must not be relative: {link}"
+        );
+    }
+
+    #[test]
+    fn one_sided_bounds_leave_the_open_end_open() {
+        let since = super::AttributionQuery {
+            pod: "p".to_string(),
+            namespace: "n".to_string(),
+            window: 5,
+            from: Some(1_700_000_000),
+            to: None,
+        };
+        let (from, to) = since.resolve_bounds();
+        assert_eq!(from, 1_700_000_000, "an explicit start must be honoured");
+        assert!(to > from, "an open end runs to now");
+
+        let until = super::AttributionQuery {
+            pod: "p".to_string(),
+            namespace: "n".to_string(),
+            window: 5,
+            from: None,
+            to: Some(1_700_000_900),
+        };
+        assert_eq!(until.resolve_bounds(), (1_700_000_900 - 300, 1_700_000_900));
+    }
+
+    #[test]
+    fn names_that_would_break_a_link_are_encoded() {
+        let query = super::AttributionQuery {
+            pod: "pod name&evil=1".to_string(),
+            namespace: "ns/../etc".to_string(),
+            window: 5,
+            from: None,
+            to: None,
+        };
+
+        let link = query.permalink(1, 2);
+        assert!(
+            !link.contains("&evil=1") && !link.contains(' '),
+            "a name must not be able to inject query parameters: {link}"
+        );
+        assert!(!link.contains("ns/../etc"), "{link}");
     }
 
     /// The one intended difference between the two listeners, pinned: same

--- a/cognitod/src/api/mod.rs
+++ b/cognitod/src/api/mod.rs
@@ -1288,6 +1288,13 @@ struct AttributionQuery {
     /// "lately" and means something different every time it is asked.
     from: Option<i64>,
     to: Option<i64>,
+    /// Highest attribution row id the answer may include.
+    ///
+    /// Timestamps are not sufficient on their own: they have one-second
+    /// resolution, so a row written later in the same second as `to` falls
+    /// inside the bounds but was not in the original answer. The watermark
+    /// pins the answer to the rows that existed when it was given.
+    max_id: Option<i64>,
 }
 
 fn default_window() -> i64 {
@@ -1331,8 +1338,8 @@ async fn get_attributions(
             // not quite the one just answered.
             let (from, to) = query.resolve_bounds();
 
-            let attributions = store
-                .query_attributions_between(&query.pod, &query.namespace, from, to)
+            let (attributions, watermark) = store
+                .query_attributions_between(&query.pod, &query.namespace, from, to, query.max_id)
                 .await
                 .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
 
@@ -1344,13 +1351,17 @@ async fn get_attributions(
                     "pod": query.pod,
                     "namespace": query.namespace
                 },
-                "window_minutes": query.window,
+                // Derived from the bounds rather than echoed from `window`.
+                // A permalink carries `from`/`to` and no `window`, so echoing
+                // the input would report the 5-minute default beside bounds
+                // spanning any duration at all.
+                "window_minutes": (to - from) / 60,
                 // The bounds actually queried, always absolute — a caller that
                 // asked for "the last 15 minutes" can cite what that turned
                 // out to mean instead of re-asking and getting a later answer.
                 "from": from,
                 "to": to,
-                "permalink": query.permalink(from, to),
+                "permalink": query.permalink(from, to, watermark),
                 "attributions": attributions
             })))
         }
@@ -1379,13 +1390,19 @@ impl AttributionQuery {
     }
 
     /// A query string that returns these exact rows whenever it is opened.
-    fn permalink(&self, from: i64, to: i64) -> String {
+    ///
+    /// Carries the row-id watermark as well as the time bounds, so a row
+    /// written later in the same second as `to` — or backfilled afterwards
+    /// with an older timestamp — cannot appear in evidence that has already
+    /// been cited.
+    fn permalink(&self, from: i64, to: i64, max_id: i64) -> String {
         format!(
-            "/attribution?pod={}&namespace={}&from={}&to={}",
+            "/attribution?pod={}&namespace={}&from={}&to={}&max_id={}",
             urlencode(&self.pod),
             urlencode(&self.namespace),
             from,
-            to
+            to,
+            max_id
         )
     }
 }
@@ -2982,14 +2999,15 @@ mod tests {
             window: 5,
             from: Some(1_700_000_000),
             to: Some(1_700_000_900),
+            max_id: Some(4_096),
         };
 
         // The whole point: the same request tomorrow returns the same rows, so
         // `window` must not quietly re-enter the calculation.
         assert_eq!(query.resolve_bounds(), (1_700_000_000, 1_700_000_900));
         assert_eq!(
-            query.permalink(1_700_000_000, 1_700_000_900),
-            "/attribution?pod=payment-api&namespace=payments&from=1700000000&to=1700000900"
+            query.permalink(1_700_000_000, 1_700_000_900, 4_096),
+            "/attribution?pod=payment-api&namespace=payments&from=1700000000&to=1700000900&max_id=4096"
         );
     }
 
@@ -3001,6 +3019,7 @@ mod tests {
             window: 15,
             from: None,
             to: None,
+            max_id: None,
         };
 
         let (from, to) = query.resolve_bounds();
@@ -3008,7 +3027,7 @@ mod tests {
 
         // A caller who asked for "the last 15 minutes" gets back the fixed
         // range that turned out to be, which is the thing they can cite.
-        let link = query.permalink(from, to);
+        let link = query.permalink(from, to, 77);
         assert!(link.contains(&format!("from={from}")), "{link}");
         assert!(link.contains(&format!("to={to}")), "{link}");
         assert!(
@@ -3025,6 +3044,7 @@ mod tests {
             window: 5,
             from: Some(1_700_000_000),
             to: None,
+            max_id: None,
         };
         let (from, to) = since.resolve_bounds();
         assert_eq!(from, 1_700_000_000, "an explicit start must be honoured");
@@ -3036,6 +3056,7 @@ mod tests {
             window: 5,
             from: None,
             to: Some(1_700_000_900),
+            max_id: None,
         };
         assert_eq!(until.resolve_bounds(), (1_700_000_900 - 300, 1_700_000_900));
     }
@@ -3048,9 +3069,10 @@ mod tests {
             window: 5,
             from: None,
             to: None,
+            max_id: None,
         };
 
-        let link = query.permalink(1, 2);
+        let link = query.permalink(1, 2, 3);
         assert!(
             !link.contains("&evil=1") && !link.contains(' '),
             "a name must not be able to inject query parameters: {link}"

--- a/cognitod/src/incidents.rs
+++ b/cognitod/src/incidents.rs
@@ -404,30 +404,58 @@ impl IncidentStore {
     }
 
     /// Query stall attributions for a victim pod within a time window
+    /// Attributions for a victim over a window ending now.
+    ///
+    /// Convenience over [`query_attributions_between`] for "what is happening
+    /// lately". The bounds it resolves to move with every call, so a caller
+    /// that needs a stable answer — anything shareable — must resolve them once
+    /// and pass them explicitly.
     pub async fn query_attributions(
         &self,
         victim_pod: &str,
         victim_namespace: &str,
         window_seconds: i64,
     ) -> Result<Vec<StallAttribution>, sqlx::Error> {
-        let now = std::time::SystemTime::now()
+        let to = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap()
             .as_secs() as i64;
-        let start_time = now - window_seconds;
 
+        self.query_attributions_between(victim_pod, victim_namespace, to - window_seconds, to)
+            .await
+    }
+
+    /// Attributions for a victim between two absolute unix timestamps.
+    ///
+    /// Both bounds are inclusive. Timestamps here have one-second resolution,
+    /// so an exclusive upper bound would drop any attribution recorded during
+    /// the current second — invisible in testing and wrong exactly when a
+    /// stall is being written as it is being read.
+    ///
+    /// Fixed bounds are what makes an answer citable: the same pair of
+    /// timestamps returns the same rows next week, which a `now`-relative
+    /// window cannot promise for the length of a paragraph, let alone an
+    /// incident review.
+    pub async fn query_attributions_between(
+        &self,
+        victim_pod: &str,
+        victim_namespace: &str,
+        from: i64,
+        to: i64,
+    ) -> Result<Vec<StallAttribution>, sqlx::Error> {
         let rows = sqlx::query(
             r#"
             SELECT offender_pod, offender_namespace, stall_us, blame_score, timestamp,
                    cpu_share, fork_count, short_job_count, attributed_stall_us
             FROM stall_attributions
-            WHERE victim_pod = ? AND victim_namespace = ? AND timestamp >= ?
+            WHERE victim_pod = ? AND victim_namespace = ? AND timestamp >= ? AND timestamp <= ?
             ORDER BY blame_score DESC
             "#,
         )
         .bind(victim_pod)
         .bind(victim_namespace)
-        .bind(start_time)
+        .bind(from)
+        .bind(to)
         .fetch_all(&self.pool)
         .await?;
 

--- a/cognitod/src/incidents.rs
+++ b/cognitod/src/incidents.rs
@@ -421,8 +421,9 @@ impl IncidentStore {
             .unwrap()
             .as_secs() as i64;
 
-        self.query_attributions_between(victim_pod, victim_namespace, to - window_seconds, to)
+        self.query_attributions_between(victim_pod, victim_namespace, to - window_seconds, to, None)
             .await
+            .map(|(rows, _watermark)| rows)
     }
 
     /// Attributions for a victim between two absolute unix timestamps.
@@ -436,19 +437,45 @@ impl IncidentStore {
     /// timestamps returns the same rows next week, which a `now`-relative
     /// window cannot promise for the length of a paragraph, let alone an
     /// incident review.
+    ///
+    /// Timestamps alone are not enough for that promise, though. They have
+    /// one-second resolution and the PSI collector writes on the same clock,
+    /// so a row stamped in the current second can land *after* a query has
+    /// answered and still fall inside its inclusive upper bound — absent from
+    /// the response, present when the link is reopened. `max_row_id` closes
+    /// that: rows are only considered up to a watermark taken before the
+    /// select, and the returned watermark is what the caller puts in the link.
+    /// Passing it back reproduces the original answer exactly, including
+    /// against rows backfilled later with older timestamps, which no
+    /// time-based boundary can exclude.
+    ///
+    /// Returns the rows and the watermark they were read at.
     pub async fn query_attributions_between(
         &self,
         victim_pod: &str,
         victim_namespace: &str,
         from: i64,
         to: i64,
-    ) -> Result<Vec<StallAttribution>, sqlx::Error> {
+        max_row_id: Option<i64>,
+    ) -> Result<(Vec<StallAttribution>, i64), sqlx::Error> {
+        // Taken before the select, never after: a watermark read afterwards
+        // could include a row the select had already missed, which is the race
+        // this exists to remove.
+        let watermark = match max_row_id {
+            Some(id) => id,
+            None => sqlx::query("SELECT COALESCE(MAX(id), 0) AS watermark FROM stall_attributions")
+                .fetch_one(&self.pool)
+                .await?
+                .get::<i64, _>("watermark"),
+        };
+
         let rows = sqlx::query(
             r#"
             SELECT offender_pod, offender_namespace, stall_us, blame_score, timestamp,
                    cpu_share, fork_count, short_job_count, attributed_stall_us
             FROM stall_attributions
             WHERE victim_pod = ? AND victim_namespace = ? AND timestamp >= ? AND timestamp <= ?
+                  AND id <= ?
             ORDER BY blame_score DESC
             "#,
         )
@@ -456,10 +483,11 @@ impl IncidentStore {
         .bind(victim_namespace)
         .bind(from)
         .bind(to)
+        .bind(watermark)
         .fetch_all(&self.pool)
         .await?;
 
-        Ok(rows
+        let rows = rows
             .into_iter()
             // Columns are read by name: positional access silently shifts
             // every field after any column added to the SELECT above.
@@ -476,7 +504,9 @@ impl IncidentStore {
                     .get::<Option<i64>, _>("attributed_stall_us")
                     .map(|v| v as u64),
             })
-            .collect())
+            .collect();
+
+        Ok((rows, watermark))
     }
 
     /// Get incident by ID

--- a/cognitod/tests/attribution_store_eval.rs
+++ b/cognitod/tests/attribution_store_eval.rs
@@ -303,8 +303,8 @@ async fn absolute_bounds_return_the_same_rows_however_much_later_they_are_asked(
 
     let bounds = (at as i64 - 3_660, at as i64 - 3_540);
 
-    let first = store
-        .query_attributions_between("payment-api", "prod", bounds.0, bounds.1)
+    let (first, watermark) = store
+        .query_attributions_between("payment-api", "prod", bounds.0, bounds.1, None)
         .await
         .unwrap();
     assert_eq!(first.len(), 1, "the row should be inside the fixed bounds");
@@ -316,8 +316,8 @@ async fn absolute_bounds_return_the_same_rows_however_much_later_they_are_asked(
         .await
         .unwrap();
 
-    let second = store
-        .query_attributions_between("payment-api", "prod", bounds.0, bounds.1)
+    let (second, _) = store
+        .query_attributions_between("payment-api", "prod", bounds.0, bounds.1, Some(watermark))
         .await
         .unwrap();
     assert_eq!(
@@ -344,8 +344,8 @@ async fn a_row_written_on_the_upper_bound_is_included() {
     row.timestamp = at;
     store.insert_stall_attribution(&row).await.unwrap();
 
-    let rows = store
-        .query_attributions_between("payment-api", "prod", at as i64 - 60, at as i64)
+    let (rows, _) = store
+        .query_attributions_between("payment-api", "prod", at as i64 - 60, at as i64, None)
         .await
         .unwrap();
 
@@ -353,5 +353,97 @@ async fn a_row_written_on_the_upper_bound_is_included() {
         rows.len(),
         1,
         "the instant named as the end of the window is part of it"
+    );
+}
+
+/// The race Codex found on #76: timestamps have one-second resolution, so a
+/// row written *after* a query answers can still fall inside its inclusive
+/// upper bound and appear when the cited link is reopened.
+///
+/// The watermark is what closes it. Without one, this test fails: the second
+/// read sees a row that was never in the answer being cited.
+#[tokio::test]
+async fn a_row_landing_in_the_same_second_cannot_join_cited_evidence() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = IncidentStore::new(dir.path().join("incidents.db"))
+        .await
+        .expect("fresh database should initialise");
+
+    let at = now_secs();
+    let mut first_row = attribution("image-resize-worker", 2.0, 600_000);
+    first_row.timestamp = at;
+    store.insert_stall_attribution(&first_row).await.unwrap();
+
+    // The answer someone shares.
+    let (cited, watermark) = store
+        .query_attributions_between("payment-api", "prod", at as i64 - 60, at as i64, None)
+        .await
+        .unwrap();
+    assert_eq!(cited.len(), 1);
+
+    // A second attribution lands in the very same second — inside the shared
+    // link's time bounds, but after the answer was given.
+    let mut late_row = attribution("batch-etl", 1.0, 300_000);
+    late_row.timestamp = at;
+    store.insert_stall_attribution(&late_row).await.unwrap();
+
+    let (reopened, _) = store
+        .query_attributions_between(
+            "payment-api",
+            "prod",
+            at as i64 - 60,
+            at as i64,
+            Some(watermark),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        reopened.len(),
+        1,
+        "evidence already cited must not grow rows that were written after it"
+    );
+    assert_eq!(reopened[0].offender_pod, "image-resize-worker");
+}
+
+/// A backfilled row — inserted later but stamped earlier — is the case no
+/// time-based boundary can exclude, which is why the watermark is a row id
+/// rather than a tighter timestamp.
+#[tokio::test]
+async fn a_backfilled_row_with_an_older_timestamp_stays_out_of_cited_evidence() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = IncidentStore::new(dir.path().join("incidents.db"))
+        .await
+        .expect("fresh database should initialise");
+
+    let at = now_secs();
+    let mut original = attribution("image-resize-worker", 2.0, 600_000);
+    original.timestamp = at - 30;
+    store.insert_stall_attribution(&original).await.unwrap();
+
+    let (_, watermark) = store
+        .query_attributions_between("payment-api", "prod", at as i64 - 60, at as i64, None)
+        .await
+        .unwrap();
+
+    let mut backfilled = attribution("batch-etl", 1.0, 300_000);
+    backfilled.timestamp = at - 45; // older than the row already cited
+    store.insert_stall_attribution(&backfilled).await.unwrap();
+
+    let (reopened, _) = store
+        .query_attributions_between(
+            "payment-api",
+            "prod",
+            at as i64 - 60,
+            at as i64,
+            Some(watermark),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        reopened.len(),
+        1,
+        "a row inserted after the citation must stay out of it, whatever its timestamp claims"
     );
 }

--- a/cognitod/tests/attribution_store_eval.rs
+++ b/cognitod/tests/attribution_store_eval.rs
@@ -283,3 +283,75 @@ async fn a_row_with_no_recoverable_blame_stays_unknown_rather_than_zero() {
         "an unrecoverable share must read as unknown, not as zero stall caused"
     );
 }
+
+/// The property a permalink rests on: fixed bounds give the same answer later.
+///
+/// A relative window cannot promise this — it slides — so anything shareable
+/// has to resolve to absolute timestamps first. This is the test that would
+/// fail if `query_attributions_between` ever reintroduced `now`.
+#[tokio::test]
+async fn absolute_bounds_return_the_same_rows_however_much_later_they_are_asked() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = IncidentStore::new(dir.path().join("incidents.db"))
+        .await
+        .expect("fresh database should initialise");
+
+    let at = now_secs();
+    let mut old = attribution("image-resize-worker", 2.0, 600_000);
+    old.timestamp = at - 3_600; // an hour ago, outside any short window
+    store.insert_stall_attribution(&old).await.unwrap();
+
+    let bounds = (at as i64 - 3_660, at as i64 - 3_540);
+
+    let first = store
+        .query_attributions_between("payment-api", "prod", bounds.0, bounds.1)
+        .await
+        .unwrap();
+    assert_eq!(first.len(), 1, "the row should be inside the fixed bounds");
+
+    // A newer stall lands. The fixed window must not notice it, or a link
+    // shared during an incident would keep growing new evidence afterwards.
+    store
+        .insert_stall_attribution(&attribution("batch-etl", 1.0, 300_000))
+        .await
+        .unwrap();
+
+    let second = store
+        .query_attributions_between("payment-api", "prod", bounds.0, bounds.1)
+        .await
+        .unwrap();
+    assert_eq!(
+        second.len(),
+        1,
+        "a fixed window must not pick up rows written after it was cited"
+    );
+    assert_eq!(second[0].offender_pod, first[0].offender_pod);
+    assert_eq!(second[0].attributed_stall_us, first[0].attributed_stall_us);
+}
+
+/// One-second timestamp resolution means an exclusive upper bound silently
+/// drops whatever was recorded in the current second — the rows most likely to
+/// matter while an incident is live.
+#[tokio::test]
+async fn a_row_written_on_the_upper_bound_is_included() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = IncidentStore::new(dir.path().join("incidents.db"))
+        .await
+        .expect("fresh database should initialise");
+
+    let at = now_secs();
+    let mut row = attribution("image-resize-worker", 2.0, 600_000);
+    row.timestamp = at;
+    store.insert_stall_attribution(&row).await.unwrap();
+
+    let rows = store
+        .query_attributions_between("payment-api", "prod", at as i64 - 60, at as i64)
+        .await
+        .unwrap();
+
+    assert_eq!(
+        rows.len(),
+        1,
+        "the instant named as the end of the window is part of it"
+    );
+}

--- a/linnix-cli/src/investigate.rs
+++ b/linnix-cli/src/investigate.rs
@@ -41,6 +41,10 @@ pub struct Attribution {
 #[derive(Deserialize, Debug)]
 pub struct AttributionResponse {
     pub attributions: Vec<Attribution>,
+    /// Query string that returns exactly these rows whenever it is opened.
+    /// `None` against a daemon older than this field, which is why the report
+    /// omits the line rather than printing a link that would 404.
+    pub permalink: Option<String>,
 }
 
 /// An offender's aggregated contribution across every window in the query.
@@ -235,6 +239,7 @@ pub fn render(
     pod: &str,
     since: &str,
     color: bool,
+    permalink: Option<&str>,
 ) -> String {
     let mut out = String::new();
     let heading = |s: &str| {
@@ -260,6 +265,10 @@ pub fn render(
              the node as the cause. Look at the pod's own limits, throttling and \
              workload next.\n",
         );
+        // "Nothing was attributed here" is a finding worth citing too — it is
+        // what rules the neighbours out, and it stops being reproducible the
+        // moment the window slides.
+        push_permalink(&mut out, &heading, permalink);
         return out;
     }
 
@@ -369,7 +378,20 @@ pub fn render(
          the victim's stall falls.\n",
     );
 
+    push_permalink(&mut out, &heading, permalink);
+
     out
+}
+
+/// Appends the shareable link, if the daemon supplied one.
+///
+/// Printed as the fixed window it resolved to rather than the `--since` the
+/// user typed: pasting "the last 20 minutes" into a ticket describes a
+/// different 20 minutes to everyone who opens it afterwards.
+fn push_permalink(out: &mut String, heading: &dyn Fn(&str) -> String, permalink: Option<&str>) {
+    if let Some(link) = permalink {
+        out.push_str(&format!("\n{} {}\n", heading("Evidence link:"), link));
+    }
 }
 
 pub async fn run_investigate(
@@ -408,7 +430,25 @@ pub async fn run_investigate(
 
     let body: AttributionResponse = resp.json().await?;
     let investigation = summarise(&body.attributions);
-    print!("{}", render(&investigation, namespace, pod, since, color));
+
+    // The daemon returns a path; a link is only pasteable with the host the
+    // caller actually reached, which is the one thing the daemon cannot know.
+    let permalink = body
+        .permalink
+        .as_ref()
+        .map(|path| format!("{}{}", base.trim_end_matches('/'), path));
+
+    print!(
+        "{}",
+        render(
+            &investigation,
+            namespace,
+            pod,
+            since,
+            color,
+            permalink.as_deref()
+        )
+    );
     Ok(())
 }
 
@@ -526,7 +566,7 @@ mod tests {
         assert_eq!(legacy.share, None);
         assert_eq!(legacy.unsplit_rows, 1);
 
-        let report = render(&out, "payments", "api", "20m", false);
+        let report = render(&out, "payments", "api", "20m", false, None);
         let legacy_line = report
             .lines()
             .find(|l| l.contains("media/legacy"))
@@ -540,7 +580,7 @@ mod tests {
     fn no_offenders_reports_absence_rather_than_accusing() {
         let out = summarise(&[]);
         assert!(out.offenders.is_empty());
-        let report = render(&out, "payments", "api", "20m", false);
+        let report = render(&out, "payments", "api", "20m", false, None);
         assert!(report.contains("No contention attributed"));
         assert!(!report.contains("Likely offender"));
     }
@@ -551,7 +591,7 @@ mod tests {
             attr("resizer", 100, Some(700_000), 1_000_000),
             attr("etl", 100, Some(300_000), 1_000_000),
         ];
-        let report = render(&summarise(&rows), "payments", "api", "20m", false);
+        let report = render(&summarise(&rows), "payments", "api", "20m", false, None);
         assert!(report.contains("media/resizer"));
         assert!(report.contains("70% of attributed stall"));
         assert!(report.contains("high CPU contention"));
@@ -566,7 +606,7 @@ mod tests {
         // the offender at 100% without naming the denominator would read as
         // "this pod caused the whole second".
         let rows = vec![attr("resizer", 100, Some(400_000), 1_000_000)];
-        let report = render(&summarise(&rows), "payments", "api", "20m", false);
+        let report = render(&summarise(&rows), "payments", "api", "20m", false, None);
         assert!(report.contains("lost 1.0s to stalls"));
         assert!(report.contains("400ms of that is attributed to neighbours"));
     }


### PR DESCRIPTION
Roadmap **B3, in part** — with the part that isn't possible yet stated plainly below.

## The problem with the current link
`/attribution?pod=X&namespace=Y&window=20` answers "the last 20 minutes", which means something different every time it is asked. Paste it into a ticket and your colleague opens a different window; during a live incident it keeps accruing new evidence after the point under discussion. That isn't a permalink, whatever it looks like.

## Change
- `/attribution` accepts absolute `from`/`to` unix bounds. When both are given they replace `window` entirely.
- The relative window is resolved **once**, and the response returns the bounds actually used plus a `permalink` that reproduces exactly the rows just returned. Asking for "the last 15 minutes" now hands you back the fixed window that turned out to be — which is the thing you can cite.
- One-sided bounds are honoured rather than rejected: `from` alone reads as "since then", which is what someone pasting a start time means.
- `linnix investigate` prints it as `Evidence link:`, prefixed with the host the CLI actually reached (the daemon can't know that). Printed on the *no offender* path too — ruling the neighbours out is a finding worth citing, and it stops being reproducible the moment the window slides.

```
Investigation: payments/payment-api over the last 20m
...
Evidence link: http://127.0.0.1:3000/attribution?pod=payment-api&namespace=payments&from=1700000000&to=1700001200
```

## Two things found while building it
**Bounds must be inclusive at both ends.** Timestamps have one-second resolution, so an exclusive upper bound drops anything recorded in the current second — invisible in testing, wrong exactly when a stall is being written as it's read. Verified by mutation: switching to `<` fails the new boundary test *and* an existing test covering live `/attribution` behaviour, so this would have been a regression, not just a permalink bug.

**Names are percent-encoded into the link**, so a pod name can't inject query parameters into evidence someone else opens.

## What this deliberately does not do
**A link to a specific incident.** `stall_attributions` has no incident id, and `incidents` records no victim pod — only `target_pid`/`target_name`, a process rather than a workload. Nothing joins a stored incident to the attributions that explain it, so per-incident permalinks need that column first. I built the version the schema can actually back rather than embedding a relative window in a URL and calling it permanent.

That missing join is the same prerequisite roadmap A3 needs for `facts_from_attribution()`, so it's worth doing once, deliberately.

## Tests
177 pass. New: four on bounds resolution and link encoding, two on the store — one asserting a fixed window returns identical rows *after* newer attributions land, one on the upper-bound instant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EFtVtx4BiEYyKPwkdxqHgJ