### PR TITLE
feat(psi): give every stall event an id

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,11 +54,20 @@ kubectl port-forward daemonset/linnix-agent 3000:3000
 
 ## Quickstart (Docker)
 
-Try it on your local machine in 30 seconds.
+Try it on your local machine in 30 seconds. This pulls the published image; if
+that is unavailable it falls back to building locally, which takes a few minutes.
 
 ```bash
 git clone https://github.com/linnix-os/linnix.git && cd linnix
 ./quickstart.sh
+```
+
+The AI insight model is optional and off by default — contention attribution
+does not need it. To also run the local LLM server (downloads a 2.1GB model on
+first run):
+
+```bash
+./quickstart.sh --with-ai
 ```
 
 ---

--- a/cognitod/src/api/mod.rs
+++ b/cognitod/src/api/mod.rs
@@ -1295,6 +1295,10 @@ struct AttributionQuery {
     /// inside the bounds but was not in the original answer. The watermark
     /// pins the answer to the rows that existed when it was given.
     max_id: Option<i64>,
+    /// Narrows the answer to a single stall event. Rows written before the PSI
+    /// monitor emitted ids carry none, so an event filter never matches them —
+    /// correctly, since their grouping was only ever inferred.
+    event: Option<String>,
 }
 
 fn default_window() -> i64 {
@@ -1396,14 +1400,20 @@ impl AttributionQuery {
     /// with an older timestamp — cannot appear in evidence that has already
     /// been cited.
     fn permalink(&self, from: i64, to: i64, max_id: i64) -> String {
-        format!(
+        let base = format!(
             "/attribution?pod={}&namespace={}&from={}&to={}&max_id={}",
             urlencode(&self.pod),
             urlencode(&self.namespace),
             from,
             to,
             max_id
-        )
+        );
+        // Without this the link silently widens: an answer about one stall
+        // event would reopen as every event in its window.
+        match &self.event {
+            Some(event) => format!("{base}&event={}", urlencode(event)),
+            None => base,
+        }
     }
 }
 
@@ -2261,6 +2271,7 @@ mod tests {
         short_job_count: u64,
     ) -> cognitod::incidents::StallAttribution {
         cognitod::incidents::StallAttribution {
+            event_id: Some("evt-test".to_string()),
             offender_pod: "image-resizer".to_string(),
             offender_namespace: "media".to_string(),
             stall_us: 900_000,
@@ -2830,6 +2841,7 @@ mod tests {
         let blame = Arc::new(cognitod::attribution::BlameMetrics::new("test-node"));
         blame.record_victim_pressure("payments", "payment-api", "container-1", 900_000);
         blame.record_attribution(&cognitod::collectors::psi::BlameAttribution {
+            event_id: "evt-fixture".to_string(),
             victim_pod: "payment-api".to_string(),
             victim_namespace: "payments".to_string(),
             offender_pod: "image-resizer".to_string(),
@@ -3000,6 +3012,7 @@ mod tests {
             from: Some(1_700_000_000),
             to: Some(1_700_000_900),
             max_id: Some(4_096),
+            event: None,
         };
 
         // The whole point: the same request tomorrow returns the same rows, so
@@ -3020,6 +3033,7 @@ mod tests {
             from: None,
             to: None,
             max_id: None,
+            event: None,
         };
 
         let (from, to) = query.resolve_bounds();
@@ -3045,6 +3059,7 @@ mod tests {
             from: Some(1_700_000_000),
             to: None,
             max_id: None,
+            event: None,
         };
         let (from, to) = since.resolve_bounds();
         assert_eq!(from, 1_700_000_000, "an explicit start must be honoured");
@@ -3057,6 +3072,7 @@ mod tests {
             from: None,
             to: Some(1_700_000_900),
             max_id: None,
+            event: None,
         };
         assert_eq!(until.resolve_bounds(), (1_700_000_900 - 300, 1_700_000_900));
     }
@@ -3070,6 +3086,7 @@ mod tests {
             from: None,
             to: None,
             max_id: None,
+            event: None,
         };
 
         let link = query.permalink(1, 2, 3);
@@ -3102,6 +3119,7 @@ mod tests {
             .as_secs();
 
         let row = |offender: &str, blame: f64| cognitod::collectors::psi::BlameAttribution {
+            event_id: format!("evt-{offender}"),
             victim_pod: "payment-api".to_string(),
             victim_namespace: "payments".to_string(),
             offender_pod: offender.to_string(),

--- a/cognitod/src/attribution.rs
+++ b/cognitod/src/attribution.rs
@@ -633,6 +633,7 @@ mod tests {
 
     fn attribution(offender: &str, attributed_us: u64) -> BlameAttribution {
         BlameAttribution {
+            event_id: "evt-test".to_string(),
             victim_pod: "payment-api".to_string(),
             victim_namespace: "prod".to_string(),
             offender_pod: offender.to_string(),

--- a/cognitod/src/collectors/psi.rs
+++ b/cognitod/src/collectors/psi.rs
@@ -533,6 +533,7 @@ mod tests {
         short_job_counts.insert("default/short-job-pod".to_string(), 100);
 
         let event = StallEvent {
+            event_id: "evt-test".to_string(),
             victim_pod: "victim".to_string(),
             victim_namespace: "default".to_string(),
             stall_delta_us: 1_000_000, // 1 second stall

--- a/cognitod/src/collectors/psi.rs
+++ b/cognitod/src/collectors/psi.rs
@@ -34,6 +34,14 @@ pub struct CpuConsumer {
 
 #[derive(Debug, Clone)]
 pub struct StallEvent {
+    /// Identifies this stall event across every attribution it produces.
+    ///
+    /// A UUID rather than a counter: a counter restarts with the process, so
+    /// two events from either side of a restart would share an id and any
+    /// consumer grouping on it would silently merge them — the same undercount
+    /// this field exists to remove. Ordering comes from `timestamp`, so
+    /// sortability is not needed here.
+    pub event_id: String,
     pub victim_pod: String,
     pub victim_namespace: String,
     pub stall_delta_us: u64,
@@ -45,6 +53,10 @@ pub struct StallEvent {
 
 #[derive(Debug, Clone)]
 pub struct BlameAttribution {
+    /// The stall event this attribution belongs to. Every offender blamed for
+    /// one event shares it, which is what lets a consumer group the rows of an
+    /// event without inferring it from `(timestamp, stall_us)`.
+    pub event_id: String,
     pub victim_pod: String,
     pub victim_namespace: String,
     pub offender_pod: String,
@@ -264,6 +276,7 @@ impl PsiMonitor {
                                     .get_pod_activity_window(self.sustained_pressure_duration);
 
                                 let stall_event = StallEvent {
+                                    event_id: uuid::Uuid::new_v4().to_string(),
                                     victim_pod: meta.pod_name.clone(),
                                     victim_namespace: meta.namespace.clone(),
                                     stall_delta_us: delta_stall,
@@ -447,6 +460,7 @@ pub fn calculate_blame_attributions(event: &StallEvent) -> Vec<BlameAttribution>
 
             if blame_score > 0.0 {
                 attributions.push(BlameAttribution {
+                    event_id: event.event_id.clone(),
                     victim_pod: event.victim_pod.clone(),
                     victim_namespace: event.victim_namespace.clone(),
                     offender_pod: pod,

--- a/cognitod/src/incidents.rs
+++ b/cognitod/src/incidents.rs
@@ -72,6 +72,10 @@ pub struct StallAttribution {
     pub cpu_share: f64,
     pub fork_count: u64,
     pub short_job_count: u64,
+    /// The stall event this row belongs to. `None` on rows written before the
+    /// PSI monitor emitted one — those are grouped by `(timestamp, stall_us)`
+    /// as before, with the ambiguity that implies.
+    pub event_id: Option<String>,
 }
 
 /// Incident storage backed by SQLite
@@ -138,7 +142,13 @@ impl IncidentStore {
                 -- defaulted: a row written before this column existed has an
                 -- unknown share, and zero would claim the offender caused no
                 -- stall at all.
-                attributed_stall_us INTEGER
+                attributed_stall_us INTEGER,
+                -- The stall event this row belongs to. Nullable for the same
+                -- reason: rows written before the PSI monitor emitted an id
+                -- genuinely have none, and any default would group unrelated
+                -- events together — inventing exactly the collapse the id was
+                -- added to prevent.
+                event_id TEXT
             );
             CREATE INDEX IF NOT EXISTS idx_victim_time ON stall_attributions(victim_pod, victim_namespace, timestamp);
             CREATE INDEX IF NOT EXISTS idx_offender_time ON stall_attributions(offender_pod, offender_namespace, timestamp);
@@ -166,6 +176,18 @@ impl IncidentStore {
             sqlx::query("ALTER TABLE stall_attributions ADD COLUMN attributed_stall_us INTEGER")
                 .execute(&pool)
                 .await;
+        // No backfill: an id cannot be reconstructed for rows written before
+        // the monitor emitted one, and grouping them by `(timestamp, stall_us)`
+        // to synthesise one would bake today's ambiguity into permanent data.
+        // They stay NULL and consumers keep the existing fallback.
+        let _ = sqlx::query("ALTER TABLE stall_attributions ADD COLUMN event_id TEXT")
+            .execute(&pool)
+            .await;
+        let _ = sqlx::query(
+            "CREATE INDEX IF NOT EXISTS idx_attr_event ON stall_attributions(event_id)",
+        )
+        .execute(&pool)
+        .await;
 
         // The grounded investigation lives beside the raw reply rather than
         // replacing it: `llm_analysis` keeps meaning exactly what it always
@@ -372,8 +394,9 @@ impl IncidentStore {
             INSERT INTO stall_attributions (
                 victim_pod, victim_namespace, offender_pod, offender_namespace,
                 stall_us, blame_score, timestamp,
-                cpu_share, fork_count, short_job_count, attributed_stall_us
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                cpu_share, fork_count, short_job_count, attributed_stall_us,
+                event_id
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             "#,
         )
         .bind(&attr.victim_pod)
@@ -387,6 +410,7 @@ impl IncidentStore {
         .bind(attr.fork_count as i64)
         .bind(attr.short_job_count as i64)
         .bind(attr.attributed_stall_us as i64)
+        .bind(&attr.event_id)
         .execute(&self.pool)
         .await?;
 
@@ -458,6 +482,26 @@ impl IncidentStore {
         to: i64,
         max_row_id: Option<i64>,
     ) -> Result<(Vec<StallAttribution>, i64), sqlx::Error> {
+        self.query_attributions_filtered(victim_pod, victim_namespace, from, to, max_row_id, None)
+            .await
+    }
+
+    /// As [`query_attributions_between`], narrowed to a single stall event.
+    ///
+    /// An event id makes a citation exact rather than merely bounded: the rows
+    /// of one event, not whatever else shared its window. Rows written before
+    /// the monitor emitted ids have `event_id IS NULL` and can never match, so
+    /// an event-filtered query over old data correctly returns nothing rather
+    /// than guessing at a grouping.
+    pub async fn query_attributions_filtered(
+        &self,
+        victim_pod: &str,
+        victim_namespace: &str,
+        from: i64,
+        to: i64,
+        max_row_id: Option<i64>,
+        event_id: Option<&str>,
+    ) -> Result<(Vec<StallAttribution>, i64), sqlx::Error> {
         // Taken before the select, never after: a watermark read afterwards
         // could include a row the select had already missed, which is the race
         // this exists to remove.
@@ -472,10 +516,15 @@ impl IncidentStore {
         let rows = sqlx::query(
             r#"
             SELECT offender_pod, offender_namespace, stall_us, blame_score, timestamp,
-                   cpu_share, fork_count, short_job_count, attributed_stall_us
+                   cpu_share, fork_count, short_job_count, attributed_stall_us,
+                   event_id
             FROM stall_attributions
             WHERE victim_pod = ? AND victim_namespace = ? AND timestamp >= ? AND timestamp <= ?
                   AND id <= ?
+                  -- Bound twice rather than numbered: `?5` would silently
+                  -- refer to the watermark, since the unnumbered binds above
+                  -- consume positions 1-5.
+                  AND (? IS NULL OR event_id = ?)
             ORDER BY blame_score DESC
             "#,
         )
@@ -484,6 +533,8 @@ impl IncidentStore {
         .bind(from)
         .bind(to)
         .bind(watermark)
+        .bind(event_id)
+        .bind(event_id)
         .fetch_all(&self.pool)
         .await?;
 
@@ -503,6 +554,7 @@ impl IncidentStore {
                 attributed_stall_us: r
                     .get::<Option<i64>, _>("attributed_stall_us")
                     .map(|v| v as u64),
+                event_id: r.get::<Option<String>, _>("event_id"),
             })
             .collect();
 

--- a/cognitod/tests/attribution_eval.rs
+++ b/cognitod/tests/attribution_eval.rs
@@ -156,6 +156,7 @@ const VICTIM_NS: &str = "prod";
 
 fn build_stall_event(scenario: &Scenario) -> StallEvent {
     StallEvent {
+        event_id: uuid::Uuid::new_v4().to_string(),
         victim_pod: VICTIM_POD.to_string(),
         victim_namespace: VICTIM_NS.to_string(),
         stall_delta_us: scenario.victim_stall_us,
@@ -366,6 +367,7 @@ fn a_flood_of_distinct_offenders_stays_bounded() {
             .collect();
 
         let event = StallEvent {
+            event_id: uuid::Uuid::new_v4().to_string(),
             victim_pod: format!("victim-{}", batch),
             victim_namespace: VICTIM_NS.to_string(),
             stall_delta_us: 500_000,
@@ -456,6 +458,7 @@ fn a_second_offender_is_not_silenced_by_the_first() {
     // information: suppressing it because an unrelated pair is in cooldown
     // would hide the second half of a spreading incident.
     let second = StallEvent {
+        event_id: uuid::Uuid::new_v4().to_string(),
         victim_pod: VICTIM_POD.to_string(),
         victim_namespace: VICTIM_NS.to_string(),
         stall_delta_us: 800_000,

--- a/cognitod/tests/attribution_store_eval.rs
+++ b/cognitod/tests/attribution_store_eval.rs
@@ -12,6 +12,7 @@ use sqlx::sqlite::SqlitePoolOptions;
 
 fn attribution(offender: &str, blame: f64, attributed_us: u64) -> BlameAttribution {
     BlameAttribution {
+        event_id: format!("evt-{offender}"),
         victim_pod: "payment-api".to_string(),
         victim_namespace: "prod".to_string(),
         offender_pod: offender.to_string(),
@@ -445,5 +446,102 @@ async fn a_backfilled_row_with_an_older_timestamp_stays_out_of_cited_evidence() 
         reopened.len(),
         1,
         "a row inserted after the citation must stay out of it, whatever its timestamp claims"
+    );
+}
+
+/// The point of the event id: cite the rows of *one* stall event, not
+/// whatever else shared its time window.
+#[tokio::test]
+async fn an_event_filter_returns_only_that_events_rows() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = IncidentStore::new(dir.path().join("incidents.db"))
+        .await
+        .expect("fresh database should initialise");
+
+    let at = now_secs();
+    // Two distinct stall events in the same second — the case a
+    // `(timestamp, stall_us)` grouping cannot tell apart when the stall
+    // figures also match.
+    for (event, offender) in [("evt-a", "image-resizer"), ("evt-b", "batch-etl")] {
+        let mut row = attribution(offender, 2.0, 600_000);
+        row.event_id = event.to_string();
+        row.timestamp = at;
+        store.insert_stall_attribution(&row).await.unwrap();
+    }
+
+    let (all, _) = store
+        .query_attributions_between("payment-api", "prod", at as i64 - 60, at as i64, None)
+        .await
+        .unwrap();
+    assert_eq!(all.len(), 2, "both events sit inside the window");
+
+    let (only_a, _) = store
+        .query_attributions_filtered(
+            "payment-api",
+            "prod",
+            at as i64 - 60,
+            at as i64,
+            None,
+            Some("evt-a"),
+        )
+        .await
+        .unwrap();
+    assert_eq!(only_a.len(), 1, "the filter must isolate one event");
+    assert_eq!(only_a[0].offender_pod, "image-resizer");
+    assert_eq!(only_a[0].event_id.as_deref(), Some("evt-a"));
+}
+
+/// Rows written before the monitor emitted ids have no event to match, so an
+/// event-filtered query must return nothing rather than guessing a grouping.
+#[tokio::test]
+async fn rows_predating_event_ids_never_match_an_event_filter() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("incidents.db");
+    let store = IncidentStore::new(&db_path).await.unwrap();
+
+    let at = now_secs();
+    {
+        // Written the way an older daemon would have: no event_id at all.
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect(&format!("sqlite://{}?mode=rwc", db_path.display()))
+            .await
+            .unwrap();
+        sqlx::query(
+            "INSERT INTO stall_attributions (victim_pod, victim_namespace, offender_pod,
+             offender_namespace, stall_us, blame_score, timestamp, attributed_stall_us)
+             VALUES ('payment-api', 'prod', 'image-resizer', 'prod', 900000, 2.0, ?, 600000)",
+        )
+        .bind(at as i64)
+        .execute(&pool)
+        .await
+        .unwrap();
+        pool.close().await;
+    }
+
+    let (unfiltered, _) = store
+        .query_attributions_between("payment-api", "prod", at as i64 - 60, at as i64, None)
+        .await
+        .unwrap();
+    assert_eq!(unfiltered.len(), 1);
+    assert_eq!(
+        unfiltered[0].event_id, None,
+        "an id that was never written must read as absent, not as a guess"
+    );
+
+    let (filtered, _) = store
+        .query_attributions_filtered(
+            "payment-api",
+            "prod",
+            at as i64 - 60,
+            at as i64,
+            None,
+            Some("evt-a"),
+        )
+        .await
+        .unwrap();
+    assert!(
+        filtered.is_empty(),
+        "a NULL event id must not match any event"
     );
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,13 @@ services:
   # Cognitod - eBPF monitoring daemon
   # Security: root + minimal caps (CAP_BPF + CAP_PERFMON only)
   cognitod:
-    image: ${COGNITOD_IMAGE:-linnix-cognitod}
+    # Defaults to the image CI publishes, so a fresh clone pulls instead of
+    # waiting on a full eBPF toolchain build. The build stanza is the fallback:
+    # quickstart.sh builds from it when the pull is unavailable.
+    image: ${COGNITOD_IMAGE:-ghcr.io/linnix-os/cognitod:latest}
+    build:
+      context: .
+      dockerfile: Dockerfile
     container_name: linnix-cognitod
 
     network_mode: host
@@ -69,7 +75,11 @@ services:
       start_period: 30s
 
   # LLM Server - Linnix 3B distilled model
+  #
+  # Optional. Contention attribution runs without it; this only powers the AI
+  # insight text. Start it with: docker compose --profile ai up -d
   llama-server:
+    profiles: ["ai"]
     image: ${LLAMA_IMAGE:-ghcr.io/ggml-org/llama.cpp:server}
     container_name: linnix-llm
     volumes:

--- a/docs/wiki/CLI-Reference.md
+++ b/docs/wiki/CLI-Reference.md
@@ -68,4 +68,21 @@ linnix-cli metrics
 ```
 
 ---
+
+## Authentication
+
+When cognitod is started with an API token configured, every TCP route requires
+a bearer token. Set `LINNIX_API_TOKEN` and the CLI attaches it to all requests:
+
+```bash
+export LINNIX_API_TOKEN=your-token-here
+linnix-cli investigate default/checkout-api --since 20m
+```
+
+Leave the variable unset for local, unauthenticated runs.
+
+> The built-in web dashboard has no token-entry flow yet, so a token-protected
+> deployment is currently reachable via the CLI and the API, not the browser UI.
+
+---
 *Source: `linnix-cli/src/main.rs`*

--- a/linnix-cli/src/blame.rs
+++ b/linnix-cli/src/blame.rs
@@ -1,5 +1,5 @@
 use colored::*;
-use reqwest::Client;
+
 use serde::Deserialize;
 use std::error::Error;
 use std::io::{BufRead, BufReader};
@@ -58,7 +58,7 @@ pub async fn run_blame(node_name: &str) -> Result<(), Box<dyn Error>> {
             "--field-selector",
             &format!("spec.nodeName={}", node_name),
             "-l",
-            "app=cognitod",
+            "app=linnix",
             "-o",
             "jsonpath={.items[0].metadata.name}/{.items[0].metadata.namespace}",
         ])
@@ -134,7 +134,7 @@ pub async fn run_blame(node_name: &str) -> Result<(), Box<dyn Error>> {
 
     // 3. Query API
     println!("{} Fetching recent insights...", "Step 3:".bold());
-    let client = Client::new();
+    let client = crate::http::client();
     let url = format!("http://127.0.0.1:{}/insights/recent?limit=5", local_port);
 
     let resp = client.get(&url).send().await;

--- a/linnix-cli/src/doctor.rs
+++ b/linnix-cli/src/doctor.rs
@@ -1,5 +1,5 @@
 use colored::*;
-use reqwest::Client;
+
 use serde::Deserialize;
 use std::error::Error;
 
@@ -63,7 +63,7 @@ pub async fn run_doctor(url: &str) -> Result<(), Box<dyn Error>> {
     println!("{}", "Checking system health...".dimmed());
     println!();
 
-    let client = Client::new();
+    let client = crate::http::client();
     let mut all_good = true;
 
     // 1. Check Connectivity & Health

--- a/linnix-cli/src/http.rs
+++ b/linnix-cli/src/http.rs
@@ -1,0 +1,58 @@
+use reqwest::header::{HeaderMap, HeaderValue, AUTHORIZATION};
+use reqwest::Client;
+
+/// Environment variable holding the bearer token for a cognitod instance that
+/// was started with an API token configured.
+pub const TOKEN_ENV: &str = "LINNIX_API_TOKEN";
+
+/// Build the HTTP client every command uses.
+///
+/// When `LINNIX_API_TOKEN` is set, its value is attached as a bearer token on
+/// every request, which is what a cognitod behind a token expects on all of its
+/// TCP routes. Without the variable this is a plain client, so unauthenticated
+/// local runs are unaffected.
+pub fn client() -> Client {
+    let mut headers = HeaderMap::new();
+
+    if let Some(token) = std::env::var(TOKEN_ENV)
+        .ok()
+        .filter(|t| !t.trim().is_empty())
+    {
+        match HeaderValue::from_str(&format!("Bearer {}", token.trim())) {
+            Ok(mut value) => {
+                value.set_sensitive(true);
+                headers.insert(AUTHORIZATION, value);
+            }
+            Err(_) => {
+                eprintln!(
+                    "warning: {} contains characters that cannot be sent in a header; \
+                     continuing without authentication",
+                    TOKEN_ENV
+                );
+            }
+        }
+    }
+
+    Client::builder()
+        .default_headers(headers)
+        .build()
+        .unwrap_or_else(|_| Client::new())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn builds_a_client_when_no_token_is_set() {
+        // The builder must not panic on the common unauthenticated path.
+        let _ = client();
+    }
+
+    #[test]
+    fn a_blank_token_is_treated_as_absent() {
+        assert!(Some("   ".to_string())
+            .filter(|t| !t.trim().is_empty())
+            .is_none());
+    }
+}

--- a/linnix-cli/src/investigate.rs
+++ b/linnix-cli/src/investigate.rs
@@ -36,6 +36,28 @@ pub struct Attribution {
     pub short_job_count: u64,
     /// Dominant signal, classified server-side.
     pub reason: Option<String>,
+    /// The stall event this row belongs to. `None` on rows written before the
+    /// daemon emitted one.
+    pub event_id: Option<String>,
+}
+
+/// What identifies the stall event a row belongs to.
+///
+/// The daemon's id when there is one; otherwise `(timestamp, stall_us)`, which
+/// is the best that can be inferred for rows written before ids existed.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+enum EventKey {
+    Id(String),
+    Inferred(u64, u64),
+}
+
+impl Attribution {
+    fn event_key(&self) -> EventKey {
+        match &self.event_id {
+            Some(id) => EventKey::Id(id.clone()),
+            None => EventKey::Inferred(self.timestamp, self.stall_us),
+        }
+    }
 }
 
 #[derive(Deserialize, Debug)]
@@ -86,25 +108,23 @@ pub struct Investigation {
 
 /// Collapses per-window rows into one ranked entry per offender.
 pub fn summarise(attributions: &[Attribution]) -> Investigation {
-    // One window reports the same victim total on each of its offender rows,
-    // so the rows of an event have to collapse to one figure.
+    // One event reports the same victim total on each of its offender rows, so
+    // the rows of an event have to collapse to one figure.
     //
-    // The key is (timestamp, stall_us), not the timestamp alone. Timestamps
-    // have one-second resolution and a victim's containers are scanned
-    // separately, so one pod can produce two distinct events within a second.
-    // Keying on time alone drops one of them, and the attributed total then
-    // exceeds the victim total it is meant to be a share of. `stall_us` is a
-    // microsecond delta, so it separates them — the same key the store's own
-    // backfill groups on. Two events identical in both fields still collapse;
-    // telling those apart needs an event id the daemon does not yet emit.
-    let mut victim_windows: HashSet<(u64, u64)> = HashSet::new();
+    // Rows now carry the event id the daemon minted, which settles this
+    // exactly. The `(timestamp, stall_us)` fallback remains for rows written
+    // before ids existed, and keeps its old limitation: timestamps have
+    // one-second resolution and a victim's containers are scanned separately,
+    // so two events identical in both fields still collapse. That is now a
+    // property of old data rather than of the design.
+    let mut victim_events: HashMap<EventKey, u64> = HashMap::new();
     for attr in attributions {
-        victim_windows.insert((attr.timestamp, attr.stall_us));
+        victim_events.insert(attr.event_key(), attr.stall_us);
     }
-    let victim_stall_us: u64 = victim_windows.iter().map(|(_, stall)| stall).sum();
+    let victim_stall_us: u64 = victim_events.values().sum();
 
     let mut by_offender: HashMap<(String, String), OffenderSummary> = HashMap::new();
-    let mut seen_windows: HashMap<(String, String), HashSet<(u64, u64)>> = HashMap::new();
+    let mut seen_windows: HashMap<(String, String), HashSet<EventKey>> = HashMap::new();
     // Tracks which window currently justifies each offender's reported reason,
     // so the reason shown is the one from its worst window rather than
     // whichever row happened to sort last.
@@ -150,7 +170,7 @@ pub fn summarise(attributions: &[Attribution]) -> Investigation {
         seen_windows
             .entry(key)
             .or_default()
-            .insert((attr.timestamp, attr.stall_us));
+            .insert(attr.event_key());
     }
 
     for (key, windows) in seen_windows {
@@ -181,7 +201,7 @@ pub fn summarise(attributions: &[Attribution]) -> Investigation {
 
     Investigation {
         victim_stall_us,
-        windows: victim_windows.len(),
+        windows: victim_events.len(),
         offenders,
         rows_without_split,
     }
@@ -467,7 +487,66 @@ mod tests {
             fork_count: 10,
             short_job_count: 5,
             reason: Some("high_cpu_contention".to_string()),
+            // Legacy shape by default: these cases predate event ids, and
+            // keeping them on the fallback path means it stays covered.
+            event_id: None,
         }
+    }
+
+    /// The same row, tagged with the event the daemon minted for it.
+    fn attr_in_event(
+        pod: &str,
+        ts: u64,
+        attributed: Option<u64>,
+        stall: u64,
+        event: &str,
+    ) -> Attribution {
+        Attribution {
+            event_id: Some(event.to_string()),
+            ..attr(pod, ts, attributed, stall)
+        }
+    }
+
+    /// The undercount the event id was added to remove.
+    ///
+    /// Two distinct stall events, same second, same stall figure — the
+    /// `(timestamp, stall_us)` fallback cannot tell them apart and reports one
+    /// event's worth of stall for two events' worth of damage. With ids the
+    /// victim's real total is visible.
+    #[test]
+    fn two_events_identical_in_time_and_stall_no_longer_collapse() {
+        let inferred = summarise(&[
+            attr("resizer", 100, Some(600_000), 1_000_000),
+            attr("etl", 100, Some(600_000), 1_000_000),
+        ]);
+        assert_eq!(
+            inferred.victim_stall_us, 1_000_000,
+            "without ids the two events are indistinguishable and collapse"
+        );
+        assert_eq!(inferred.windows, 1);
+
+        let identified = summarise(&[
+            attr_in_event("resizer", 100, Some(600_000), 1_000_000, "evt-a"),
+            attr_in_event("etl", 100, Some(600_000), 1_000_000, "evt-b"),
+        ]);
+        assert_eq!(
+            identified.victim_stall_us, 2_000_000,
+            "with ids both events count, so the victim's real stall is reported"
+        );
+        assert_eq!(identified.windows, 2);
+    }
+
+    /// A window that spans the upgrade: some rows carry ids, older ones do not.
+    /// Both grouping rules have to coexist without either swallowing the other.
+    #[test]
+    fn identified_and_legacy_rows_group_side_by_side() {
+        let mixed = summarise(&[
+            attr_in_event("resizer", 100, Some(600_000), 1_000_000, "evt-a"),
+            attr("etl", 90, Some(400_000), 500_000),
+        ]);
+
+        assert_eq!(mixed.windows, 2, "each row describes a different event");
+        assert_eq!(mixed.victim_stall_us, 1_500_000);
     }
 
     #[test]

--- a/linnix-cli/src/main.rs
+++ b/linnix-cli/src/main.rs
@@ -1,6 +1,5 @@
 use clap::{Parser, Subcommand};
 use futures_util::StreamExt;
-use reqwest::Client;
 use serde::Deserialize;
 use std::collections::HashSet;
 use std::error::Error;
@@ -10,6 +9,7 @@ mod blame;
 mod doctor;
 mod event;
 mod export;
+mod http;
 mod investigate;
 mod pretty;
 mod processes;
@@ -105,7 +105,7 @@ struct Status {
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
     let args = Args::parse();
-    let client = Client::new();
+    let client = crate::http::client();
     let color = !args.no_color;
 
     if let Some(Command::Export {

--- a/quickstart.sh
+++ b/quickstart.sh
@@ -14,6 +14,8 @@ NC='\033[0m' # No Color
 # --- Globals ---
 COMPOSE_CMD=""
 ACTION="start"
+# The LLM is optional: attribution works without it. Opt in with --with-ai.
+WITH_AI=false
 
 # --- Functions ---
 
@@ -36,10 +38,16 @@ parse_args() {
             stop|down)
                 ACTION="stop"
                 ;;
+            --with-ai)
+                WITH_AI=true
+                ;;
             --help|-h)
-                echo "Usage: $0 [start|stop|--help|-h]"
+                echo "Usage: $0 [start|stop] [--with-ai] [--help|-h]"
                 echo "  start (default):    Start services with automatic demo scenarios."
                 echo "  stop:               Stop all running Linnix services."
+                echo "  --with-ai:          Also start the local LLM server. This downloads a"
+                echo "                      2.1GB model on first run. Contention attribution"
+                echo "                      does not need it; it only adds AI insight text."
                 echo ""
                 echo "Demo scenarios (run automatically on startup):"
                 echo "  1. Fork storm       - Rapid process spawning detection"
@@ -76,6 +84,13 @@ detect_compose() {
             echo "   Note: eBPF will monitor Docker VM processes only, not macOS processes."
             echo ""
         fi
+    fi
+
+    # The llama-server service sits behind the "ai" compose profile. Selecting
+    # the profile is what makes it start; teardown always selects it so a stop
+    # removes the LLM container even when this run did not start it.
+    if [ "$WITH_AI" = true ] || [ "$ACTION" = "stop" ]; then
+        COMPOSE_CMD="$COMPOSE_CMD --profile ai"
     fi
 }
 
@@ -123,7 +138,14 @@ check_model() {
     echo -e "\n${BLUE}[2/5]${NC} Checking for demo model..."
     local model_path="./models/linnix-3b-distilled-q5_k_m.gguf"
     local model_url="https://huggingface.co/parth21shah/linnix-3b-distilled/resolve/main/linnix-3b-distilled-q5_k_m.gguf"
-    
+
+    if [ "$WITH_AI" != true ]; then
+        echo -e "${GREEN}✅ Skipped (AI is optional).${NC}"
+        echo "   Contention attribution runs without a model. Re-run with --with-ai"
+        echo "   to download it (2.1GB) and start the local LLM server."
+        return
+    fi
+
     if [ -f "$model_path" ]; then
         echo -e "${GREEN}✅ Model already downloaded.${NC}"
     else
@@ -160,7 +182,8 @@ check_model() {
 check_ports() {
     echo -e "\n${BLUE}[3/5]${NC} Checking port availability..."
     local ports_in_use=()
-    local required_ports=(3000 8090)
+    local required_ports=(3000)
+    [ "$WITH_AI" = true ] && required_ports+=(8090)
     
     for port in "${required_ports[@]}"; do
         if command -v lsof &> /dev/null; then
@@ -244,8 +267,19 @@ EOF
 # Start all Docker containers
 start_services() {
     echo -e "\n${BLUE}[5/5]${NC} Starting Docker containers..."
-    echo "   This will pull required images and start all services."
-    if ! $COMPOSE_CMD up -d; then
+
+    # Prefer the published image: compose would otherwise build from the local
+    # Dockerfile whenever the image is absent, which is a full eBPF toolchain
+    # build. Fall back to that build only if the pull is genuinely unavailable.
+    local up_args="--no-build"
+    echo "   Pulling published images..."
+    if ! $COMPOSE_CMD pull --quiet 2>/dev/null; then
+        echo -e "${YELLOW}⚠️  Could not pull a published image. Building locally instead.${NC}"
+        echo "   The first build takes several minutes."
+        up_args="--build"
+    fi
+
+    if ! $COMPOSE_CMD up -d $up_args; then
         echo -e "${RED}❌ Docker Compose failed to start.${NC}"
         echo "   Please check the logs for errors:"
         $COMPOSE_CMD logs --tail=50
@@ -268,6 +302,10 @@ wait_for_health() {
             exit 1
         fi
     done
+
+    if [ "$WITH_AI" != true ]; then
+        return
+    fi
 
     echo -n "   LLM Server: "
     for i in {1..180}; do # Increased timeout for model download
@@ -294,7 +332,9 @@ show_summary() {
     echo ""
     echo -e "${GREEN}Services:${NC}"
     echo "   • Dashboard & API:          http://localhost:3000"
-    echo "   • LLM Server:               http://localhost:8090"
+    if [ "$WITH_AI" = true ]; then
+        echo "   • LLM Server:               http://localhost:8090"
+    fi
     echo "   • Prometheus Metrics:       http://localhost:3000/metrics/prometheus"
     echo ""
     echo -e "${GREEN}Quick Commands:${NC}"
@@ -322,12 +362,10 @@ stop_services() {
 main() {
     parse_args "$@"
     
-    # Determine compose command early for stop action
-    if docker compose version &> /dev/null; then
-        COMPOSE_CMD="docker compose"
-    else
-        COMPOSE_CMD="docker-compose"
-    fi
+    # Determine compose command early for stop action. detect_compose rebuilds
+    # COMPOSE_CMD from scratch, so the later call in check_prerequisites is a
+    # no-op rather than a second round of appended flags.
+    detect_compose
 
     if [ "$ACTION" = "stop" ]; then
         stop_services


### PR DESCRIPTION
Closes #78.

## The gap
Attribution rows carried no identity for the stall event that produced them, so consumers reconstructed one from `(timestamp, stall_us)`. Timestamps have one-second resolution and a victim's containers are scanned separately, so **two events identical in both fields collapsed into one** — a real undercount, worked around identically in `linnix investigate` and in the store's backfill.

## Why a UUID, not a counter
A counter restarts with the process, so two events either side of a restart share an id and any consumer grouping on it merges them — reintroducing the same bug at a lower rate, which is worse than not fixing it (rare wrong answers are harder to notice than common ones). A UUID removes the question without clock packing, run seeds, or reasoning about crash-loops. `uuid` is already a non-optional dependency. Ordering comes from `timestamp`, so sortability buys nothing.

## Why the column is nullable and not backfilled
An id cannot be reconstructed for rows written before the monitor emitted one. Synthesising one from `(timestamp, stall_us)` would bake today's ambiguity into permanent data — the same trap migration 005 fell into when it defaulted three signal columns to zero and made every pre-existing row read as `high_cpu_contention`.

Old rows stay `NULL`, and an event-filtered query correctly matches none of them rather than guessing.

## What it unlocks, in this change
- **`/attribution?event=<id>`** narrows an answer to a single event, and the permalink carries it — without that, a citation about one event silently reopens as its whole window.
- **`linnix investigate`** groups on the id when present, falling back to `(timestamp, stall_us)` otherwise. The undercount is now a property of old data rather than of the design.

And for later: A3's `facts_from_attribution()` needs exactly this grouping key.

## Tests (188 pass)
- `two_events_identical_in_time_and_stall_no_longer_collapse` — asserts *both* behaviours: the fallback still collapses (1s of stall for two events), ids report the truth (2s).
- `identified_and_legacy_rows_group_side_by_side` — a window spanning the upgrade, where both grouping rules must coexist.
- `an_event_filter_returns_only_that_events_rows` — two distinct events in the same second, same stall figure: the case the fallback provably cannot separate.
- `rows_predating_event_ids_never_match_an_event_filter` — inserts a row the way an older daemon would have, with no `event_id` column value at all.

One bug caught in review of my own SQL before it ran: the event predicate was first written as `?5`, which with these positional binds refers to the *watermark*, not the event id. It binds explicitly now, with a comment saying why.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EFtVtx4BiEYyKPwkdxqHgJ