### PR TITLE
feat(incidents): measure whether the action actually worked

### DIFF
--- a/cognitod/src/enforcement.rs
+++ b/cognitod/src/enforcement.rs
@@ -40,14 +40,15 @@ pub struct EnforcementAction {
     pub status: ActionStatus,
     pub created_at: u64,
     pub expires_at: u64,
-    /// When the executor actually carried the action out.
+    /// When the executor actually carried the action out, in epoch
+    /// milliseconds.
     ///
     /// Recovery has to be timed from the kill, not from whenever the watcher
     /// got around to noticing it: the insert and the polling gap in between
     /// would otherwise be silently dropped, and pressure that had already
     /// fallen would be stored as a 0ms recovery.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub executed_at: Option<u64>,
+    pub executed_at_ms: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub approved_by: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -55,6 +56,8 @@ pub struct EnforcementAction {
 }
 
 pub struct EnforcementQueue {
+    /// Count of actions that have actually executed, for detecting overlap.
+    executions: AtomicU64,
     next_id: AtomicU64,
     actions: RwLock<HashMap<String, EnforcementAction>>,
     ttl_secs: u64,
@@ -63,6 +66,7 @@ pub struct EnforcementQueue {
 impl EnforcementQueue {
     pub fn new(ttl_secs: u64) -> Self {
         Self {
+            executions: AtomicU64::new(0),
             next_id: AtomicU64::new(1),
             actions: RwLock::new(HashMap::new()),
             ttl_secs,
@@ -133,7 +137,7 @@ impl EnforcementQueue {
             status,
             created_at: now,
             expires_at: now + self.ttl_secs,
-            executed_at: None,
+            executed_at_ms: None,
             approved_by: approved_by.clone(),
             approved_at,
         };
@@ -205,7 +209,12 @@ impl EnforcementQueue {
         }
 
         action.status = ActionStatus::Executed;
-        action.executed_at = Some(current_epoch_secs());
+        action.executed_at_ms = Some(current_epoch_millis());
+        // Every execution bumps this. A recovery watch samples system-wide
+        // pressure, so a *later* kill landing mid-watch invalidates the
+        // measurement in progress — the earlier action would otherwise be
+        // credited with a fall the second kill caused.
+        self.executions.fetch_add(1, Ordering::SeqCst);
         log::info!("[enforcement] completed {id}");
         Ok(())
     }
@@ -227,6 +236,12 @@ impl EnforcementQueue {
         action.status = ActionStatus::Failed;
         log::warn!("[enforcement] {id} failed: {why}");
         Ok(())
+    }
+
+    /// How many actions have executed so far. A change during a recovery
+    /// watch means another intervention overlapped it.
+    pub fn execution_count(&self) -> u64 {
+        self.executions.load(Ordering::SeqCst)
     }
 
     pub async fn get_pending(&self) -> Vec<EnforcementAction> {
@@ -253,6 +268,13 @@ impl EnforcementQueue {
     pub async fn get_all(&self) -> Vec<EnforcementAction> {
         self.actions.read().await.values().cloned().collect()
     }
+}
+
+fn current_epoch_millis() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
 }
 
 fn current_epoch_secs() -> u64 {

--- a/cognitod/src/enforcement.rs
+++ b/cognitod/src/enforcement.rs
@@ -40,6 +40,14 @@ pub struct EnforcementAction {
     pub status: ActionStatus,
     pub created_at: u64,
     pub expires_at: u64,
+    /// When the executor actually carried the action out.
+    ///
+    /// Recovery has to be timed from the kill, not from whenever the watcher
+    /// got around to noticing it: the insert and the polling gap in between
+    /// would otherwise be silently dropped, and pressure that had already
+    /// fallen would be stored as a 0ms recovery.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub executed_at: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub approved_by: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -125,6 +133,7 @@ impl EnforcementQueue {
             status,
             created_at: now,
             expires_at: now + self.ttl_secs,
+            executed_at: None,
             approved_by: approved_by.clone(),
             approved_at,
         };
@@ -196,6 +205,7 @@ impl EnforcementQueue {
         }
 
         action.status = ActionStatus::Executed;
+        action.executed_at = Some(current_epoch_secs());
         log::info!("[enforcement] completed {id}");
         Ok(())
     }

--- a/cognitod/src/enforcement.rs
+++ b/cognitod/src/enforcement.rs
@@ -20,6 +20,13 @@ pub enum ActionStatus {
     Rejected,
     Expired,
     Executed,
+    /// The executor tried and the syscall failed — the process was already
+    /// gone, or the signal was refused.
+    ///
+    /// Distinct from `Rejected`, which is an operator's decision, and terminal
+    /// so the executor does not retry: a pid that has exited can be reused,
+    /// and retrying would eventually kill an unrelated process.
+    Failed,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -194,6 +201,24 @@ impl EnforcementQueue {
     }
 
     #[allow(dead_code)]
+    /// Marks an action the executor could not carry out.
+    ///
+    /// Valid from `Approved`, which is the state an action is in while the
+    /// executor is working on it — `reject` is the operator's path and only
+    /// applies to pending proposals.
+    pub async fn fail(&self, id: &str, why: String) -> Result<(), String> {
+        let mut actions = self.actions.write().await;
+        let action = actions.get_mut(id).ok_or("action not found")?;
+
+        if action.status != ActionStatus::Approved {
+            return Err(format!("not approved: {:?}", action.status));
+        }
+
+        action.status = ActionStatus::Failed;
+        log::warn!("[enforcement] {id} failed: {why}");
+        Ok(())
+    }
+
     pub async fn get_pending(&self) -> Vec<EnforcementAction> {
         let now = current_epoch_secs();
         let mut actions = self.actions.write().await;

--- a/cognitod/src/incidents.rs
+++ b/cognitod/src/incidents.rs
@@ -5,6 +5,7 @@
 
 mod analyzer;
 pub mod investigation;
+pub mod outcome;
 
 pub use analyzer::{AnalysisOutcome, IncidentAnalyzer};
 pub use investigation::{Fact, IncidentInvestigation};
@@ -561,6 +562,30 @@ impl IncidentStore {
         Ok((rows, watermark))
     }
 
+    /// Records what happened after the action.
+    ///
+    /// Separate from `insert` because the outcome is not known when the
+    /// incident is written — that is the whole point of measuring it. Called
+    /// once per incident, after the recovery window closes.
+    pub async fn record_outcome(
+        &self,
+        id: i64,
+        outcome: &crate::incidents::outcome::RecoveryOutcome,
+    ) -> Result<(), sqlx::Error> {
+        sqlx::query("UPDATE incidents SET psi_after = ?, recovery_time_ms = ? WHERE id = ?")
+            .bind(outcome.psi_after)
+            .bind(outcome.recovery_time_ms)
+            .bind(id)
+            .execute(&self.pool)
+            .await?;
+
+        debug!(
+            "Recorded outcome for incident #{}: psi_after={:.1} recovery={:?}",
+            id, outcome.psi_after, outcome.recovery_time_ms
+        );
+        Ok(())
+    }
+
     /// Get incident by ID
     pub async fn get(&self, id: i64) -> Result<Option<Incident>, sqlx::Error> {
         let row = sqlx::query(
@@ -737,6 +762,13 @@ impl IncidentStore {
 pub struct IncidentStats {
     pub total: u64,
     pub circuit_breaker_triggers: u64,
+    /// Mean recovery time across incidents that *did* recover.
+    ///
+    /// Incidents watched but still stalling at the end of the window record no
+    /// recovery time, so they are absent here rather than counted as slow
+    /// recoveries. Read it as "when it worked, how fast", not "how well it
+    /// works" — `total` against the number with a recovery time is
+    /// the second half of that picture.
     pub avg_recovery_time_ms: Option<u64>,
     pub feedback_entries: u64,
 }

--- a/cognitod/src/incidents.rs
+++ b/cognitod/src/incidents.rs
@@ -580,7 +580,7 @@ impl IncidentStore {
             .await?;
 
         debug!(
-            "Recorded outcome for incident #{}: psi_after={:.1} recovery={:?}",
+            "Recorded outcome for incident #{}: psi_after={:?} recovery={:?}",
             id, outcome.psi_after, outcome.recovery_time_ms
         );
         Ok(())

--- a/cognitod/src/incidents/outcome.rs
+++ b/cognitod/src/incidents/outcome.rs
@@ -1,0 +1,188 @@
+//! Did the action work?
+//!
+//! An incident records that pressure was high and something was done about it.
+//! On its own that is a claim, not a result: the columns for the result —
+//! `psi_after` and `recovery_time_ms` — have existed since the first schema,
+//! are read back by `/incidents/{id}`, and are averaged into
+//! `avg_recovery_time_ms` on `/incidents/stats`, but nothing ever wrote them.
+//! That endpoint has been reporting an average over a column that is always
+//! NULL.
+//!
+//! Watching a victim's pressure after an action is what turns a blame
+//! heuristic into a verified attribution: the difference between "this pod was
+//! contending" and "removing it demonstrably reduced the stall".
+
+use std::time::Duration;
+
+use tokio::time::Instant;
+
+/// How long to watch, and what counts as recovered.
+#[derive(Debug, Clone, Copy)]
+pub struct RecoveryWatch {
+    /// How often to sample pressure.
+    pub poll_interval: Duration,
+    /// How long to keep watching before giving up on recovery.
+    pub max_wait: Duration,
+    /// Pressure at or below this is recovered.
+    ///
+    /// This is the same threshold that decided the incident was happening, not
+    /// a second number invented for the outcome. Recovery has to mean "the
+    /// condition we acted on is no longer true", or the two halves of the
+    /// record describe different things.
+    pub recovered_below: f32,
+}
+
+impl RecoveryWatch {
+    pub const DEFAULT_POLL: Duration = Duration::from_secs(1);
+    pub const DEFAULT_MAX_WAIT: Duration = Duration::from_secs(120);
+
+    pub fn with_threshold(recovered_below: f32) -> Self {
+        Self {
+            poll_interval: Self::DEFAULT_POLL,
+            max_wait: Self::DEFAULT_MAX_WAIT,
+            recovered_below,
+        }
+    }
+}
+
+/// What was actually observed after the action.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct RecoveryOutcome {
+    /// Pressure at the end of the observation, whatever happened. Always
+    /// recorded: "we watched and it stayed bad" is a result, and the most
+    /// important one to be able to see.
+    pub psi_after: f32,
+    /// Time until pressure fell below the threshold.
+    ///
+    /// `None` means it never did within `max_wait` — deliberately not the
+    /// window length, which would record a recovery that did not happen. A row
+    /// with `psi_after` set and this `None` says "observed, did not recover",
+    /// which is a different statement from a row where both are `None` and
+    /// nothing was ever measured.
+    pub recovery_time_ms: Option<i64>,
+}
+
+/// Watches pressure until it recovers or the window expires.
+///
+/// `sample` is called rather than reading `/proc` directly so the caller
+/// chooses what pressure means for this incident — and so this is testable
+/// without a stalling machine.
+pub async fn observe_recovery<S>(mut sample: S, watch: RecoveryWatch) -> RecoveryOutcome
+where
+    S: FnMut() -> f32,
+{
+    let started = Instant::now();
+    let mut last = sample();
+
+    // Checked before the first sleep: an action that worked immediately should
+    // report a fast recovery, not one rounded up to the poll interval.
+    if last <= watch.recovered_below {
+        return RecoveryOutcome {
+            psi_after: last,
+            recovery_time_ms: Some(0),
+        };
+    }
+
+    loop {
+        tokio::time::sleep(watch.poll_interval).await;
+        last = sample();
+        let elapsed = started.elapsed();
+
+        if last <= watch.recovered_below {
+            return RecoveryOutcome {
+                psi_after: last,
+                recovery_time_ms: Some(elapsed.as_millis() as i64),
+            };
+        }
+
+        if elapsed >= watch.max_wait {
+            return RecoveryOutcome {
+                psi_after: last,
+                recovery_time_ms: None,
+            };
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A queue of readings, so a test can describe pressure over time.
+    fn readings(values: &[f32]) -> impl FnMut() -> f32 + '_ {
+        let mut idx = 0;
+        move || {
+            let value = values[idx.min(values.len() - 1)];
+            idx += 1;
+            value
+        }
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn recovery_is_timed_from_the_action() {
+        // Still bad for two polls, recovered on the third.
+        let outcome = observe_recovery(
+            readings(&[80.0, 70.0, 60.0, 5.0]),
+            RecoveryWatch {
+                poll_interval: Duration::from_secs(1),
+                max_wait: Duration::from_secs(60),
+                recovered_below: 10.0,
+            },
+        )
+        .await;
+
+        assert_eq!(outcome.psi_after, 5.0);
+        assert_eq!(outcome.recovery_time_ms, Some(3_000));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn pressure_that_never_falls_records_the_reading_and_no_recovery() {
+        let outcome = observe_recovery(
+            readings(&[80.0]),
+            RecoveryWatch {
+                poll_interval: Duration::from_secs(1),
+                max_wait: Duration::from_secs(5),
+                recovered_below: 10.0,
+            },
+        )
+        .await;
+
+        // The distinction this whole type exists to preserve: we watched, and
+        // it did not recover. Recording the window length here would claim a
+        // recovery at 5s that never happened.
+        assert_eq!(outcome.psi_after, 80.0);
+        assert_eq!(outcome.recovery_time_ms, None);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn an_immediate_recovery_is_not_rounded_up_to_a_poll() {
+        let outcome = observe_recovery(
+            readings(&[2.0]),
+            RecoveryWatch {
+                poll_interval: Duration::from_secs(30),
+                max_wait: Duration::from_secs(120),
+                recovered_below: 10.0,
+            },
+        )
+        .await;
+
+        assert_eq!(outcome.recovery_time_ms, Some(0));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn pressure_exactly_at_the_threshold_counts_as_recovered() {
+        // The threshold is the line the incident was declared on, so sitting
+        // on it is no longer breaching.
+        let outcome = observe_recovery(
+            readings(&[80.0, 10.0]),
+            RecoveryWatch {
+                poll_interval: Duration::from_secs(1),
+                max_wait: Duration::from_secs(60),
+                recovered_below: 10.0,
+            },
+        )
+        .await;
+
+        assert_eq!(outcome.recovery_time_ms, Some(1_000));
+    }
+}

--- a/cognitod/src/incidents/outcome.rs
+++ b/cognitod/src/incidents/outcome.rs
@@ -12,9 +12,12 @@
 //! heuristic into a verified attribution: the difference between "this pod was
 //! contending" and "removing it demonstrably reduced the stall".
 
+use std::sync::Arc;
 use std::time::Duration;
 
 use tokio::time::Instant;
+
+use crate::enforcement::{ActionStatus, EnforcementQueue};
 
 /// How long to watch, and what counts as recovered.
 #[derive(Debug, Clone, Copy)]
@@ -48,10 +51,15 @@ impl RecoveryWatch {
 /// What was actually observed after the action.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct RecoveryOutcome {
-    /// Pressure at the end of the observation, whatever happened. Always
-    /// recorded: "we watched and it stayed bad" is a result, and the most
+    /// Pressure at the end of the observation. Recorded whatever the reading
+    /// was — "we watched and it stayed bad" is a result, and the most
     /// important one to be able to see.
-    pub psi_after: f32,
+    ///
+    /// `None` when pressure could not be read at all. A failed read is not a
+    /// low reading: `PsiMetrics::read` yields zeros when `/proc/pressure` is
+    /// unavailable, and zero is below every threshold, so treating it as a
+    /// value would record a missing measurement as an instant recovery.
+    pub psi_after: Option<f32>,
     /// Time until pressure fell below the threshold.
     ///
     /// `None` means it never did within `max_wait` — deliberately not the
@@ -69,14 +77,14 @@ pub struct RecoveryOutcome {
 /// without a stalling machine.
 pub async fn observe_recovery<S>(mut sample: S, watch: RecoveryWatch) -> RecoveryOutcome
 where
-    S: FnMut() -> f32,
+    S: FnMut() -> Option<f32>,
 {
     let started = Instant::now();
     let mut last = sample();
 
     // Checked before the first sleep: an action that worked immediately should
     // report a fast recovery, not one rounded up to the poll interval.
-    if last <= watch.recovered_below {
+    if last.is_some_and(|psi| psi <= watch.recovered_below) {
         return RecoveryOutcome {
             psi_after: last,
             recovery_time_ms: Some(0),
@@ -85,17 +93,22 @@ where
 
     loop {
         tokio::time::sleep(watch.poll_interval).await;
-        last = sample();
-        let elapsed = started.elapsed();
+        // A failed read leaves the previous reading standing rather than
+        // overwriting it with an absence: the last thing actually observed is
+        // better evidence than nothing, and a transient unreadable /proc must
+        // not end the watch.
+        if let Some(reading) = sample() {
+            last = Some(reading);
 
-        if last <= watch.recovered_below {
-            return RecoveryOutcome {
-                psi_after: last,
-                recovery_time_ms: Some(elapsed.as_millis() as i64),
-            };
+            if reading <= watch.recovered_below {
+                return RecoveryOutcome {
+                    psi_after: last,
+                    recovery_time_ms: Some(started.elapsed().as_millis() as i64),
+                };
+            }
         }
 
-        if elapsed >= watch.max_wait {
+        if started.elapsed() >= watch.max_wait {
             return RecoveryOutcome {
                 psi_after: last,
                 recovery_time_ms: None,
@@ -104,12 +117,53 @@ where
     }
 }
 
+impl RecoveryOutcome {
+    /// Whether anything was actually observed.
+    ///
+    /// An unmeasured outcome must not be written: leaving both columns NULL
+    /// says "nobody looked", which is true, where writing them would claim an
+    /// observation that never happened.
+    pub fn is_measured(&self) -> bool {
+        self.psi_after.is_some()
+    }
+}
+
+/// Waits until a proposed action has actually executed.
+///
+/// Returns false if it was rejected, expired, or is still waiting when the
+/// deadline passes. This gates the recovery watch, because timing a recovery
+/// against an action that has not run measures the weather: in `monitor` mode
+/// and whenever human approval is required — both defaults — `propose_auto`
+/// returns successfully with a *pending* action, and a natural fall in
+/// pressure would otherwise be recorded as a successful auto-kill.
+pub async fn await_execution(
+    queue: &Arc<EnforcementQueue>,
+    action_id: &str,
+    timeout: Duration,
+    poll_interval: Duration,
+) -> bool {
+    let started = Instant::now();
+
+    loop {
+        match queue.get_by_id(action_id).await.map(|a| a.status) {
+            Some(ActionStatus::Executed) => return true,
+            Some(ActionStatus::Rejected) | Some(ActionStatus::Expired) | None => return false,
+            _ => {}
+        }
+
+        if started.elapsed() >= timeout {
+            return false;
+        }
+        tokio::time::sleep(poll_interval).await;
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
     /// A queue of readings, so a test can describe pressure over time.
-    fn readings(values: &[f32]) -> impl FnMut() -> f32 + '_ {
+    fn readings(values: &[Option<f32>]) -> impl FnMut() -> Option<f32> + '_ {
         let mut idx = 0;
         move || {
             let value = values[idx.min(values.len() - 1)];
@@ -122,7 +176,7 @@ mod tests {
     async fn recovery_is_timed_from_the_action() {
         // Still bad for two polls, recovered on the third.
         let outcome = observe_recovery(
-            readings(&[80.0, 70.0, 60.0, 5.0]),
+            readings(&[Some(80.0), Some(70.0), Some(60.0), Some(5.0)]),
             RecoveryWatch {
                 poll_interval: Duration::from_secs(1),
                 max_wait: Duration::from_secs(60),
@@ -131,14 +185,14 @@ mod tests {
         )
         .await;
 
-        assert_eq!(outcome.psi_after, 5.0);
+        assert_eq!(outcome.psi_after, Some(5.0));
         assert_eq!(outcome.recovery_time_ms, Some(3_000));
     }
 
     #[tokio::test(start_paused = true)]
     async fn pressure_that_never_falls_records_the_reading_and_no_recovery() {
         let outcome = observe_recovery(
-            readings(&[80.0]),
+            readings(&[Some(80.0)]),
             RecoveryWatch {
                 poll_interval: Duration::from_secs(1),
                 max_wait: Duration::from_secs(5),
@@ -150,14 +204,14 @@ mod tests {
         // The distinction this whole type exists to preserve: we watched, and
         // it did not recover. Recording the window length here would claim a
         // recovery at 5s that never happened.
-        assert_eq!(outcome.psi_after, 80.0);
+        assert_eq!(outcome.psi_after, Some(80.0));
         assert_eq!(outcome.recovery_time_ms, None);
     }
 
     #[tokio::test(start_paused = true)]
     async fn an_immediate_recovery_is_not_rounded_up_to_a_poll() {
         let outcome = observe_recovery(
-            readings(&[2.0]),
+            readings(&[Some(2.0)]),
             RecoveryWatch {
                 poll_interval: Duration::from_secs(30),
                 max_wait: Duration::from_secs(120),
@@ -170,11 +224,137 @@ mod tests {
     }
 
     #[tokio::test(start_paused = true)]
+    async fn an_unreadable_proc_is_not_a_recovery() {
+        // `PsiMetrics::read` yields zeros when /proc/pressure is unavailable,
+        // and zero is below every threshold. Treating a failed read as a
+        // reading would record "recovered instantly" for a measurement that
+        // never happened — the most flattering possible lie.
+        let outcome = observe_recovery(
+            readings(&[None]),
+            RecoveryWatch {
+                poll_interval: Duration::from_secs(1),
+                max_wait: Duration::from_secs(5),
+                recovered_below: 10.0,
+            },
+        )
+        .await;
+
+        assert_eq!(outcome.psi_after, None);
+        assert_eq!(outcome.recovery_time_ms, None);
+        assert!(
+            !outcome.is_measured(),
+            "an outcome with no reading must not be written at all"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn a_transient_read_failure_does_not_end_the_watch() {
+        // One unreadable sample in the middle must not abandon the watch or
+        // discard what was already observed.
+        let outcome = observe_recovery(
+            readings(&[Some(80.0), None, Some(70.0), Some(4.0)]),
+            RecoveryWatch {
+                poll_interval: Duration::from_secs(1),
+                max_wait: Duration::from_secs(60),
+                recovered_below: 10.0,
+            },
+        )
+        .await;
+
+        assert_eq!(outcome.psi_after, Some(4.0));
+        assert_eq!(outcome.recovery_time_ms, Some(3_000));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn an_action_that_never_executes_is_never_credited() {
+        use crate::enforcement::{ActionType, EnforcementQueue};
+
+        let queue = Arc::new(EnforcementQueue::new(3_600));
+        // The default posture: proposed, awaiting a human.
+        let id = queue
+            .propose_auto(
+                ActionType::KillProcess {
+                    pid: 1234,
+                    signal: 9,
+                },
+                "test".to_string(),
+                "circuit_breaker".to_string(),
+                None,
+                false,
+            )
+            .await
+            .unwrap();
+
+        let executed =
+            await_execution(&queue, &id, Duration::from_secs(5), Duration::from_secs(1)).await;
+
+        assert!(
+            !executed,
+            "a pending action must not start the recovery clock"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn a_rejected_action_stops_the_wait_immediately() {
+        use crate::enforcement::{ActionType, EnforcementQueue};
+
+        let queue = Arc::new(EnforcementQueue::new(3_600));
+        let id = queue
+            .propose_auto(
+                ActionType::KillProcess {
+                    pid: 1234,
+                    signal: 9,
+                },
+                "test".to_string(),
+                "circuit_breaker".to_string(),
+                None,
+                false,
+            )
+            .await
+            .unwrap();
+        queue.reject(&id, "operator".to_string()).await.unwrap();
+
+        assert!(
+            !await_execution(
+                &queue,
+                &id,
+                Duration::from_secs(600),
+                Duration::from_secs(1)
+            )
+            .await,
+            "a rejected action is a decision, not something to keep waiting on"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn an_executed_action_starts_the_watch() {
+        use crate::enforcement::{ActionType, EnforcementQueue};
+
+        let queue = Arc::new(EnforcementQueue::new(3_600));
+        let id = queue
+            .propose_auto(
+                ActionType::KillProcess {
+                    pid: 1234,
+                    signal: 9,
+                },
+                "test".to_string(),
+                "circuit_breaker".to_string(),
+                None,
+                true,
+            )
+            .await
+            .unwrap();
+        queue.complete(&id).await.unwrap();
+
+        assert!(await_execution(&queue, &id, Duration::from_secs(5), Duration::from_secs(1)).await);
+    }
+
+    #[tokio::test(start_paused = true)]
     async fn pressure_exactly_at_the_threshold_counts_as_recovered() {
         // The threshold is the line the incident was declared on, so sitting
         // on it is no longer breaching.
         let outcome = observe_recovery(
-            readings(&[80.0, 10.0]),
+            readings(&[Some(80.0), Some(10.0)]),
             RecoveryWatch {
                 poll_interval: Duration::from_secs(1),
                 max_wait: Duration::from_secs(60),

--- a/cognitod/src/incidents/outcome.rs
+++ b/cognitod/src/incidents/outcome.rs
@@ -141,6 +141,13 @@ pub async fn await_execution(
     action_id: &str,
     poll_interval: Duration,
 ) -> bool {
+    // Deadlines live on the same clock as the sleeps below. Comparing a wall
+    // clock against virtual sleeps is not merely untestable — under paused
+    // time the sleeps advance and the wall clock does not, so the loop spins
+    // for the TTL in *real* seconds.
+    let mut pending_deadline: Option<Instant> = None;
+    let mut approved_deadline: Option<Instant> = None;
+
     loop {
         let Some(action) = queue.get_by_id(action_id).await else {
             return false;
@@ -148,29 +155,57 @@ pub async fn await_execution(
 
         match action.status {
             ActionStatus::Executed => return true,
-            ActionStatus::Rejected | ActionStatus::Expired => return false,
-            _ => {}
-        }
+            ActionStatus::Rejected | ActionStatus::Expired | ActionStatus::Failed => return false,
+            ActionStatus::Pending => {
+                // While pending, the action's own approval lifetime is the
+                // deadline: the queue holds proposals for 300s while the
+                // recovery watch runs for 120s, and borrowing the shorter
+                // number would abandon an incident an operator could still
+                // validly approve.
+                let deadline = *pending_deadline.get_or_insert_with(|| {
+                    let now = std::time::SystemTime::now()
+                        .duration_since(std::time::UNIX_EPOCH)
+                        .map(|d| d.as_secs())
+                        .unwrap_or(0);
+                    // One poll of slack, and strictly after: `approve` accepts
+                    // an approval at exactly `expires_at`, so giving up *at*
+                    // the boundary would abandon an action an operator is
+                    // still allowed to approve — and which would then really
+                    // execute, with its incident permanently unverifiable.
+                    Instant::now()
+                        + Duration::from_secs(action.expires_at.saturating_sub(now))
+                        + poll_interval
+                });
 
-        // The deadline is the action's own approval lifetime, not the recovery
-        // window. The queue holds proposals for 300s while the recovery watch
-        // runs for 120s, so borrowing the shorter number would abandon an
-        // incident at two minutes and leave it permanently without an outcome
-        // even though an operator could still validly approve it at four.
-        if current_epoch_secs() >= action.expires_at {
-            return false;
+                if Instant::now() > deadline {
+                    return false;
+                }
+            }
+            ActionStatus::Approved => {
+                // Approval stops the expiry clock. `approve` allows approval
+                // at the boundary and the executor only scans once a second,
+                // so exiting on the proposal's expiry here would abandon an
+                // action that is about to really run — and the kill would then
+                // happen with the incident permanently unverifiable.
+                let deadline =
+                    *approved_deadline.get_or_insert_with(|| Instant::now() + EXECUTION_GRACE);
+
+                if Instant::now() >= deadline {
+                    return false;
+                }
+            }
         }
 
         tokio::time::sleep(poll_interval).await;
     }
 }
 
-fn current_epoch_secs() -> u64 {
-    std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.as_secs())
-        .unwrap_or(0)
-}
+/// How long an approved action may sit before the executor is presumed dead.
+///
+/// The executor scans every second, so this is generous by two orders of
+/// magnitude; it exists only so a stalled executor cannot leave the watch
+/// waiting forever.
+const EXECUTION_GRACE: Duration = Duration::from_secs(60);
 
 /// The whole verification, in the order it has to happen: wait for the action
 /// to run, then measure.
@@ -405,6 +440,101 @@ mod tests {
         assert!(
             outcome.is_none(),
             "an action that never ran must produce no verification at all"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn approval_at_the_expiry_boundary_still_gets_measured() {
+        use crate::enforcement::{ActionType, EnforcementQueue};
+
+        // `approve` permits approval at `now == expires_at`, and the executor
+        // only scans once a second. Exiting on the proposal's expiry would
+        // abandon an action that is about to really run, leaving a real kill
+        // permanently unverifiable.
+        let queue = Arc::new(EnforcementQueue::new(2));
+        let id = queue
+            .propose_auto(
+                ActionType::KillProcess {
+                    pid: UNUSED_PID,
+                    signal: 9,
+                },
+                "test".to_string(),
+                "circuit_breaker".to_string(),
+                None,
+                false,
+            )
+            .await
+            .unwrap();
+
+        let late = Arc::clone(&queue);
+        let late_id = id.clone();
+        tokio::spawn(async move {
+            // Approved right at the boundary, executed a scan later.
+            tokio::time::sleep(Duration::from_secs(2)).await;
+            let _ = late.approve(&late_id, "operator".to_string()).await;
+            tokio::time::sleep(Duration::from_secs(1)).await;
+            let _ = late.complete(&late_id).await;
+        });
+
+        assert!(
+            await_execution(&queue, &id, Duration::from_millis(200)).await,
+            "an action approved at the boundary and then executed must be seen"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn a_kill_that_failed_is_never_treated_as_executed() {
+        use crate::enforcement::{ActionType, EnforcementQueue};
+
+        let queue = Arc::new(EnforcementQueue::new(60));
+        let id = queue
+            .propose_auto(
+                ActionType::KillProcess {
+                    pid: UNUSED_PID,
+                    signal: 9,
+                },
+                "test".to_string(),
+                "circuit_breaker".to_string(),
+                None,
+                true,
+            )
+            .await
+            .unwrap();
+
+        // What the executor now does when libc::kill returns an error.
+        queue
+            .fail(&id, "kill failed: No such process".to_string())
+            .await
+            .expect("failing an approved action is a valid transition");
+
+        assert!(
+            !await_execution(&queue, &id, Duration::from_millis(200)).await,
+            "a failed kill must not start a recovery watch"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn an_approved_action_the_executor_never_runs_does_not_wait_forever() {
+        use crate::enforcement::{ActionType, EnforcementQueue};
+
+        let queue = Arc::new(EnforcementQueue::new(3_600));
+        let id = queue
+            .propose_auto(
+                ActionType::KillProcess {
+                    pid: UNUSED_PID,
+                    signal: 9,
+                },
+                "test".to_string(),
+                "circuit_breaker".to_string(),
+                None,
+                true, // approved, but nothing ever executes it
+            )
+            .await
+            .unwrap();
+
+        assert!(
+            !await_execution(&queue, &id, Duration::from_secs(1)).await,
+            "a stalled executor must not hold the watch open indefinitely"
         );
     }
 

--- a/cognitod/src/incidents/outcome.rs
+++ b/cognitod/src/incidents/outcome.rs
@@ -158,6 +158,33 @@ pub async fn await_execution(
     }
 }
 
+/// The whole verification, in the order it has to happen: wait for the action
+/// to run, then measure.
+///
+/// Exists as one function so the ordering is testable. Split across the call
+/// site it is just a convention, and a convention that "measure only after the
+/// action executed" is exactly the kind that silently stops holding.
+///
+/// `None` means there is nothing to record: either the action never ran, or
+/// pressure could never be read. Both are honestly represented by leaving the
+/// incident's outcome columns NULL.
+pub async fn verify_action_outcome<S>(
+    queue: &Arc<EnforcementQueue>,
+    action_id: &str,
+    sample: S,
+    watch: RecoveryWatch,
+) -> Option<RecoveryOutcome>
+where
+    S: FnMut() -> Option<f32>,
+{
+    if !await_execution(queue, action_id, watch.max_wait, watch.poll_interval).await {
+        return None;
+    }
+
+    let outcome = observe_recovery(sample, watch).await;
+    outcome.is_measured().then_some(outcome)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -323,6 +350,120 @@ mod tests {
             )
             .await,
             "a rejected action is a decision, not something to keep waiting on"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn a_pending_action_is_never_measured_however_calm_the_machine_gets() {
+        use crate::enforcement::{ActionType, EnforcementQueue};
+
+        let queue = Arc::new(EnforcementQueue::new(3_600));
+        let id = queue
+            .propose_auto(
+                ActionType::KillProcess {
+                    pid: 1234,
+                    signal: 9,
+                },
+                "test".to_string(),
+                "circuit_breaker".to_string(),
+                None,
+                false, // the default: awaiting a human
+            )
+            .await
+            .unwrap();
+
+        // Pressure is perfect throughout. Measuring here would credit the
+        // pending kill with a recovery that happened on its own — the failure
+        // the ordering exists to prevent.
+        let outcome = verify_action_outcome(
+            &queue,
+            &id,
+            || Some(0.0),
+            RecoveryWatch {
+                poll_interval: Duration::from_secs(1),
+                max_wait: Duration::from_secs(5),
+                recovered_below: 10.0,
+            },
+        )
+        .await;
+
+        assert!(
+            outcome.is_none(),
+            "an action that never ran must produce no verification at all"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn an_executed_action_is_measured() {
+        use crate::enforcement::{ActionType, EnforcementQueue};
+
+        let queue = Arc::new(EnforcementQueue::new(3_600));
+        let id = queue
+            .propose_auto(
+                ActionType::KillProcess {
+                    pid: 1234,
+                    signal: 9,
+                },
+                "test".to_string(),
+                "circuit_breaker".to_string(),
+                None,
+                true,
+            )
+            .await
+            .unwrap();
+        queue.complete(&id).await.unwrap();
+
+        let outcome = verify_action_outcome(
+            &queue,
+            &id,
+            || Some(2.0),
+            RecoveryWatch {
+                poll_interval: Duration::from_secs(1),
+                max_wait: Duration::from_secs(5),
+                recovered_below: 10.0,
+            },
+        )
+        .await
+        .expect("an executed action is measured");
+
+        assert_eq!(outcome.recovery_time_ms, Some(0));
+        assert_eq!(outcome.psi_after, Some(2.0));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn an_executed_action_with_unreadable_pressure_records_nothing() {
+        use crate::enforcement::{ActionType, EnforcementQueue};
+
+        let queue = Arc::new(EnforcementQueue::new(3_600));
+        let id = queue
+            .propose_auto(
+                ActionType::KillProcess {
+                    pid: 1234,
+                    signal: 9,
+                },
+                "test".to_string(),
+                "circuit_breaker".to_string(),
+                None,
+                true,
+            )
+            .await
+            .unwrap();
+        queue.complete(&id).await.unwrap();
+
+        assert!(
+            verify_action_outcome(
+                &queue,
+                &id,
+                || None,
+                RecoveryWatch {
+                    poll_interval: Duration::from_secs(1),
+                    max_wait: Duration::from_secs(3),
+                    recovered_below: 10.0,
+                },
+            )
+            .await
+            .is_none(),
+            "nothing observed means nothing to write"
         );
     }
 

--- a/cognitod/src/incidents/outcome.rs
+++ b/cognitod/src/incidents/outcome.rs
@@ -17,6 +17,8 @@ use std::time::Duration;
 
 use tokio::time::Instant;
 
+use tokio::sync::Semaphore;
+
 use crate::enforcement::{ActionStatus, EnforcementQueue};
 
 /// How long to watch, and what counts as recovered.
@@ -140,7 +142,7 @@ pub async fn await_execution(
     queue: &Arc<EnforcementQueue>,
     action_id: &str,
     poll_interval: Duration,
-) -> bool {
+) -> Option<u64> {
     // Deadlines live on the same clock as the sleeps below. Comparing a wall
     // clock against virtual sleeps is not merely untestable — under paused
     // time the sleeps advance and the wall clock does not, so the loop spins
@@ -149,13 +151,11 @@ pub async fn await_execution(
     let mut approved_deadline: Option<Instant> = None;
 
     loop {
-        let Some(action) = queue.get_by_id(action_id).await else {
-            return false;
-        };
+        let action = queue.get_by_id(action_id).await?;
 
         match action.status {
-            ActionStatus::Executed => return true,
-            ActionStatus::Rejected | ActionStatus::Expired | ActionStatus::Failed => return false,
+            ActionStatus::Executed => return Some(action.executed_at.unwrap_or_else(epoch_secs)),
+            ActionStatus::Rejected | ActionStatus::Expired | ActionStatus::Failed => return None,
             ActionStatus::Pending => {
                 // While pending, the action's own approval lifetime is the
                 // deadline: the queue holds proposals for 300s while the
@@ -178,7 +178,7 @@ pub async fn await_execution(
                 });
 
                 if Instant::now() > deadline {
-                    return false;
+                    return None;
                 }
             }
             ActionStatus::Approved => {
@@ -191,7 +191,7 @@ pub async fn await_execution(
                     *approved_deadline.get_or_insert_with(|| Instant::now() + EXECUTION_GRACE);
 
                 if Instant::now() >= deadline {
-                    return false;
+                    return None;
                 }
             }
         }
@@ -207,6 +207,13 @@ pub async fn await_execution(
 /// waiting forever.
 const EXECUTION_GRACE: Duration = Duration::from_secs(60);
 
+fn epoch_secs() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
 /// The whole verification, in the order it has to happen: wait for the action
 /// to run, then measure.
 ///
@@ -220,18 +227,39 @@ const EXECUTION_GRACE: Duration = Duration::from_secs(60);
 pub async fn verify_action_outcome<S>(
     queue: &Arc<EnforcementQueue>,
     action_id: &str,
+    slot: &Arc<Semaphore>,
     sample: S,
     watch: RecoveryWatch,
 ) -> Option<RecoveryOutcome>
 where
     S: FnMut() -> Option<f32>,
 {
-    if !await_execution(queue, action_id, watch.poll_interval).await {
+    let executed_at = await_execution(queue, action_id, watch.poll_interval).await?;
+
+    // Only one action is verified at a time. The sampler reads *system-wide*
+    // pressure, so two overlapping watches would both credit themselves with
+    // the same fall — and a second kill during a sustained incident is exactly
+    // when that happens. A verification that cannot be attributed to one
+    // action is worth less than no verification, so the loser records nothing.
+    let Ok(_slot) = slot.try_acquire() else {
+        return None;
+    };
+
+    let outcome = observe_recovery(sample, watch).await;
+    if !outcome.is_measured() {
         return None;
     }
 
-    let outcome = observe_recovery(sample, watch).await;
-    outcome.is_measured().then_some(outcome)
+    // Timed from the kill, not from when this watch started: the insert and
+    // the polling gap in between are real delay, and dropping them stores an
+    // already-recovered system as a 0ms recovery.
+    let since_execution_ms = epoch_secs().saturating_sub(executed_at) * 1_000;
+    Some(RecoveryOutcome {
+        recovery_time_ms: outcome
+            .recovery_time_ms
+            .map(|ms| ms + since_execution_ms as i64),
+        ..outcome
+    })
 }
 
 #[cfg(test)]
@@ -369,7 +397,9 @@ mod tests {
             .await
             .unwrap();
 
-        let executed = await_execution(&queue, &id, Duration::from_secs(1)).await;
+        let executed = await_execution(&queue, &id, Duration::from_secs(1))
+            .await
+            .is_some();
 
         assert!(
             !executed,
@@ -398,7 +428,9 @@ mod tests {
         queue.reject(&id, "operator".to_string()).await.unwrap();
 
         assert!(
-            !await_execution(&queue, &id, Duration::from_secs(1)).await,
+            await_execution(&queue, &id, Duration::from_secs(1))
+                .await
+                .is_none(),
             "a rejected action is a decision, not something to keep waiting on"
         );
     }
@@ -428,6 +460,7 @@ mod tests {
         let outcome = verify_action_outcome(
             &queue,
             &id,
+            &Arc::new(Semaphore::new(1)),
             || Some(0.0),
             RecoveryWatch {
                 poll_interval: Duration::from_secs(1),
@@ -477,7 +510,9 @@ mod tests {
         });
 
         assert!(
-            await_execution(&queue, &id, Duration::from_millis(200)).await,
+            await_execution(&queue, &id, Duration::from_millis(200))
+                .await
+                .is_some(),
             "an action approved at the boundary and then executed must be seen"
         );
     }
@@ -508,7 +543,9 @@ mod tests {
             .expect("failing an approved action is a valid transition");
 
         assert!(
-            !await_execution(&queue, &id, Duration::from_millis(200)).await,
+            await_execution(&queue, &id, Duration::from_millis(200))
+                .await
+                .is_none(),
             "a failed kill must not start a recovery watch"
         );
     }
@@ -533,7 +570,9 @@ mod tests {
             .unwrap();
 
         assert!(
-            !await_execution(&queue, &id, Duration::from_secs(1)).await,
+            await_execution(&queue, &id, Duration::from_secs(1))
+                .await
+                .is_none(),
             "a stalled executor must not hold the watch open indefinitely"
         );
     }
@@ -576,6 +615,7 @@ mod tests {
         let outcome = verify_action_outcome(
             &queue,
             &id,
+            &Arc::new(Semaphore::new(1)),
             || Some(1.0),
             RecoveryWatch {
                 poll_interval: Duration::from_secs(1),
@@ -588,6 +628,101 @@ mod tests {
         assert!(
             outcome.is_some(),
             "an action approved at 180s is inside its 300s life and must be measured"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn a_second_overlapping_verification_records_nothing() {
+        use crate::enforcement::{ActionType, EnforcementQueue};
+
+        let queue = Arc::new(EnforcementQueue::new(60));
+        let slot = Arc::new(Semaphore::new(1));
+
+        let mut ids = Vec::new();
+        for _ in 0..2 {
+            let id = queue
+                .propose_auto(
+                    ActionType::KillProcess {
+                        pid: UNUSED_PID,
+                        signal: 9,
+                    },
+                    "test".to_string(),
+                    "circuit_breaker".to_string(),
+                    None,
+                    true,
+                )
+                .await
+                .unwrap();
+            queue.complete(&id).await.unwrap();
+            ids.push(id);
+        }
+
+        let watch = RecoveryWatch {
+            poll_interval: Duration::from_secs(1),
+            max_wait: Duration::from_secs(10),
+            recovered_below: 10.0,
+        };
+
+        // Both kills happened; both watches would see the same system-wide
+        // pressure fall and each claim it. Only one may record an outcome.
+        let (first, second) = tokio::join!(
+            verify_action_outcome(&queue, &ids[0], &slot, || Some(50.0), watch),
+            verify_action_outcome(&queue, &ids[1], &slot, || Some(50.0), watch),
+        );
+
+        assert!(
+            first.is_some() ^ second.is_some(),
+            "exactly one overlapping verification may record an outcome"
+        );
+    }
+
+    /// Real time on purpose: `executed_at` is a wall-clock stamp, so a paused
+    /// clock would advance the sleeps and not the stamp, and the test would
+    /// pass for the wrong reason. Kept to one second for that reason.
+    #[tokio::test]
+    async fn recovery_is_timed_from_the_kill_not_from_the_watch() {
+        use crate::enforcement::{ActionType, EnforcementQueue};
+
+        let queue = Arc::new(EnforcementQueue::new(60));
+        let id = queue
+            .propose_auto(
+                ActionType::KillProcess {
+                    pid: UNUSED_PID,
+                    signal: 9,
+                },
+                "test".to_string(),
+                "circuit_breaker".to_string(),
+                None,
+                true,
+            )
+            .await
+            .unwrap();
+        queue.complete(&id).await.unwrap();
+
+        // Time passes between the kill and the watch — the incident insert,
+        // the executor poll. Pressure is already fine by the time we look.
+        tokio::time::sleep(Duration::from_millis(1_100)).await;
+
+        let outcome = verify_action_outcome(
+            &queue,
+            &id,
+            &Arc::new(Semaphore::new(1)),
+            || Some(1.0),
+            RecoveryWatch {
+                poll_interval: Duration::from_secs(1),
+                max_wait: Duration::from_secs(10),
+                recovered_below: 10.0,
+            },
+        )
+        .await
+        .expect("an executed action with readable pressure is measured");
+
+        // Storing 0ms would claim the kill worked instantly, when in truth
+        // nobody looked for half a minute.
+        assert!(
+            outcome.recovery_time_ms.unwrap() >= 1_000,
+            "recovery must be timed from the kill, got {:?}",
+            outcome.recovery_time_ms
         );
     }
 
@@ -614,6 +749,7 @@ mod tests {
         let outcome = verify_action_outcome(
             &queue,
             &id,
+            &Arc::new(Semaphore::new(1)),
             || Some(2.0),
             RecoveryWatch {
                 poll_interval: Duration::from_secs(1),
@@ -652,6 +788,7 @@ mod tests {
             verify_action_outcome(
                 &queue,
                 &id,
+                &Arc::new(Semaphore::new(1)),
                 || None,
                 RecoveryWatch {
                     poll_interval: Duration::from_secs(1),
@@ -685,7 +822,11 @@ mod tests {
             .unwrap();
         queue.complete(&id).await.unwrap();
 
-        assert!(await_execution(&queue, &id, Duration::from_secs(1)).await);
+        assert!(
+            await_execution(&queue, &id, Duration::from_secs(1))
+                .await
+                .is_some()
+        );
     }
 
     #[tokio::test(start_paused = true)]

--- a/cognitod/src/incidents/outcome.rs
+++ b/cognitod/src/incidents/outcome.rs
@@ -17,8 +17,6 @@ use std::time::Duration;
 
 use tokio::time::Instant;
 
-use tokio::sync::Semaphore;
-
 use crate::enforcement::{ActionStatus, EnforcementQueue};
 
 /// How long to watch, and what counts as recovered.
@@ -77,9 +75,14 @@ pub struct RecoveryOutcome {
 /// `sample` is called rather than reading `/proc` directly so the caller
 /// chooses what pressure means for this incident — and so this is testable
 /// without a stalling machine.
-pub async fn observe_recovery<S>(mut sample: S, watch: RecoveryWatch) -> RecoveryOutcome
+pub async fn observe_recovery<S, I>(
+    mut sample: S,
+    mut invalidated: I,
+    watch: RecoveryWatch,
+) -> RecoveryOutcome
 where
     S: FnMut() -> Option<f32>,
+    I: FnMut() -> bool,
 {
     let started = Instant::now();
     let mut last = sample();
@@ -95,6 +98,18 @@ where
 
     loop {
         tokio::time::sleep(watch.poll_interval).await;
+
+        // Another intervention landed while this one was being measured. Both
+        // watches read the same system-wide pressure, so whatever happens next
+        // cannot be attributed to this action — and crediting it anyway is how
+        // a second kill's success gets recorded against the first.
+        if invalidated() {
+            return RecoveryOutcome {
+                psi_after: None,
+                recovery_time_ms: None,
+            };
+        }
+
         // A failed read leaves the previous reading standing rather than
         // overwriting it with an absence: the last thing actually observed is
         // better evidence than nothing, and a transient unreadable /proc must
@@ -154,7 +169,9 @@ pub async fn await_execution(
         let action = queue.get_by_id(action_id).await?;
 
         match action.status {
-            ActionStatus::Executed => return Some(action.executed_at.unwrap_or_else(epoch_secs)),
+            ActionStatus::Executed => {
+                return Some(action.executed_at_ms.unwrap_or_else(epoch_millis));
+            }
             ActionStatus::Rejected | ActionStatus::Expired | ActionStatus::Failed => return None,
             ActionStatus::Pending => {
                 // While pending, the action's own approval lifetime is the
@@ -207,10 +224,10 @@ pub async fn await_execution(
 /// waiting forever.
 const EXECUTION_GRACE: Duration = Duration::from_secs(60);
 
-fn epoch_secs() -> u64 {
+fn epoch_millis() -> u64 {
     std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.as_secs())
+        .map(|d| d.as_millis() as u64)
         .unwrap_or(0)
 }
 
@@ -227,37 +244,50 @@ fn epoch_secs() -> u64 {
 pub async fn verify_action_outcome<S>(
     queue: &Arc<EnforcementQueue>,
     action_id: &str,
-    slot: &Arc<Semaphore>,
     sample: S,
     watch: RecoveryWatch,
 ) -> Option<RecoveryOutcome>
 where
     S: FnMut() -> Option<f32>,
 {
-    let executed_at = await_execution(queue, action_id, watch.poll_interval).await?;
+    let executed_at_ms = await_execution(queue, action_id, watch.poll_interval).await?;
 
-    // Only one action is verified at a time. The sampler reads *system-wide*
-    // pressure, so two overlapping watches would both credit themselves with
-    // the same fall — and a second kill during a sustained incident is exactly
-    // when that happens. A verification that cannot be attributed to one
-    // action is worth less than no verification, so the loser records nothing.
-    let Ok(_slot) = slot.try_acquire() else {
+    // Measured *before* observing, not after. Computing it afterwards folds
+    // the watch's own duration into the delay and then adds the watch again —
+    // a three-second recovery reported as six.
+    let pre_watch_delay = Duration::from_millis(epoch_millis().saturating_sub(executed_at_ms));
+
+    // The window is 120 seconds after the *kill*, so whatever the insert and
+    // the polling already consumed comes out of it. Otherwise a fall three
+    // minutes after the action could still be recorded as its recovery.
+    let remaining = watch.max_wait.checked_sub(pre_watch_delay)?;
+    if remaining.is_zero() {
         return None;
-    };
+    }
 
-    let outcome = observe_recovery(sample, watch).await;
+    // Any execution after this one invalidates the measurement: two watches
+    // reading system-wide pressure cannot both own the same fall.
+    let executions_at_start = queue.execution_count();
+    let queue_for_check = Arc::clone(queue);
+
+    let outcome = observe_recovery(
+        sample,
+        move || queue_for_check.execution_count() != executions_at_start,
+        RecoveryWatch {
+            max_wait: remaining,
+            ..watch
+        },
+    )
+    .await;
+
     if !outcome.is_measured() {
         return None;
     }
 
-    // Timed from the kill, not from when this watch started: the insert and
-    // the polling gap in between are real delay, and dropping them stores an
-    // already-recovered system as a 0ms recovery.
-    let since_execution_ms = epoch_secs().saturating_sub(executed_at) * 1_000;
     Some(RecoveryOutcome {
         recovery_time_ms: outcome
             .recovery_time_ms
-            .map(|ms| ms + since_execution_ms as i64),
+            .map(|ms| ms + pre_watch_delay.as_millis() as i64),
         ..outcome
     })
 }
@@ -289,6 +319,7 @@ mod tests {
         // Still bad for two polls, recovered on the third.
         let outcome = observe_recovery(
             readings(&[Some(80.0), Some(70.0), Some(60.0), Some(5.0)]),
+            || false,
             RecoveryWatch {
                 poll_interval: Duration::from_secs(1),
                 max_wait: Duration::from_secs(60),
@@ -305,6 +336,7 @@ mod tests {
     async fn pressure_that_never_falls_records_the_reading_and_no_recovery() {
         let outcome = observe_recovery(
             readings(&[Some(80.0)]),
+            || false,
             RecoveryWatch {
                 poll_interval: Duration::from_secs(1),
                 max_wait: Duration::from_secs(5),
@@ -324,6 +356,7 @@ mod tests {
     async fn an_immediate_recovery_is_not_rounded_up_to_a_poll() {
         let outcome = observe_recovery(
             readings(&[Some(2.0)]),
+            || false,
             RecoveryWatch {
                 poll_interval: Duration::from_secs(30),
                 max_wait: Duration::from_secs(120),
@@ -343,6 +376,7 @@ mod tests {
         // never happened — the most flattering possible lie.
         let outcome = observe_recovery(
             readings(&[None]),
+            || false,
             RecoveryWatch {
                 poll_interval: Duration::from_secs(1),
                 max_wait: Duration::from_secs(5),
@@ -365,6 +399,7 @@ mod tests {
         // discard what was already observed.
         let outcome = observe_recovery(
             readings(&[Some(80.0), None, Some(70.0), Some(4.0)]),
+            || false,
             RecoveryWatch {
                 poll_interval: Duration::from_secs(1),
                 max_wait: Duration::from_secs(60),
@@ -460,7 +495,6 @@ mod tests {
         let outcome = verify_action_outcome(
             &queue,
             &id,
-            &Arc::new(Semaphore::new(1)),
             || Some(0.0),
             RecoveryWatch {
                 poll_interval: Duration::from_secs(1),
@@ -615,7 +649,6 @@ mod tests {
         let outcome = verify_action_outcome(
             &queue,
             &id,
-            &Arc::new(Semaphore::new(1)),
             || Some(1.0),
             RecoveryWatch {
                 poll_interval: Duration::from_secs(1),
@@ -632,15 +665,36 @@ mod tests {
     }
 
     #[tokio::test(start_paused = true)]
-    async fn a_second_overlapping_verification_records_nothing() {
+    async fn an_overlapping_execution_invalidates_the_measurement() {
         use crate::enforcement::{ActionType, EnforcementQueue};
 
         let queue = Arc::new(EnforcementQueue::new(60));
-        let slot = Arc::new(Semaphore::new(1));
+        let propose = |queue: Arc<EnforcementQueue>| async move {
+            queue
+                .propose_auto(
+                    ActionType::KillProcess {
+                        pid: UNUSED_PID,
+                        signal: 9,
+                    },
+                    "test".to_string(),
+                    "circuit_breaker".to_string(),
+                    None,
+                    true,
+                )
+                .await
+                .unwrap()
+        };
 
-        let mut ids = Vec::new();
-        for _ in 0..2 {
-            let id = queue
+        let first = propose(Arc::clone(&queue)).await;
+        queue.complete(&first).await.unwrap();
+
+        // A second kill lands while the first is still being watched. Both
+        // read the same system-wide pressure, so the fall that follows cannot
+        // be attributed to the first action.
+        let interferer = Arc::clone(&queue);
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_secs(2)).await;
+            let second = interferer
                 .propose_auto(
                     ActionType::KillProcess {
                         pid: UNUSED_PID,
@@ -653,34 +707,35 @@ mod tests {
                 )
                 .await
                 .unwrap();
-            queue.complete(&id).await.unwrap();
-            ids.push(id);
-        }
+            interferer.complete(&second).await.unwrap();
+        });
 
-        let watch = RecoveryWatch {
-            poll_interval: Duration::from_secs(1),
-            max_wait: Duration::from_secs(10),
-            recovered_below: 10.0,
-        };
-
-        // Both kills happened; both watches would see the same system-wide
-        // pressure fall and each claim it. Only one may record an outcome.
-        let (first, second) = tokio::join!(
-            verify_action_outcome(&queue, &ids[0], &slot, || Some(50.0), watch),
-            verify_action_outcome(&queue, &ids[1], &slot, || Some(50.0), watch),
-        );
+        let outcome = verify_action_outcome(
+            &queue,
+            &first,
+            || Some(50.0), // never recovers on its own
+            RecoveryWatch {
+                poll_interval: Duration::from_secs(1),
+                max_wait: Duration::from_secs(30),
+                recovered_below: 10.0,
+            },
+        )
+        .await;
 
         assert!(
-            first.is_some() ^ second.is_some(),
-            "exactly one overlapping verification may record an outcome"
+            outcome.is_none(),
+            "a measurement overlapped by another kill must record nothing"
         );
     }
 
-    /// Real time on purpose: `executed_at` is a wall-clock stamp, so a paused
-    /// clock would advance the sleeps and not the stamp, and the test would
-    /// pass for the wrong reason. Kept to one second for that reason.
+    /// Real time on purpose: `executed_at_ms` is a wall-clock stamp, so a
+    /// paused clock would advance the sleeps and not the stamp, and the test
+    /// would pass without testing anything. Kept to ~1.6s for that reason.
+    ///
+    /// The watch itself must take measurable time here: with an instant
+    /// recovery, counting the observation twice adds nothing and the bug hides.
     #[tokio::test]
-    async fn recovery_is_timed_from_the_kill_not_from_the_watch() {
+    async fn recovery_is_timed_from_the_kill_and_counted_once() {
         use crate::enforcement::{ActionType, EnforcementQueue};
 
         let queue = Arc::new(EnforcementQueue::new(60));
@@ -699,30 +754,41 @@ mod tests {
             .unwrap();
         queue.complete(&id).await.unwrap();
 
-        // Time passes between the kill and the watch — the incident insert,
-        // the executor poll. Pressure is already fine by the time we look.
-        tokio::time::sleep(Duration::from_millis(1_100)).await;
+        // The incident insert and the executor poll: real delay before anyone
+        // starts watching.
+        tokio::time::sleep(Duration::from_millis(1_000)).await;
 
+        // Still stalling for two polls, then recovered: the watch spans ~600ms.
+        let mut polls = 0;
         let outcome = verify_action_outcome(
             &queue,
             &id,
-            &Arc::new(Semaphore::new(1)),
-            || Some(1.0),
+            move || {
+                polls += 1;
+                Some(if polls > 2 { 1.0 } else { 90.0 })
+            },
             RecoveryWatch {
-                poll_interval: Duration::from_secs(1),
-                max_wait: Duration::from_secs(10),
+                poll_interval: Duration::from_millis(300),
+                max_wait: Duration::from_secs(30),
                 recovered_below: 10.0,
             },
         )
         .await
         .expect("an executed action with readable pressure is measured");
 
-        // Storing 0ms would claim the kill worked instantly, when in truth
-        // nobody looked for half a minute.
+        let reported = outcome.recovery_time_ms.unwrap();
+
+        // ~1000ms of pre-watch delay plus ~600ms of watching.
         assert!(
-            outcome.recovery_time_ms.unwrap() >= 1_000,
-            "recovery must be timed from the kill, got {:?}",
-            outcome.recovery_time_ms
+            reported >= 1_500,
+            "recovery must be timed from the kill, got {reported}ms"
+        );
+
+        // The half that catches double counting: measuring the delay *after*
+        // observing folds the watch in twice, which lands near 2200ms.
+        assert!(
+            reported < 2_000,
+            "the observation interval must not be counted twice, got {reported}ms"
         );
     }
 
@@ -749,7 +815,6 @@ mod tests {
         let outcome = verify_action_outcome(
             &queue,
             &id,
-            &Arc::new(Semaphore::new(1)),
             || Some(2.0),
             RecoveryWatch {
                 poll_interval: Duration::from_secs(1),
@@ -788,7 +853,6 @@ mod tests {
             verify_action_outcome(
                 &queue,
                 &id,
-                &Arc::new(Semaphore::new(1)),
                 || None,
                 RecoveryWatch {
                     poll_interval: Duration::from_secs(1),
@@ -835,6 +899,7 @@ mod tests {
         // on it is no longer breaching.
         let outcome = observe_recovery(
             readings(&[Some(80.0), Some(10.0)]),
+            || false,
             RecoveryWatch {
                 poll_interval: Duration::from_secs(1),
                 max_wait: Duration::from_secs(60),

--- a/cognitod/src/incidents/outcome.rs
+++ b/cognitod/src/incidents/outcome.rs
@@ -139,23 +139,37 @@ impl RecoveryOutcome {
 pub async fn await_execution(
     queue: &Arc<EnforcementQueue>,
     action_id: &str,
-    timeout: Duration,
     poll_interval: Duration,
 ) -> bool {
-    let started = Instant::now();
-
     loop {
-        match queue.get_by_id(action_id).await.map(|a| a.status) {
-            Some(ActionStatus::Executed) => return true,
-            Some(ActionStatus::Rejected) | Some(ActionStatus::Expired) | None => return false,
+        let Some(action) = queue.get_by_id(action_id).await else {
+            return false;
+        };
+
+        match action.status {
+            ActionStatus::Executed => return true,
+            ActionStatus::Rejected | ActionStatus::Expired => return false,
             _ => {}
         }
 
-        if started.elapsed() >= timeout {
+        // The deadline is the action's own approval lifetime, not the recovery
+        // window. The queue holds proposals for 300s while the recovery watch
+        // runs for 120s, so borrowing the shorter number would abandon an
+        // incident at two minutes and leave it permanently without an outcome
+        // even though an operator could still validly approve it at four.
+        if current_epoch_secs() >= action.expires_at {
             return false;
         }
+
         tokio::time::sleep(poll_interval).await;
     }
+}
+
+fn current_epoch_secs() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
 }
 
 /// The whole verification, in the order it has to happen: wait for the action
@@ -177,7 +191,7 @@ pub async fn verify_action_outcome<S>(
 where
     S: FnMut() -> Option<f32>,
 {
-    if !await_execution(queue, action_id, watch.max_wait, watch.poll_interval).await {
+    if !await_execution(queue, action_id, watch.poll_interval).await {
         return None;
     }
 
@@ -296,7 +310,7 @@ mod tests {
     async fn an_action_that_never_executes_is_never_credited() {
         use crate::enforcement::{ActionType, EnforcementQueue};
 
-        let queue = Arc::new(EnforcementQueue::new(3_600));
+        let queue = Arc::new(EnforcementQueue::new(5));
         // The default posture: proposed, awaiting a human.
         let id = queue
             .propose_auto(
@@ -312,8 +326,7 @@ mod tests {
             .await
             .unwrap();
 
-        let executed =
-            await_execution(&queue, &id, Duration::from_secs(5), Duration::from_secs(1)).await;
+        let executed = await_execution(&queue, &id, Duration::from_secs(1)).await;
 
         assert!(
             !executed,
@@ -342,13 +355,7 @@ mod tests {
         queue.reject(&id, "operator".to_string()).await.unwrap();
 
         assert!(
-            !await_execution(
-                &queue,
-                &id,
-                Duration::from_secs(600),
-                Duration::from_secs(1)
-            )
-            .await,
+            !await_execution(&queue, &id, Duration::from_secs(1)).await,
             "a rejected action is a decision, not something to keep waiting on"
         );
     }
@@ -357,7 +364,7 @@ mod tests {
     async fn a_pending_action_is_never_measured_however_calm_the_machine_gets() {
         use crate::enforcement::{ActionType, EnforcementQueue};
 
-        let queue = Arc::new(EnforcementQueue::new(3_600));
+        let queue = Arc::new(EnforcementQueue::new(5));
         let id = queue
             .propose_auto(
                 ActionType::KillProcess {
@@ -390,6 +397,59 @@ mod tests {
         assert!(
             outcome.is_none(),
             "an action that never ran must produce no verification at all"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn an_approval_after_the_recovery_window_is_still_measured() {
+        use crate::enforcement::{ActionType, EnforcementQueue};
+
+        // The production shape: proposals live for 300s, the recovery watch
+        // runs for 120s. An operator approving at minute three is acting well
+        // within the action's life, and that incident must still get an
+        // outcome — borrowing the watch duration as the execution deadline
+        // would abandon it at two minutes, permanently.
+        let queue = Arc::new(EnforcementQueue::new(300));
+        let id = queue
+            .propose_auto(
+                ActionType::KillProcess {
+                    pid: 1234,
+                    signal: 9,
+                },
+                "test".to_string(),
+                "circuit_breaker".to_string(),
+                None,
+                false,
+            )
+            .await
+            .unwrap();
+
+        let approver = Arc::clone(&queue);
+        let late_id = id.clone();
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_secs(180)).await;
+            approver
+                .approve(&late_id, "operator".to_string())
+                .await
+                .unwrap();
+            approver.complete(&late_id).await.unwrap();
+        });
+
+        let outcome = verify_action_outcome(
+            &queue,
+            &id,
+            || Some(1.0),
+            RecoveryWatch {
+                poll_interval: Duration::from_secs(1),
+                max_wait: Duration::from_secs(120),
+                recovered_below: 10.0,
+            },
+        )
+        .await;
+
+        assert!(
+            outcome.is_some(),
+            "an action approved at 180s is inside its 300s life and must be measured"
         );
     }
 
@@ -487,7 +547,7 @@ mod tests {
             .unwrap();
         queue.complete(&id).await.unwrap();
 
-        assert!(await_execution(&queue, &id, Duration::from_secs(5), Duration::from_secs(1)).await);
+        assert!(await_execution(&queue, &id, Duration::from_secs(1)).await);
     }
 
     #[tokio::test(start_paused = true)]

--- a/cognitod/src/incidents/outcome.rs
+++ b/cognitod/src/incidents/outcome.rs
@@ -203,6 +203,14 @@ where
 mod tests {
     use super::*;
 
+    /// Above Linux's maximum `pid_max` (2^22), so no process can hold it.
+    ///
+    /// `SafetyGuard::is_safe_to_kill` inspects the live process table, so a
+    /// plausible-looking pid makes these tests depend on whatever happens to
+    /// be running on the machine — which is how they passed locally and failed
+    /// in CI, where pid 1234 belonged to a process on the critical list.
+    const UNUSED_PID: u32 = 4_000_001;
+
     /// A queue of readings, so a test can describe pressure over time.
     fn readings(values: &[Option<f32>]) -> impl FnMut() -> Option<f32> + '_ {
         let mut idx = 0;
@@ -315,7 +323,7 @@ mod tests {
         let id = queue
             .propose_auto(
                 ActionType::KillProcess {
-                    pid: 1234,
+                    pid: UNUSED_PID,
                     signal: 9,
                 },
                 "test".to_string(),
@@ -342,7 +350,7 @@ mod tests {
         let id = queue
             .propose_auto(
                 ActionType::KillProcess {
-                    pid: 1234,
+                    pid: UNUSED_PID,
                     signal: 9,
                 },
                 "test".to_string(),
@@ -368,7 +376,7 @@ mod tests {
         let id = queue
             .propose_auto(
                 ActionType::KillProcess {
-                    pid: 1234,
+                    pid: UNUSED_PID,
                     signal: 9,
                 },
                 "test".to_string(),
@@ -413,7 +421,7 @@ mod tests {
         let id = queue
             .propose_auto(
                 ActionType::KillProcess {
-                    pid: 1234,
+                    pid: UNUSED_PID,
                     signal: 9,
                 },
                 "test".to_string(),
@@ -461,7 +469,7 @@ mod tests {
         let id = queue
             .propose_auto(
                 ActionType::KillProcess {
-                    pid: 1234,
+                    pid: UNUSED_PID,
                     signal: 9,
                 },
                 "test".to_string(),
@@ -498,7 +506,7 @@ mod tests {
         let id = queue
             .propose_auto(
                 ActionType::KillProcess {
-                    pid: 1234,
+                    pid: UNUSED_PID,
                     signal: 9,
                 },
                 "test".to_string(),
@@ -535,7 +543,7 @@ mod tests {
         let id = queue
             .propose_auto(
                 ActionType::KillProcess {
-                    pid: 1234,
+                    pid: UNUSED_PID,
                     signal: 9,
                 },
                 "test".to_string(),

--- a/cognitod/src/main.rs
+++ b/cognitod/src/main.rs
@@ -975,11 +975,6 @@ async fn main() -> Result<(), Box<dyn Error>> {
         let queue_clone = Arc::clone(queue);
         let incident_store_clone = incident_store.clone();
         let incident_analyzer_clone = incident_analyzer.clone();
-        // One verification at a time. The watcher reads system-wide pressure,
-        // so overlapping watches would each credit themselves with the same
-        // fall — and a second kill during a sustained incident is exactly when
-        // that happens.
-        let verification_slot = Arc::new(tokio::sync::Semaphore::new(1));
 
         tokio::spawn(async move {
             if !cb_cfg.enabled {
@@ -1095,7 +1090,6 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                             let analyzer_clone = incident_analyzer_clone.clone();
                                             let psi_threshold = cb_cfg.cpu_psi_threshold;
                                             let watch_queue = Arc::clone(&queue_clone);
-                                            let watch_slot = Arc::clone(&verification_slot);
                                             let watch_action_id = action_id.clone();
                                             tokio::spawn(async move {
                                                 if let Ok(id) = store_clone.insert(&incident).await
@@ -1111,7 +1105,6 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                                     // whether or not a model is configured.
                                                     let outcome_store = Arc::clone(&store_clone);
                                                     let outcome_queue = Arc::clone(&watch_queue);
-                                                    let outcome_slot = Arc::clone(&watch_slot);
                                                     tokio::spawn(async move {
                                                         // Ordering — wait for execution, then
                                                         // measure — lives in one tested function
@@ -1119,7 +1112,6 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                                         let Some(outcome) = cognitod::incidents::outcome::verify_action_outcome(
                                                             &outcome_queue,
                                                             &watch_action_id,
-                                                            &outcome_slot,
                                                             || {
                                                                 // Not `PsiMetrics::read`: that
                                                                 // degrades to zeros when

--- a/cognitod/src/main.rs
+++ b/cognitod/src/main.rs
@@ -1054,7 +1054,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                     )
                                     .await
                                 {
-                                    Ok(_) => {
+                                    Ok(action_id) => {
                                         warn!(
                                             "[circuit_breaker] AUTO-KILLED {}({}): {}",
                                             proc.comm, proc.pid, reason
@@ -1089,6 +1089,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                             let store_clone = Arc::clone(store);
                                             let analyzer_clone = incident_analyzer_clone.clone();
                                             let psi_threshold = cb_cfg.cpu_psi_threshold;
+                                            let watch_queue = Arc::clone(&queue_clone);
+                                            let watch_action_id = action_id.clone();
                                             tokio::spawn(async move {
                                                 if let Ok(id) = store_clone.insert(&incident).await
                                                 {
@@ -1102,12 +1104,40 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                                     // measurement is the part that must happen
                                                     // whether or not a model is configured.
                                                     let outcome_store = Arc::clone(&store_clone);
+                                                    let outcome_queue = Arc::clone(&watch_queue);
                                                     tokio::spawn(async move {
+                                                        // Nothing to verify until the action has
+                                                        // actually run. In monitor mode, and
+                                                        // whenever human approval is required —
+                                                        // both defaults — the proposal sits
+                                                        // pending, and timing a recovery against
+                                                        // it would credit the kill for pressure
+                                                        // that fell on its own.
+                                                        if !cognitod::incidents::outcome::await_execution(
+                                                            &outcome_queue,
+                                                            &watch_action_id,
+                                                            cognitod::incidents::outcome::RecoveryWatch::DEFAULT_MAX_WAIT,
+                                                            cognitod::incidents::outcome::RecoveryWatch::DEFAULT_POLL,
+                                                        )
+                                                        .await
+                                                        {
+                                                            info!(
+                                                                "[circuit_breaker] Incident #{} action never executed; outcome left unmeasured",
+                                                                id
+                                                            );
+                                                            return;
+                                                        }
+
                                                         let outcome = cognitod::incidents::outcome::observe_recovery(
                                                             || {
+                                                                // A failed read is not a low
+                                                                // reading: PsiMetrics yields zeros
+                                                                // when /proc/pressure is missing,
+                                                                // and zero would score as an
+                                                                // instant recovery.
                                                                 cognitod::utils::psi::PsiMetrics::read()
+                                                                    .ok()
                                                                     .map(|m| m.cpu_some_avg10)
-                                                                    .unwrap_or(0.0)
                                                             },
                                                             cognitod::incidents::outcome::RecoveryWatch::with_threshold(
                                                                 psi_threshold,
@@ -1115,14 +1145,25 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                                         )
                                                         .await;
 
-                                                        match outcome.recovery_time_ms {
-                                                            Some(ms) => info!(
-                                                                "[circuit_breaker] Incident #{} recovered after {}ms (PSI {:.1}%)",
-                                                                id, ms, outcome.psi_after
+                                                        if !outcome.is_measured() {
+                                                            warn!(
+                                                                "[circuit_breaker] Incident #{} outcome left unmeasured: pressure could not be read",
+                                                                id
+                                                            );
+                                                            return;
+                                                        }
+
+                                                        match (
+                                                            outcome.recovery_time_ms,
+                                                            outcome.psi_after,
+                                                        ) {
+                                                            (Some(ms), psi) => info!(
+                                                                "[circuit_breaker] Incident #{} recovered after {}ms (PSI {:?})",
+                                                                id, ms, psi
                                                             ),
-                                                            None => warn!(
-                                                                "[circuit_breaker] Incident #{} did not recover: PSI still {:.1}% after the watch window",
-                                                                id, outcome.psi_after
+                                                            (None, psi) => warn!(
+                                                                "[circuit_breaker] Incident #{} did not recover: PSI still {:?} after the watch window",
+                                                                id, psi
                                                             ),
                                                         }
 

--- a/cognitod/src/main.rs
+++ b/cognitod/src/main.rs
@@ -1088,6 +1088,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
                                             let store_clone = Arc::clone(store);
                                             let analyzer_clone = incident_analyzer_clone.clone();
+                                            let psi_threshold = cb_cfg.cpu_psi_threshold;
                                             tokio::spawn(async move {
                                                 if let Ok(id) = store_clone.insert(&incident).await
                                                 {
@@ -1095,6 +1096,46 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                                         "[circuit_breaker] Incident #{} recorded",
                                                         id
                                                     );
+
+                                                    // Watch what the action actually achieved.
+                                                    // Spawned separately from the analyzer: the
+                                                    // measurement is the part that must happen
+                                                    // whether or not a model is configured.
+                                                    let outcome_store = Arc::clone(&store_clone);
+                                                    tokio::spawn(async move {
+                                                        let outcome = cognitod::incidents::outcome::observe_recovery(
+                                                            || {
+                                                                cognitod::utils::psi::PsiMetrics::read()
+                                                                    .map(|m| m.cpu_some_avg10)
+                                                                    .unwrap_or(0.0)
+                                                            },
+                                                            cognitod::incidents::outcome::RecoveryWatch::with_threshold(
+                                                                psi_threshold,
+                                                            ),
+                                                        )
+                                                        .await;
+
+                                                        match outcome.recovery_time_ms {
+                                                            Some(ms) => info!(
+                                                                "[circuit_breaker] Incident #{} recovered after {}ms (PSI {:.1}%)",
+                                                                id, ms, outcome.psi_after
+                                                            ),
+                                                            None => warn!(
+                                                                "[circuit_breaker] Incident #{} did not recover: PSI still {:.1}% after the watch window",
+                                                                id, outcome.psi_after
+                                                            ),
+                                                        }
+
+                                                        if let Err(e) = outcome_store
+                                                            .record_outcome(id, &outcome)
+                                                            .await
+                                                        {
+                                                            warn!(
+                                                                "[circuit_breaker] Incident #{} outcome not recorded: {}",
+                                                                id, e
+                                                            );
+                                                        }
+                                                    });
 
                                                     if let Some(analyzer) = analyzer_clone {
                                                         tokio::spawn(async move {

--- a/cognitod/src/main.rs
+++ b/cognitod/src/main.rs
@@ -1266,8 +1266,13 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                         "[enforcement] kill pid={} signal={} failed: {}",
                                         pid, signal, err
                                     );
+                                    // `reject` is the operator's path and only
+                                    // applies to pending proposals; this action
+                                    // is Approved, so rejecting it fails and
+                                    // leaves it to be retried every second
+                                    // against a pid that may be reused.
                                     let _ = queue_clone
-                                        .reject(&action.id, "executor: kill failed".to_string())
+                                        .fail(&action.id, format!("kill failed: {err}"))
                                         .await;
                                 }
                             }

--- a/cognitod/src/main.rs
+++ b/cognitod/src/main.rs
@@ -1113,14 +1113,14 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                                             &outcome_queue,
                                                             &watch_action_id,
                                                             || {
-                                                                // A failed read is not a low
-                                                                // reading: PsiMetrics yields zeros
-                                                                // when /proc/pressure is missing,
-                                                                // and zero would score as an
-                                                                // instant recovery.
-                                                                cognitod::utils::psi::PsiMetrics::read()
-                                                                    .ok()
-                                                                    .map(|m| m.cpu_some_avg10)
+                                                                // Not `PsiMetrics::read`: that
+                                                                // degrades to zeros when
+                                                                // /proc/pressure is unreadable,
+                                                                // and zero is below every
+                                                                // threshold, so a failed read
+                                                                // would score as an instant
+                                                                // recovery.
+                                                                cognitod::utils::psi::PsiMetrics::read_cpu_some_avg10()
                                                             },
                                                             cognitod::incidents::outcome::RecoveryWatch::with_threshold(
                                                                 psi_threshold,
@@ -1253,10 +1253,23 @@ async fn main() -> Result<(), Box<dyn Error>> {
                         match action.action {
                             cognitod::enforcement::ActionType::KillProcess { pid, signal } => {
                                 info!("[enforcement] EXECUTING KILL pid={} signal={}", pid, signal);
-                                unsafe {
-                                    libc::kill(pid as i32, signal);
+                                let sent = unsafe { libc::kill(pid as i32, signal) };
+                                if sent == 0 {
+                                    let _ = queue_clone.complete(&action.id).await;
+                                } else {
+                                    // The process was already gone, or the
+                                    // signal was refused. Marking this executed
+                                    // would let a later fall in pressure be
+                                    // credited to a kill that never landed.
+                                    let err = std::io::Error::last_os_error();
+                                    warn!(
+                                        "[enforcement] kill pid={} signal={} failed: {}",
+                                        pid, signal, err
+                                    );
+                                    let _ = queue_clone
+                                        .reject(&action.id, "executor: kill failed".to_string())
+                                        .await;
                                 }
-                                let _ = queue_clone.complete(&action.id).await;
                             }
                         }
                     }

--- a/cognitod/src/main.rs
+++ b/cognitod/src/main.rs
@@ -1106,29 +1106,12 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                                     let outcome_store = Arc::clone(&store_clone);
                                                     let outcome_queue = Arc::clone(&watch_queue);
                                                     tokio::spawn(async move {
-                                                        // Nothing to verify until the action has
-                                                        // actually run. In monitor mode, and
-                                                        // whenever human approval is required —
-                                                        // both defaults — the proposal sits
-                                                        // pending, and timing a recovery against
-                                                        // it would credit the kill for pressure
-                                                        // that fell on its own.
-                                                        if !cognitod::incidents::outcome::await_execution(
+                                                        // Ordering — wait for execution, then
+                                                        // measure — lives in one tested function
+                                                        // rather than being a convention here.
+                                                        let Some(outcome) = cognitod::incidents::outcome::verify_action_outcome(
                                                             &outcome_queue,
                                                             &watch_action_id,
-                                                            cognitod::incidents::outcome::RecoveryWatch::DEFAULT_MAX_WAIT,
-                                                            cognitod::incidents::outcome::RecoveryWatch::DEFAULT_POLL,
-                                                        )
-                                                        .await
-                                                        {
-                                                            info!(
-                                                                "[circuit_breaker] Incident #{} action never executed; outcome left unmeasured",
-                                                                id
-                                                            );
-                                                            return;
-                                                        }
-
-                                                        let outcome = cognitod::incidents::outcome::observe_recovery(
                                                             || {
                                                                 // A failed read is not a low
                                                                 // reading: PsiMetrics yields zeros
@@ -1143,15 +1126,14 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                                                 psi_threshold,
                                                             ),
                                                         )
-                                                        .await;
-
-                                                        if !outcome.is_measured() {
-                                                            warn!(
-                                                                "[circuit_breaker] Incident #{} outcome left unmeasured: pressure could not be read",
+                                                        .await
+                                                        else {
+                                                            info!(
+                                                                "[circuit_breaker] Incident #{} left unverified: the action did not run, or pressure could not be read",
                                                                 id
                                                             );
                                                             return;
-                                                        }
+                                                        };
 
                                                         match (
                                                             outcome.recovery_time_ms,

--- a/cognitod/src/main.rs
+++ b/cognitod/src/main.rs
@@ -975,6 +975,11 @@ async fn main() -> Result<(), Box<dyn Error>> {
         let queue_clone = Arc::clone(queue);
         let incident_store_clone = incident_store.clone();
         let incident_analyzer_clone = incident_analyzer.clone();
+        // One verification at a time. The watcher reads system-wide pressure,
+        // so overlapping watches would each credit themselves with the same
+        // fall — and a second kill during a sustained incident is exactly when
+        // that happens.
+        let verification_slot = Arc::new(tokio::sync::Semaphore::new(1));
 
         tokio::spawn(async move {
             if !cb_cfg.enabled {
@@ -1090,6 +1095,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                             let analyzer_clone = incident_analyzer_clone.clone();
                                             let psi_threshold = cb_cfg.cpu_psi_threshold;
                                             let watch_queue = Arc::clone(&queue_clone);
+                                            let watch_slot = Arc::clone(&verification_slot);
                                             let watch_action_id = action_id.clone();
                                             tokio::spawn(async move {
                                                 if let Ok(id) = store_clone.insert(&incident).await
@@ -1105,6 +1111,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                                     // whether or not a model is configured.
                                                     let outcome_store = Arc::clone(&store_clone);
                                                     let outcome_queue = Arc::clone(&watch_queue);
+                                                    let outcome_slot = Arc::clone(&watch_slot);
                                                     tokio::spawn(async move {
                                                         // Ordering — wait for execution, then
                                                         // measure — lives in one tested function
@@ -1112,6 +1119,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                                         let Some(outcome) = cognitod::incidents::outcome::verify_action_outcome(
                                                             &outcome_queue,
                                                             &watch_action_id,
+                                                            &outcome_slot,
                                                             || {
                                                                 // Not `PsiMetrics::read`: that
                                                                 // degrades to zeros when

--- a/cognitod/src/utils/psi.rs
+++ b/cognitod/src/utils/psi.rs
@@ -83,6 +83,25 @@ impl PsiMetrics {
         Ok(metrics)
     }
 
+    /// CPU "some" pressure over the last 10s, or `None` if it could not be
+    /// read or parsed.
+    ///
+    /// [`PsiMetrics::read`] deliberately degrades to zeros so that a kernel
+    /// without PSI still yields a snapshot. That is the wrong contract for a
+    /// caller that must tell a *low* reading from a *missing* one: zero is
+    /// below every pressure threshold, so a failed read would otherwise look
+    /// like a perfectly healthy machine.
+    pub fn read_cpu_some_avg10() -> Option<f32> {
+        Self::read_cpu_some_avg10_from(&get_psi_path("cpu"))
+    }
+
+    /// The path-taking half, so the failure modes are testable without
+    /// touching `/proc` or process-wide environment.
+    fn read_cpu_some_avg10_from(path: &str) -> Option<f32> {
+        let content = fs::read_to_string(path).ok()?;
+        parse_avg10(&content, "some")
+    }
+
     /// Check if PSI is available on this kernel
     pub fn is_available() -> bool {
         Path::new(&get_psi_path("cpu")).exists()
@@ -123,6 +142,37 @@ fn parse_avg10(content: &str, line_prefix: &str) -> Option<f32> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn a_missing_pressure_file_reads_as_unknown_not_as_calm() {
+        // The distinction the recovery watcher depends on: absent is not zero.
+        assert_eq!(
+            PsiMetrics::read_cpu_some_avg10_from("/nonexistent/pressure/cpu"),
+            None
+        );
+    }
+
+    #[test]
+    fn a_malformed_pressure_file_reads_as_unknown() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("cpu");
+        std::fs::write(&path, "garbage that is not psi\n").unwrap();
+        assert_eq!(
+            PsiMetrics::read_cpu_some_avg10_from(path.to_str().unwrap()),
+            None
+        );
+    }
+
+    #[test]
+    fn a_well_formed_pressure_file_yields_its_reading() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("cpu");
+        std::fs::write(&path, "some avg10=42.50 avg60=3.45 avg300=2.11 total=1\n").unwrap();
+        assert_eq!(
+            PsiMetrics::read_cpu_some_avg10_from(path.to_str().unwrap()),
+            Some(42.5)
+        );
+    }
 
     #[test]
     fn test_parse_avg10_some() {

--- a/cognitod/tests/incident_outcome_eval.rs
+++ b/cognitod/tests/incident_outcome_eval.rs
@@ -53,7 +53,7 @@ async fn an_outcome_reaches_the_row_the_api_reads_back() {
         .record_outcome(
             id,
             &RecoveryOutcome {
-                psi_after: 4.5,
+                psi_after: Some(4.5),
                 recovery_time_ms: Some(3_000),
             },
         )
@@ -82,7 +82,7 @@ async fn watched_but_not_recovered_is_distinguishable_from_never_measured() {
         .record_outcome(
             measured,
             &RecoveryOutcome {
-                psi_after: 71.0,
+                psi_after: Some(71.0),
                 recovery_time_ms: None,
             },
         )
@@ -115,7 +115,7 @@ async fn the_stats_average_counts_only_incidents_that_recovered() {
         .record_outcome(
             fast,
             &RecoveryOutcome {
-                psi_after: 3.0,
+                psi_after: Some(3.0),
                 recovery_time_ms: Some(1_000),
             },
         )
@@ -125,7 +125,7 @@ async fn the_stats_average_counts_only_incidents_that_recovered() {
         .record_outcome(
             slow,
             &RecoveryOutcome {
-                psi_after: 6.0,
+                psi_after: Some(6.0),
                 recovery_time_ms: Some(3_000),
             },
         )
@@ -135,7 +135,7 @@ async fn the_stats_average_counts_only_incidents_that_recovered() {
         .record_outcome(
             never,
             &RecoveryOutcome {
-                psi_after: 80.0,
+                psi_after: Some(80.0),
                 recovery_time_ms: None,
             },
         )
@@ -164,7 +164,7 @@ async fn the_average_stays_absent_until_something_recovers() {
         .record_outcome(
             id,
             &RecoveryOutcome {
-                psi_after: 90.0,
+                psi_after: Some(90.0),
                 recovery_time_ms: None,
             },
         )

--- a/cognitod/tests/incident_outcome_eval.rs
+++ b/cognitod/tests/incident_outcome_eval.rs
@@ -1,0 +1,179 @@
+//! Eval suite for incident outcomes — the "did it work" half of an incident.
+//!
+//! `psi_after` and `recovery_time_ms` were in the schema from the start, were
+//! read back by the API, and were averaged into `avg_recovery_time_ms` on
+//! `/incidents/stats` — while nothing ever wrote them. These cases cover the
+//! write path end to end, and the distinction the columns now have to carry:
+//! "recovered", "watched and did not recover", and "never measured" are three
+//! different statements.
+
+use cognitod::incidents::outcome::RecoveryOutcome;
+use cognitod::incidents::{Incident, IncidentStore};
+
+fn incident() -> Incident {
+    Incident {
+        id: None,
+        timestamp: 1_732_242_135,
+        event_type: "circuit_breaker_cpu".to_string(),
+        psi_cpu: 75.21,
+        psi_memory: 12.34,
+        cpu_percent: 96.3,
+        load_avg: "26.00,24.20,21.30".to_string(),
+        action: "auto_kill".to_string(),
+        target_pid: Some(472_693),
+        target_name: Some("aggressive-stress.sh".to_string()),
+        system_snapshot: None,
+        llm_analysis: None,
+        llm_analyzed_at: None,
+        investigation: None,
+        recovery_time_ms: None,
+        psi_after: None,
+    }
+}
+
+async fn store() -> (tempfile::TempDir, IncidentStore) {
+    let dir = tempfile::tempdir().unwrap();
+    let store = IncidentStore::new(dir.path().join("incidents.db"))
+        .await
+        .expect("fresh database should initialise");
+    (dir, store)
+}
+
+#[tokio::test]
+async fn an_outcome_reaches_the_row_the_api_reads_back() {
+    let (_dir, store) = store().await;
+    let id = store.insert(&incident()).await.unwrap();
+
+    // Before: the state every incident has been stuck in.
+    let before = store.get(id).await.unwrap().expect("incident exists");
+    assert_eq!(before.psi_after, None);
+    assert_eq!(before.recovery_time_ms, None);
+
+    store
+        .record_outcome(
+            id,
+            &RecoveryOutcome {
+                psi_after: 4.5,
+                recovery_time_ms: Some(3_000),
+            },
+        )
+        .await
+        .unwrap();
+
+    let after = store.get(id).await.unwrap().expect("incident exists");
+    assert_eq!(after.recovery_time_ms, Some(3_000));
+    assert_eq!(after.psi_after, Some(4.5));
+
+    // The rest of the row must be untouched — the outcome is an addition to
+    // the record, not a rewrite of what was observed at the time.
+    assert_eq!(after.psi_cpu, before.psi_cpu);
+    assert_eq!(after.target_pid, before.target_pid);
+    assert_eq!(after.action, before.action);
+}
+
+#[tokio::test]
+async fn watched_but_not_recovered_is_distinguishable_from_never_measured() {
+    let (_dir, store) = store().await;
+
+    let measured = store.insert(&incident()).await.unwrap();
+    let unmeasured = store.insert(&incident()).await.unwrap();
+
+    store
+        .record_outcome(
+            measured,
+            &RecoveryOutcome {
+                psi_after: 71.0,
+                recovery_time_ms: None,
+            },
+        )
+        .await
+        .unwrap();
+
+    let watched = store.get(measured).await.unwrap().unwrap();
+    let untouched = store.get(unmeasured).await.unwrap().unwrap();
+
+    // Both have no recovery time, and they mean different things. The
+    // pressure reading is what separates "we looked and it stayed bad" from
+    // "nobody looked" — which is the difference between evidence a fix failed
+    // and no evidence at all.
+    assert_eq!(watched.recovery_time_ms, None);
+    assert_eq!(watched.psi_after, Some(71.0));
+    assert_eq!(untouched.recovery_time_ms, None);
+    assert_eq!(untouched.psi_after, None);
+}
+
+#[tokio::test]
+async fn the_stats_average_counts_only_incidents_that_recovered() {
+    let (_dir, store) = store().await;
+
+    let fast = store.insert(&incident()).await.unwrap();
+    let slow = store.insert(&incident()).await.unwrap();
+    let never = store.insert(&incident()).await.unwrap();
+    let _unmeasured = store.insert(&incident()).await.unwrap();
+
+    store
+        .record_outcome(
+            fast,
+            &RecoveryOutcome {
+                psi_after: 3.0,
+                recovery_time_ms: Some(1_000),
+            },
+        )
+        .await
+        .unwrap();
+    store
+        .record_outcome(
+            slow,
+            &RecoveryOutcome {
+                psi_after: 6.0,
+                recovery_time_ms: Some(3_000),
+            },
+        )
+        .await
+        .unwrap();
+    store
+        .record_outcome(
+            never,
+            &RecoveryOutcome {
+                psi_after: 80.0,
+                recovery_time_ms: None,
+            },
+        )
+        .await
+        .unwrap();
+
+    let stats = store.stats().await.unwrap();
+
+    // 1000 and 3000 average to 2000. The incident that never recovered must
+    // not be folded in as a slow recovery — that would make a failed action
+    // look like a sluggish one, which is the more flattering reading.
+    assert_eq!(stats.avg_recovery_time_ms, Some(2_000));
+    assert_eq!(stats.total, 4);
+}
+
+#[tokio::test]
+async fn the_average_stays_absent_until_something_recovers() {
+    let (_dir, store) = store().await;
+    let id = store.insert(&incident()).await.unwrap();
+
+    // The state that shipped: an endpoint reporting an average over a column
+    // nothing writes. It has to read as "no data", not as zero.
+    assert_eq!(store.stats().await.unwrap().avg_recovery_time_ms, None);
+
+    store
+        .record_outcome(
+            id,
+            &RecoveryOutcome {
+                psi_after: 90.0,
+                recovery_time_ms: None,
+            },
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        store.stats().await.unwrap().avg_recovery_time_ms,
+        None,
+        "an incident that never recovered contributes no recovery time"
+    );
+}


### PR DESCRIPTION
Roadmap A1 — the item the roadmap calls the highest-value thing on the list, and it starts as a bug fix.

## The bug
`psi_after` and `recovery_time_ms` have been in the schema since the first migration. They are read back by `/incidents/{id}` and averaged into `avg_recovery_time_ms` on `/incidents/stats`. **Nothing has ever written them**, so that endpoint has been reporting an average over a permanently NULL column.

## The measurement
After the circuit breaker acts, a watcher samples CPU pressure until it falls below **the same threshold that declared the incident** (`cb_cfg.cpu_psi_threshold`) — not a second number invented for the outcome. Recovery has to mean "the condition we acted on is no longer true", or the two halves of the record describe different things.

## Three states, deliberately kept distinct

| | `psi_after` | `recovery_time_ms` |
|---|---|---|
| recovered | written | time from the action |
| watched, did not recover | written | **NULL** |
| never measured | NULL | NULL |

The middle row is the point. Writing the window length for an incident that never recovered would claim a recovery that did not happen, and would let a failed action read as a merely slow one — the more flattering error. Keeping it NULL while recording the pressure reading preserves the difference between *evidence a fix failed* and *no evidence at all*.

That makes `avg_recovery_time_ms` mean "when it worked, how fast" rather than "how well it works", which is now documented on the field instead of being implied by a `WHERE ... IS NOT NULL` several layers away.

## Notes
- The watcher is spawned separately from the incident analyzer: measuring what happened must not depend on whether a model is configured.
- Sampling goes through a closure rather than reading `/proc` inline, so the behaviour is testable without a stalling machine.
- Unit tests use `start_paused = true`, so the 120-second window costs nothing to test.

## Tests (197 pass)
Deliberately **through the store**, not only as a pure function — twice recently I have shipped logic that was correct at one layer and never wired at the one above it:

- `an_outcome_reaches_the_row_the_api_reads_back` — insert, record, read back; also asserts the original observations are untouched
- `watched_but_not_recovered_is_distinguishable_from_never_measured`
- `the_stats_average_counts_only_incidents_that_recovered` — 1000ms and 3000ms average to 2000ms with an unrecovered incident present, not folded in
- `the_average_stays_absent_until_something_recovers`

Plus four on the watcher itself: timing from the action, never-recovers, immediate recovery not rounded up to a poll interval, and pressure exactly at the threshold counting as recovered.

## Not in scope
Attribution-triggered incidents (A3) still do not exist, so this measures circuit-breaker actions only. The same watcher is what A3 would reuse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EFtVtx4BiEYyKPwkdxqHgJ