### PR TITLE
feat(incidents): make the grounded investigation legible

### DIFF
--- a/cognitod/src/api/mod.rs
+++ b/cognitod/src/api/mod.rs
@@ -2005,8 +2005,19 @@ fn with_rendered_investigation(incident: &Incident) -> serde_json::Value {
     // A stored investigation that no longer parses is left exactly as it is.
     // It is evidence about a past incident, and silently dropping it would be
     // worse than showing it in the shape it was written.
+    // An explicit null says "this build tried and could not". Omitting the key
+    // instead would be indistinguishable from an older daemon that never had
+    // this field, and a client cannot tell an unreadable record from a version
+    // skew without that difference.
+    let unreadable = |mut value: serde_json::Value| {
+        if let Some(obj) = value.as_object_mut() {
+            obj.insert("investigation_rendered".into(), serde_json::Value::Null);
+        }
+        value
+    };
+
     let Ok(parsed) = serde_json::from_str::<cognitod::incidents::IncidentInvestigation>(raw) else {
-        return value;
+        return unreadable(value);
     };
 
     // Serde ignores unknown fields, so an investigation written by a newer
@@ -2015,7 +2026,7 @@ fn with_rendered_investigation(incident: &Incident) -> serde_json::Value {
     // semantics. `IncidentStore::get_investigation` already refuses those, and
     // this path has to agree or one row means two things depending on route.
     if parsed.schema_version > cognitod::incidents::investigation::SCHEMA_VERSION {
-        return value;
+        return unreadable(value);
     }
 
     if let Some(obj) = value.as_object_mut() {
@@ -3522,9 +3533,14 @@ mod tests {
 
         let value = super::with_rendered_investigation(&incident);
 
-        assert!(
-            value.get("investigation_rendered").is_none(),
-            "a future-version investigation must not be rendered with today's semantics"
+        // Present and null, not absent. Null says "this build tried and could
+        // not"; an absent key is what an *older* daemon returns, and a client
+        // that cannot tell them apart reports a staggered upgrade as a corrupt
+        // record.
+        assert_eq!(
+            value.get("investigation_rendered"),
+            Some(&serde_json::Value::Null),
+            "a future-version investigation must be refused explicitly, not silently"
         );
         assert!(
             value["investigation"].is_string(),

--- a/cognitod/src/api/mod.rs
+++ b/cognitod/src/api/mod.rs
@@ -2009,6 +2009,15 @@ fn with_rendered_investigation(incident: &Incident) -> serde_json::Value {
         return value;
     };
 
+    // Serde ignores unknown fields, so an investigation written by a newer
+    // build parses here and would be re-serialised at *this* version — quietly
+    // dropping whatever it knew and rendering the remainder with older
+    // semantics. `IncidentStore::get_investigation` already refuses those, and
+    // this path has to agree or one row means two things depending on route.
+    if parsed.schema_version > cognitod::incidents::investigation::SCHEMA_VERSION {
+        return value;
+    }
+
     if let Some(obj) = value.as_object_mut() {
         obj.insert(
             "investigation".into(),
@@ -3478,6 +3487,57 @@ mod tests {
 
         // The raw reply is still there, unchanged.
         assert_eq!(json["llm_analysis"], "raw model reply");
+    }
+
+    /// An investigation from a newer build must be handed back untouched.
+    ///
+    /// Serde ignores unknown fields, so it parses cleanly here; re-serialising
+    /// it would silently drop what that build knew and render the remainder
+    /// with this build's semantics. `IncidentStore::get_investigation` already
+    /// refuses those, and both routes have to agree.
+    #[tokio::test]
+    async fn an_investigation_from_a_newer_build_is_left_alone() {
+        let incident = cognitod::Incident {
+            id: Some(1),
+            timestamp: 1_732_242_135,
+            event_type: "circuit_breaker_cpu".to_string(),
+            psi_cpu: 75.21,
+            psi_memory: 12.34,
+            cpu_percent: 96.3,
+            load_avg: "26.00,24.20,21.30".to_string(),
+            action: "auto_kill".to_string(),
+            target_pid: Some(472_693),
+            target_name: Some("aggressive-stress.sh".to_string()),
+            system_snapshot: None,
+            llm_analysis: Some("raw model reply".to_string()),
+            llm_analyzed_at: Some(1_732_242_200),
+            investigation: Some(
+                r#"{"schema_version":99,"hypotheses":[],"discarded":[],
+                    "facts":[],"certainty_note":"from the future"}"#
+                    .to_string(),
+            ),
+            recovery_time_ms: None,
+            psi_after: None,
+        };
+
+        let value = super::with_rendered_investigation(&incident);
+
+        assert!(
+            value.get("investigation_rendered").is_none(),
+            "a future-version investigation must not be rendered with today's semantics"
+        );
+        assert!(
+            value["investigation"].is_string(),
+            "it must be handed back exactly as stored, got: {}",
+            value["investigation"]
+        );
+        assert!(
+            value["investigation"]
+                .as_str()
+                .unwrap()
+                .contains("from the future"),
+            "nothing may be dropped from it"
+        );
     }
 
     /// An incident with no investigation must not grow empty fields that read

--- a/cognitod/src/api/mod.rs
+++ b/cognitod/src/api/mod.rs
@@ -1968,7 +1968,7 @@ async fn get_incidents(
 async fn get_incident_by_id(
     Path(id): Path<i64>,
     State(app): State<Arc<AppState>>,
-) -> Result<Json<Incident>, (StatusCode, String)> {
+) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
     let store = app.incident_store.as_ref().ok_or_else(|| {
         (
             StatusCode::SERVICE_UNAVAILABLE,
@@ -1982,7 +1982,42 @@ async fn get_incident_by_id(
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
         .ok_or_else(|| (StatusCode::NOT_FOUND, "Incident not found".to_string()))?;
 
-    Ok(Json(incident))
+    Ok(Json(with_rendered_investigation(&incident)))
+}
+
+/// Serialises an incident with its investigation made legible.
+///
+/// The column holds JSON as text, so the endpoint used to return it as one
+/// escaped string — the grounding work was there and unreadable. This parses it
+/// into a real object and adds `investigation_rendered`, the same text
+/// `IncidentInvestigation::render` produces.
+///
+/// Rendering happens here rather than in each client for the reason the
+/// grounding exists at all: every cited fact is resolved through the daemon's
+/// own wording, so no consumer can restate a fact while claiming to quote it.
+fn with_rendered_investigation(incident: &Incident) -> serde_json::Value {
+    let mut value = serde_json::to_value(incident).unwrap_or_default();
+
+    let Some(raw) = incident.investigation.as_deref() else {
+        return value;
+    };
+
+    // A stored investigation that no longer parses is left exactly as it is.
+    // It is evidence about a past incident, and silently dropping it would be
+    // worse than showing it in the shape it was written.
+    let Ok(parsed) = serde_json::from_str::<cognitod::incidents::IncidentInvestigation>(raw) else {
+        return value;
+    };
+
+    if let Some(obj) = value.as_object_mut() {
+        obj.insert(
+            "investigation".into(),
+            serde_json::to_value(&parsed).unwrap_or_default(),
+        );
+        obj.insert("investigation_rendered".into(), parsed.render().into());
+    }
+
+    value
 }
 
 /// GET /incidents/stats - Get incident statistics
@@ -3323,6 +3358,195 @@ mod tests {
             reopened["attributions"].as_array().unwrap().len(),
             1,
             "an event link must stay event-specific when reopened: {link}"
+        );
+    }
+
+    /// The grounding work has to reach a human. Until now `/incidents/{id}`
+    /// returned the investigation as one escaped JSON string and
+    /// `IncidentInvestigation::render` was called only from tests.
+    #[tokio::test]
+    async fn an_incident_exposes_its_investigation_as_text_and_structure() {
+        use cognitod::incidents::investigation::{Fact, parse_and_ground};
+
+        let dir = tempfile::tempdir().unwrap();
+        let store = Arc::new(
+            cognitod::IncidentStore::new(dir.path().join("incidents.db"))
+                .await
+                .unwrap(),
+        );
+
+        let facts = vec![
+            Fact::new("f1", "CPU usage was 96.3%"),
+            Fact::new("f2", "CPU pressure stall was 75.2%"),
+        ];
+        let grounded = parse_and_ground(
+            r#"{"hypotheses":[{"reason_code":"cpu_spin",
+               "statement":"A single runaway process held the CPU",
+               "supporting_fact_ids":["f1","f2"],
+               "proposed_action":"Inspect the deployment"}]}"#,
+            facts,
+        )
+        .expect("the reply grounds");
+
+        let mut incident = cognitod::Incident {
+            id: None,
+            timestamp: 1_732_242_135,
+            event_type: "circuit_breaker_cpu".to_string(),
+            psi_cpu: 75.21,
+            psi_memory: 12.34,
+            cpu_percent: 96.3,
+            load_avg: "26.00,24.20,21.30".to_string(),
+            action: "auto_kill".to_string(),
+            target_pid: Some(472_693),
+            target_name: Some("aggressive-stress.sh".to_string()),
+            system_snapshot: None,
+            llm_analysis: None,
+            llm_analyzed_at: None,
+            investigation: None,
+            recovery_time_ms: None,
+            psi_after: None,
+        };
+        // The real flow: an incident is recorded first, and the analysis lands
+        // afterwards — `insert` deliberately does not write those columns.
+        let id = store.insert(&incident).await.unwrap();
+        incident.id = Some(id);
+        store
+            .add_llm_analysis(
+                id,
+                &cognitod::incidents::AnalysisOutcome {
+                    raw_response: "raw model reply".to_string(),
+                    investigation: Some(grounded),
+                    parse_error: None,
+                },
+            )
+            .await
+            .unwrap();
+
+        let app_state = Arc::new(AppState {
+            context: Arc::new(ContextStore::new(Duration::from_secs(60), 10, None)),
+            metrics: Arc::new(Metrics::new()),
+            alerts: None,
+            insights: Arc::new(InsightStore::new(16, None)),
+            offline: Arc::new(OfflineGuard::new(false)),
+            transport: "perf",
+            probe_state: ProbeState::disabled(),
+            require_kernel_instrumentation: true,
+            enforcement: None,
+            reasoner: ReasonerConfig::default(),
+            prometheus_enabled: false,
+            alert_history: Arc::new(AlertHistory::new(16)),
+            auth_token: None,
+            incident_store: Some(Arc::clone(&store)),
+            k8s: None,
+            blame_metrics: Arc::new(cognitod::attribution::BlameMetrics::new("test-node")),
+        });
+
+        let response = super::all_routes(app_state)
+            .oneshot(
+                Request::builder()
+                    .uri(format!("/incidents/{id}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+        // Structure, not an escaped string: a client can walk the hypotheses.
+        assert!(
+            json["investigation"]["hypotheses"][0]["statement"]
+                .as_str()
+                .unwrap()
+                .contains("runaway process"),
+            "investigation must be an object, got: {}",
+            json["investigation"]
+        );
+
+        // And the rendered form, where every citation is the daemon's wording.
+        let rendered = json["investigation_rendered"].as_str().unwrap();
+        assert!(rendered.contains("cpu_spin"), "{rendered}");
+        assert!(
+            rendered.contains("CPU pressure stall was 75.2%"),
+            "cited facts must be quoted from the daemon: {rendered}"
+        );
+        assert!(rendered.contains("Inspect the deployment"), "{rendered}");
+
+        // The raw reply is still there, unchanged.
+        assert_eq!(json["llm_analysis"], "raw model reply");
+    }
+
+    /// An incident with no investigation must not grow empty fields that read
+    /// as "analysed, found nothing".
+    #[tokio::test]
+    async fn an_incident_without_an_investigation_gains_no_rendered_field() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Arc::new(
+            cognitod::IncidentStore::new(dir.path().join("incidents.db"))
+                .await
+                .unwrap(),
+        );
+
+        let incident = cognitod::Incident {
+            id: None,
+            timestamp: 1_732_242_135,
+            event_type: "circuit_breaker_cpu".to_string(),
+            psi_cpu: 75.21,
+            psi_memory: 12.34,
+            cpu_percent: 96.3,
+            load_avg: "26.00,24.20,21.30".to_string(),
+            action: "auto_kill".to_string(),
+            target_pid: Some(472_693),
+            target_name: Some("aggressive-stress.sh".to_string()),
+            system_snapshot: None,
+            llm_analysis: None,
+            llm_analyzed_at: None,
+            investigation: None,
+            recovery_time_ms: None,
+            psi_after: None,
+        };
+        let id = store.insert(&incident).await.unwrap();
+
+        let app_state = Arc::new(AppState {
+            context: Arc::new(ContextStore::new(Duration::from_secs(60), 10, None)),
+            metrics: Arc::new(Metrics::new()),
+            alerts: None,
+            insights: Arc::new(InsightStore::new(16, None)),
+            offline: Arc::new(OfflineGuard::new(false)),
+            transport: "perf",
+            probe_state: ProbeState::disabled(),
+            require_kernel_instrumentation: true,
+            enforcement: None,
+            reasoner: ReasonerConfig::default(),
+            prometheus_enabled: false,
+            alert_history: Arc::new(AlertHistory::new(16)),
+            auth_token: None,
+            incident_store: Some(Arc::clone(&store)),
+            k8s: None,
+            blame_metrics: Arc::new(cognitod::attribution::BlameMetrics::new("test-node")),
+        });
+
+        let response = super::all_routes(app_state)
+            .oneshot(
+                Request::builder()
+                    .uri(format!("/incidents/{id}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+        assert!(
+            json.get("investigation_rendered").is_none(),
+            "no investigation means no rendered field, not an empty one"
         );
     }
 

--- a/cognitod/src/incidents/investigation.rs
+++ b/cognitod/src/incidents/investigation.rs
@@ -171,6 +171,13 @@ impl IncidentInvestigation {
 
     /// Renders the investigation for a human, resolving every citation through
     /// the daemon's own text rather than anything the model wrote.
+    ///
+    /// Every interpolated scalar is forced onto one line first. The layout
+    /// *is* the guarantee here — a line beginning `supports:` means the daemon
+    /// resolved that citation — so a statement containing a newline could
+    /// otherwise print a fabricated citation that reads exactly like a real
+    /// one. The model authors the statement, and fact text quotes process
+    /// names, so both sides of this are untrusted.
     pub fn render(&self) -> String {
         let mut out = String::new();
 
@@ -187,21 +194,21 @@ impl IncidentInvestigation {
                 "{}. [{}] {}\n",
                 i + 1,
                 hypothesis.reason_code.as_str(),
-                hypothesis.statement
+                single_line(&hypothesis.statement)
             ));
 
             for id in &hypothesis.supporting_fact_ids {
                 if let Some(statement) = self.fact_statement(id) {
-                    out.push_str(&format!("   supports:    {statement}\n"));
+                    out.push_str(&format!("   supports:    {}\n", single_line(statement)));
                 }
             }
             for id in &hypothesis.contradicting_fact_ids {
                 if let Some(statement) = self.fact_statement(id) {
-                    out.push_str(&format!("   contradicts: {statement}\n"));
+                    out.push_str(&format!("   contradicts: {}\n", single_line(statement)));
                 }
             }
             if let Some(action) = &hypothesis.proposed_action {
-                out.push_str(&format!("   proposed:    {action}\n"));
+                out.push_str(&format!("   proposed:    {}\n", single_line(action)));
             }
             if let Some(confidence) = hypothesis.model_stated_confidence {
                 out.push_str(&format!(
@@ -292,6 +299,27 @@ pub fn parse_and_ground(text: &str, facts: Vec<Fact>) -> Result<IncidentInvestig
         serde_json::from_str(&text[start..=end]).map_err(|e| e.to_string())?;
 
     Ok(ground(proposed, facts))
+}
+
+/// Flattens a value onto one line so it cannot forge the layout around it.
+///
+/// Line breaks and tabs become their escaped spelling rather than being
+/// dropped: the operator should see that the text contained them, since a
+/// statement trying to fake a citation is itself worth noticing. Other control
+/// characters are removed — they carry no meaning here and ESC begins the
+/// terminal-escape family.
+fn single_line(text: &str) -> String {
+    let mut out = String::with_capacity(text.len());
+    for c in text.chars() {
+        match c {
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            c if c.is_control() => {}
+            c => out.push(c),
+        }
+    }
+    out
 }
 
 #[cfg(test)]
@@ -407,6 +435,68 @@ mod tests {
         );
 
         assert_eq!(out.hypotheses[0].model_stated_confidence, None);
+    }
+
+    /// The layout carries the guarantee: a line starting `supports:` means the
+    /// daemon resolved that citation. A statement with an embedded newline
+    /// could otherwise print a line indistinguishable from a real one.
+    #[test]
+    fn a_statement_cannot_forge_a_citation_line() {
+        let out = ground(
+            proposed(
+                r#"{"hypotheses":[{"reason_code":"cpu_spin",
+                   "statement":"Runaway loop\n   supports:    the disk was on fire",
+                   "supporting_fact_ids":["f1"]}]}"#,
+            ),
+            facts(),
+        );
+
+        let report = out.render();
+        let forged: Vec<&str> = report
+            .lines()
+            .filter(|l| l.trim_start().starts_with("supports:"))
+            .collect();
+
+        assert_eq!(
+            forged.len(),
+            1,
+            "only the daemon's own citation may appear as a supports line: {report}"
+        );
+        assert!(
+            forged[0].contains("CPU usage was 96.3%"),
+            "the surviving line must be the resolved fact: {report}"
+        );
+        assert!(
+            !report.contains("\n   supports:    the disk"),
+            "the injected break must not survive as layout: {report}"
+        );
+        // The text is still shown, with the break visible as an escape, so an
+        // operator can see the attempt rather than a silently trimmed line.
+        assert!(report.contains("Runaway loop\\n"), "{report}");
+    }
+
+    /// Facts quote process names, so the same injection arrives from the other
+    /// direction — through text the daemon itself wrote.
+    #[test]
+    fn a_fact_cannot_forge_a_citation_line_either() {
+        let out = ground(
+            proposed(
+                r#"{"hypotheses":[{"reason_code":"cpu_spin","statement":"Runaway loop",
+                   "supporting_fact_ids":["f1"]}]}"#,
+            ),
+            vec![Fact::new(
+                "f1",
+                "process evil\n   contradicts: nothing was wrong was busy",
+            )],
+        );
+
+        let report = out.render();
+        assert!(
+            !report
+                .lines()
+                .any(|l| l.trim_start().starts_with("contradicts:")),
+            "a process name must not be able to add a contradicts line: {report}"
+        );
     }
 
     #[test]

--- a/linnix-cli/src/explain.rs
+++ b/linnix-cli/src/explain.rs
@@ -23,6 +23,11 @@ pub struct IncidentView {
     pub cpu_percent: f32,
     /// Present only when a grounded investigation exists.
     pub investigation_rendered: Option<String>,
+    /// The stored investigation itself. Present-but-unrendered means the
+    /// daemon kept the row and could not read it — a different situation from
+    /// there being no investigation at all, and one the operator has to be
+    /// told about rather than shown a plausible wrong explanation.
+    pub investigation: Option<serde_json::Value>,
     /// The model's reply verbatim. Kept even when nothing grounded, which is
     /// the only way to tell a broken endpoint from a model that answers badly.
     pub llm_analysis: Option<String>,
@@ -78,24 +83,48 @@ pub fn render(incident: &IncidentView, id: &str, color: bool) -> String {
     match &incident.investigation_rendered {
         Some(rendered) => {
             out.push_str(&format!("{}\n", heading("Investigation")));
-            out.push_str(rendered);
+            // Facts quote process names, which are attacker-controlled, and
+            // hypothesis text comes from a model. Either can carry escape
+            // sequences that rewrite what the terminal displays — including
+            // overwriting the evidence above this line.
+            out.push_str(&strip_terminal_controls(rendered));
         }
         None => {
-            // Saying which of the two happened matters: an operator debugging a
-            // silent reasoner needs to know whether the model was never asked
-            // or answered in a way nothing could be checked against.
-            out.push_str(match incident.llm_analysis {
-                Some(_) => {
-                    "No hypothesis survived grounding for this incident: the model \
-                            replied, but nothing it claimed could be checked against the \
-                            facts the daemon supplied.\n"
+            // Three distinct situations, and telling an operator the wrong one
+            // sends them to debug the wrong thing.
+            out.push_str(match (&incident.investigation, &incident.llm_analysis) {
+                // Stored but unrendered: the daemon kept the row and could not
+                // read it — corrupt, or written by a newer build.
+                (Some(_), _) => {
+                    "This incident has a stored investigation the daemon could not read: \
+                     it is corrupt, or was written by a newer version. The raw record is \
+                     still on the incident.\n"
                 }
-                None => "No analysis has run for this incident.\n",
+                (None, Some(_)) => {
+                    "No hypothesis survived grounding for this incident: the model \
+                     replied, but nothing it claimed could be checked against the \
+                     facts the daemon supplied.\n"
+                }
+                (None, None) => "No analysis has run for this incident.\n",
             });
         }
     }
 
     out
+}
+
+/// Removes control characters that a terminal would act on rather than print.
+///
+/// Newline and tab are kept because the daemon's rendering uses them for
+/// layout. Everything else in the C0 range, plus DEL, is dropped — ESC is the
+/// entry point for ANSI and OSC sequences, so removing it disarms the whole
+/// family without needing to parse it. The wording itself is untouched, which
+/// matters: this text is evidence, and rewriting it would defeat the point of
+/// resolving citations through the daemon.
+fn strip_terminal_controls(text: &str) -> String {
+    text.chars()
+        .filter(|c| *c == '\n' || *c == '\t' || (!c.is_control()))
+        .collect()
 }
 
 pub async fn run_explain(
@@ -138,6 +167,7 @@ mod tests {
             psi_cpu: 75.2,
             cpu_percent: 96.3,
             investigation_rendered: None,
+            investigation: None,
             llm_analysis: None,
             psi_after: None,
             recovery_time_ms: None,
@@ -165,6 +195,44 @@ mod tests {
         let never = incident();
         let out = render(&never, "7", false);
         assert!(out.contains("No analysis has run"), "{out}");
+    }
+
+    #[test]
+    fn an_unreadable_investigation_is_not_reported_as_ungrounded() {
+        // The daemon keeps the row and omits the rendering when it cannot
+        // parse it. Reading only `llm_analysis` here would tell the operator
+        // the model failed to ground, sending them to debug the reasoner when
+        // the real problem is a corrupt or newer-version record.
+        let mut view = incident();
+        view.llm_analysis = Some("some prose".to_string());
+        view.investigation = Some(serde_json::json!({"schema_version": 99}));
+
+        let out = render(&view, "7", false);
+        assert!(out.contains("could not read"), "{out}");
+        assert!(
+            !out.contains("No hypothesis survived grounding"),
+            "an unreadable record must not be reported as a grounding failure: {out}"
+        );
+    }
+
+    #[test]
+    fn terminal_controls_in_evidence_are_disarmed() {
+        let mut view = incident();
+        // A process name is attacker-controlled and reaches the facts verbatim.
+        view.investigation_rendered = Some(
+            "1. [cpu_spin] Runaway loop\n   supports:    process \u{1b}[2J\u{1b}[Hevil was busy\n"
+                .to_string(),
+        );
+
+        let out = render(&view, "7", false);
+        assert!(
+            !out.contains('\u{1b}'),
+            "escape sequences must not reach the terminal: {out:?}"
+        );
+        // The wording survives — this is evidence, not decoration.
+        assert!(out.contains("Runaway loop"), "{out}");
+        assert!(out.contains("evil was busy"), "{out}");
+        assert!(out.contains("supports:"), "{out}");
     }
 
     #[test]

--- a/linnix-cli/src/explain.rs
+++ b/linnix-cli/src/explain.rs
@@ -9,7 +9,7 @@
 
 use colored::*;
 use reqwest::Client;
-use serde::{Deserialize, Deserializer};
+use serde::Deserialize;
 use std::error::Error;
 
 #[derive(Deserialize, Debug)]

--- a/linnix-cli/src/explain.rs
+++ b/linnix-cli/src/explain.rs
@@ -68,7 +68,7 @@ impl IncidentView {
 }
 
 /// Renders the incident. Returned rather than printed so tests can read it.
-pub fn render(incident: &IncidentView, id: &str, color: bool) -> String {
+pub fn render(incident: &IncidentView, id: i64, color: bool) -> String {
     let heading = |s: &str| {
         if color {
             s.bold().to_string()
@@ -181,7 +181,7 @@ fn strip_terminal_controls(text: &str) -> String {
 pub async fn run_explain(
     client: &Client,
     base: &str,
-    id: &str,
+    id: i64,
     color: bool,
 ) -> Result<(), Box<dyn Error>> {
     let resp = client
@@ -231,7 +231,7 @@ mod tests {
         view.investigation_rendered =
             Some("1. [cpu_spin] A runaway loop\n   supports:    CPU usage was 96.3%\n".to_string());
 
-        let out = render(&view, "7", false);
+        let out = render(&view, 7, false);
         assert!(out.contains("1. [cpu_spin] A runaway loop"), "{out}");
         assert!(out.contains("supports:    CPU usage was 96.3%"), "{out}");
     }
@@ -240,11 +240,11 @@ mod tests {
     fn a_reply_that_did_not_ground_is_distinguished_from_no_analysis() {
         let mut answered = incident();
         answered.llm_analysis = Some("some prose".to_string());
-        let out = render(&answered, "7", false);
+        let out = render(&answered, 7, false);
         assert!(out.contains("nothing it claimed could be checked"), "{out}");
 
         let never = incident();
-        let out = render(&never, "7", false);
+        let out = render(&never, 7, false);
         assert!(out.contains("No analysis has run"), "{out}");
     }
 
@@ -258,7 +258,7 @@ mod tests {
         view.llm_analysis = Some("some prose".to_string());
         view.investigation = Some(serde_json::json!({"schema_version": 99}));
 
-        let out = render(&view, "7", false);
+        let out = render(&view, 7, false);
         assert!(out.contains("could not read"), "{out}");
         assert!(
             !out.contains("No hypothesis survived grounding"),
@@ -277,7 +277,7 @@ mod tests {
         view.action = "auto_kill\u{7}".to_string();
         view.llm_analysis = Some("prose\u{1b}[2J".to_string());
 
-        let out = render(&view.sanitized(), "7", false);
+        let out = render(&view.sanitized(), 7, false);
 
         assert!(
             !out.contains('\u{1b}') && !out.contains('\u{7}'),
@@ -290,6 +290,23 @@ mod tests {
     }
 
     #[test]
+    fn the_incident_id_cannot_carry_layout_at_all() {
+        // The id is typed `i64` at the command line, so a value like
+        // `7#\n  Afterwards: recovered` — which the daemon would still answer,
+        // since a URL fragment is never sent — cannot reach this function.
+        // This pins the type rather than a sanitizer: the class is impossible,
+        // not escaped.
+        let out = render(&incident().sanitized(), 7, false);
+        assert!(out.contains("Incident: #7 "), "{out}");
+
+        let forged: Vec<&str> = out
+            .lines()
+            .filter(|l| l.trim_start().starts_with("Afterwards:"))
+            .collect();
+        assert_eq!(forged.len(), 1, "one outcome row only: {out}");
+    }
+
+    #[test]
     fn a_process_name_cannot_forge_a_header_row() {
         // Removing escapes is not enough: a bare newline in `proc.comm` splits
         // the Action line and the second half reads as a header the daemon
@@ -298,7 +315,7 @@ mod tests {
         let mut view = incident();
         view.target_name = Some("innocent\n  Afterwards:  recovered after 0.1s".to_string());
 
-        let out = render(&view.sanitized(), "7", false);
+        let out = render(&view.sanitized(), 7, false);
 
         let forged: Vec<&str> = out
             .lines()
@@ -323,7 +340,7 @@ mod tests {
         // not under a test harness, so the override is what makes this assert
         // anything at all.
         colored::control::set_override(true);
-        let out = render(&incident().sanitized(), "7", true);
+        let out = render(&incident().sanitized(), 7, true);
         colored::control::unset_override();
 
         assert!(
@@ -341,7 +358,7 @@ mod tests {
                 .to_string(),
         );
 
-        let out = render(&view.sanitized(), "7", false);
+        let out = render(&view.sanitized(), 7, false);
         assert!(
             !out.contains('\u{1b}'),
             "escape sequences must not reach the terminal: {out:?}"
@@ -357,13 +374,13 @@ mod tests {
         let mut recovered = incident();
         recovered.recovery_time_ms = Some(3_200);
         recovered.psi_after = Some(4.1);
-        assert!(render(&recovered, "7", false).contains("recovered after 3.2s"));
+        assert!(render(&recovered, 7, false).contains("recovered after 3.2s"));
 
         let mut stuck = incident();
         stuck.psi_after = Some(71.0);
-        assert!(render(&stuck, "7", false).contains("did not recover"));
+        assert!(render(&stuck, 7, false).contains("did not recover"));
 
         // Never measured must not read as a finding.
-        assert!(render(&incident(), "7", false).contains("not measured"));
+        assert!(render(&incident(), 7, false).contains("not measured"));
     }
 }

--- a/linnix-cli/src/explain.rs
+++ b/linnix-cli/src/explain.rs
@@ -167,10 +167,17 @@ pub fn render(incident: &IncidentView, id: i64, color: bool) -> String {
                      version that cannot render it. Upgrade cognitod, or read the raw \
                      record on the incident.\n"
                 }
+                // Not a grounding failure. A reply that parses but whose
+                // hypotheses are all discarded is still *stored* as an
+                // investigation and renders its own "no grounded hypothesis"
+                // message above. Reaching here means the reply could not be
+                // parsed at all — malformed JSON, or prose where an object was
+                // expected — so pointing the operator at the model's evidence
+                // would send them to debug the wrong half of it.
                 (None, Some(_)) => {
-                    "No hypothesis survived grounding for this incident: the model \
-                     replied, but nothing it claimed could be checked against the \
-                     facts the daemon supplied.\n"
+                    "The model replied, but the response could not be parsed into an \
+                     investigation: it was malformed, or not in the expected shape. \
+                     The raw reply is on the incident.\n"
                 }
                 (None, None) => "No analysis has run for this incident.\n",
             });
@@ -273,15 +280,46 @@ mod tests {
     }
 
     #[test]
-    fn a_reply_that_did_not_ground_is_distinguished_from_no_analysis() {
+    fn an_unparseable_reply_is_named_as_such_not_as_a_grounding_failure() {
+        // A reply whose hypotheses are all discarded still parses, so it is
+        // stored and renders its own "no grounded hypothesis" message. A
+        // stored reply with no investigation means the opposite: the response
+        // could not be parsed. Telling an operator their model produced
+        // uncheckable evidence would send them to debug its reasoning when the
+        // problem is its output format.
         let mut answered = incident();
-        answered.llm_analysis = Some("some prose".to_string());
+        answered.llm_analysis = Some("I think the CPU was busy.".to_string());
+
         let out = render(&answered, 7, false);
-        assert!(out.contains("nothing it claimed could be checked"), "{out}");
+        assert!(out.contains("could not be parsed"), "{out}");
+        assert!(
+            !out.contains("nothing it claimed could be checked"),
+            "a parse failure is not a grounding failure: {out}"
+        );
 
         let never = incident();
         let out = render(&never, 7, false);
         assert!(out.contains("No analysis has run"), "{out}");
+    }
+
+    /// The genuine grounding failure travels the other path: it is stored, so
+    /// it arrives as a rendering rather than as an absence.
+    #[test]
+    fn a_grounding_failure_arrives_as_the_daemons_own_rendering() {
+        let mut view = incident();
+        view.llm_analysis = Some("valid but unsupported".to_string());
+        view.investigation = Some(serde_json::json!({"schema_version": 1, "hypotheses": []}));
+        view.investigation_rendered = Some(Some(
+            "No grounded hypothesis for this incident.\n1 hypothesis discarded: cited unknown facts.\n"
+                .to_string(),
+        ));
+
+        let out = render(&view.sanitized(), 7, false);
+        assert!(out.contains("No grounded hypothesis"), "{out}");
+        assert!(
+            !out.contains("could not be parsed"),
+            "a stored investigation is not a parse failure: {out}"
+        );
     }
 
     /// The three states, taken through actual deserialization.

--- a/linnix-cli/src/explain.rs
+++ b/linnix-cli/src/explain.rs
@@ -9,7 +9,7 @@
 
 use colored::*;
 use reqwest::Client;
-use serde::Deserialize;
+use serde::{Deserialize, Deserializer};
 use std::error::Error;
 
 #[derive(Deserialize, Debug)]
@@ -25,12 +25,14 @@ pub struct IncidentView {
     ///
     /// Three states that have to stay distinct: a string is the rendering; an
     /// explicit `null` means this daemon tried and could not read the stored
-    /// record; an **absent** key means the daemon predates this field. Typed
-    /// as `Value` because serde cannot otherwise tell a null from a missing
-    /// key, and collapsing those two reports a version skew as a corrupt
-    /// record.
-    #[serde(default)]
-    pub investigation_rendered: Option<serde_json::Value>,
+    /// record; an **absent** key means the daemon predates this field.
+    ///
+    /// A double option because serde collapses an explicit `null` to `None`
+    /// exactly as it does a missing key — `Option<T>` of any inner type cannot
+    /// express this, which is how a real unreadable record got reported as a
+    /// version skew. Outer `None` is "key absent"; `Some(None)` is "null".
+    #[serde(default, deserialize_with = "deserialize_present")]
+    pub investigation_rendered: Option<Option<String>>,
     /// The stored investigation itself. Present-but-unrendered means the
     /// daemon kept the row and could not read it — a different situation from
     /// there being no investigation at all, and one the operator has to be
@@ -41,6 +43,19 @@ pub struct IncidentView {
     pub llm_analysis: Option<String>,
     pub psi_after: Option<f32>,
     pub recovery_time_ms: Option<i64>,
+}
+
+/// Keeps `null` distinguishable from a missing key.
+///
+/// Serde's own `Option` impl answers "was it null *or* absent" with one
+/// `None`. Wrapping it means the outer layer records presence and the inner
+/// one records the value, which is the only way to carry a three-state field
+/// over JSON.
+fn deserialize_present<'de, D>(deserializer: D) -> Result<Option<Option<String>>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    Option::<String>::deserialize(deserializer).map(Some)
 }
 
 impl IncidentView {
@@ -65,12 +80,9 @@ impl IncidentView {
             // The one field whose newlines *are* the daemon's layout. Its
             // scalars were already flattened server-side before being placed
             // into that layout, so only escape sequences need removing here.
-            investigation_rendered: self.investigation_rendered.map(|v| match v {
-                serde_json::Value::String(s) => {
-                    serde_json::Value::String(strip_terminal_controls(&s))
-                }
-                other => other,
-            }),
+            investigation_rendered: self
+                .investigation_rendered
+                .map(|inner| inner.as_deref().map(strip_terminal_controls)),
             llm_analysis: self.llm_analysis.as_deref().map(single_line),
             ..self
         }
@@ -125,7 +137,7 @@ pub fn render(incident: &IncidentView, id: i64, color: bool) -> String {
     match incident
         .investigation_rendered
         .as_ref()
-        .and_then(|v| v.as_str())
+        .and_then(|inner| inner.as_deref())
     {
         Some(rendered) => {
             out.push_str(&format!("{}\n", heading("Investigation")));
@@ -251,8 +263,8 @@ mod tests {
     #[test]
     fn the_daemons_rendering_is_printed_verbatim() {
         let mut view = incident();
-        view.investigation_rendered = Some(serde_json::json!(
-            "1. [cpu_spin] A runaway loop\n   supports:    CPU usage was 96.3%\n"
+        view.investigation_rendered = Some(Some(
+            "1. [cpu_spin] A runaway loop\n   supports:    CPU usage was 96.3%\n".to_string(),
         ));
 
         let out = render(&view, 7, false);
@@ -270,6 +282,59 @@ mod tests {
         let never = incident();
         let out = render(&never, 7, false);
         assert!(out.contains("No analysis has run"), "{out}");
+    }
+
+    /// The three states, taken through actual deserialization.
+    ///
+    /// The previous version of this contract was tested by building the struct
+    /// by hand, which is exactly why it passed while being broken: serde
+    /// collapses an explicit `null` into `None` just as it does a missing key,
+    /// and a hand-built value never exercises that.
+    #[test]
+    fn the_wire_format_carries_all_three_states() {
+        let base =
+            r#""timestamp":1,"event_type":"cb","action":"kill","psi_cpu":1.0,"cpu_percent":1.0"#;
+
+        let rendered: IncidentView =
+            serde_json::from_str(&format!(r#"{{{base},"investigation_rendered":"text"}}"#))
+                .unwrap();
+        assert_eq!(
+            rendered.investigation_rendered,
+            Some(Some("text".to_string())),
+            "a string is the rendering"
+        );
+
+        let unreadable: IncidentView =
+            serde_json::from_str(&format!(r#"{{{base},"investigation_rendered":null}}"#)).unwrap();
+        assert_eq!(
+            unreadable.investigation_rendered,
+            Some(None),
+            "an explicit null means the daemon tried and could not"
+        );
+
+        let older: IncidentView = serde_json::from_str(&format!(r#"{{{base}}}"#)).unwrap();
+        assert_eq!(
+            older.investigation_rendered, None,
+            "an absent key means the daemon predates the field"
+        );
+    }
+
+    /// And the diagnosis that depends on it, driven from JSON rather than from
+    /// a struct literal.
+    #[test]
+    fn an_unreadable_record_from_the_wire_is_not_called_a_version_skew() {
+        let json = r#"{"timestamp":1,"event_type":"cb","action":"kill","psi_cpu":1.0,
+            "cpu_percent":1.0,"llm_analysis":"prose",
+            "investigation":{"schema_version":99},"investigation_rendered":null}"#;
+
+        let view: IncidentView = serde_json::from_str(json).unwrap();
+        let out = render(&view.sanitized(), 7, false);
+
+        assert!(out.contains("could not read"), "{out}");
+        assert!(
+            !out.contains("older version"),
+            "an explicit null is this daemon failing, not an old one: {out}"
+        );
     }
 
     #[test]
@@ -302,7 +367,7 @@ mod tests {
         view.investigation = Some(serde_json::json!({"schema_version": 99}));
         // The daemon says "I tried and could not" with an explicit null, which
         // is what separates this from a daemon that has no such field.
-        view.investigation_rendered = Some(serde_json::Value::Null);
+        view.investigation_rendered = Some(None);
 
         let out = render(&view, 7, false);
         assert!(out.contains("could not read"), "{out}");
@@ -399,8 +464,9 @@ mod tests {
     fn terminal_controls_in_evidence_are_disarmed() {
         let mut view = incident();
         // A process name is attacker-controlled and reaches the facts verbatim.
-        view.investigation_rendered = Some(serde_json::json!(
+        view.investigation_rendered = Some(Some(
             "1. [cpu_spin] Runaway loop\n   supports:    process \u{1b}[2J\u{1b}[Hevil was busy\n"
+                .to_string(),
         ));
 
         let out = render(&view.sanitized(), 7, false);

--- a/linnix-cli/src/explain.rs
+++ b/linnix-cli/src/explain.rs
@@ -167,17 +167,24 @@ pub fn render(incident: &IncidentView, id: i64, color: bool) -> String {
                      version that cannot render it. Upgrade cognitod, or read the raw \
                      record on the incident.\n"
                 }
-                // Not a grounding failure. A reply that parses but whose
-                // hypotheses are all discarded is still *stored* as an
-                // investigation and renders its own "no grounded hypothesis"
-                // message above. Reaching here means the reply could not be
-                // parsed at all — malformed JSON, or prose where an object was
-                // expected — so pointing the operator at the model's evidence
-                // would send them to debug the wrong half of it.
+                // A reply is stored but no investigation is. Two things
+                // produce that and the daemon cannot currently tell them
+                // apart: a modern reply that failed to parse, or an incident
+                // analysed before grounded investigations existed, where prose
+                // was all that was ever stored.
+                //
+                // Not a grounding failure either way — a reply that parses and
+                // has every hypothesis discarded is still stored, and renders
+                // its own "no grounded hypothesis" message above.
+                //
+                // The wording therefore states what is known and offers both
+                // readings rather than accusing a legacy record of being
+                // malformed. Persisting `AnalysisOutcome::parse_error` would
+                // make this precise; see the follow-up issue.
                 (None, Some(_)) => {
-                    "The model replied, but the response could not be parsed into an \
-                     investigation: it was malformed, or not in the expected shape. \
-                     The raw reply is on the incident.\n"
+                    "The model replied, but no investigation was stored. Either the reply \
+                     could not be parsed into one, or this incident predates grounded \
+                     investigations. The raw reply is on the incident.\n"
                 }
                 (None, None) => "No analysis has run for this incident.\n",
             });
@@ -291,10 +298,16 @@ mod tests {
         answered.llm_analysis = Some("I think the CPU was busy.".to_string());
 
         let out = render(&answered, 7, false);
-        assert!(out.contains("could not be parsed"), "{out}");
+        assert!(out.contains("no investigation was stored"), "{out}");
         assert!(
             !out.contains("nothing it claimed could be checked"),
-            "a parse failure is not a grounding failure: {out}"
+            "this is not a grounding failure: {out}"
+        );
+        // An incident analysed before grounding existed lands in this same
+        // state legitimately, so the wording must not call it malformed.
+        assert!(
+            out.contains("predates grounded investigations"),
+            "a legacy analysis must not be accused of being malformed: {out}"
         );
 
         let never = incident();

--- a/linnix-cli/src/explain.rs
+++ b/linnix-cli/src/explain.rs
@@ -1,0 +1,184 @@
+//! `linnix explain <incident-id>` — what was concluded about an incident, and
+//! on what evidence.
+//!
+//! The daemon renders the investigation; this command prints it. That split is
+//! deliberate and is the same rule the grounding itself follows: every cited
+//! fact is resolved through the daemon's own wording, so a client cannot
+//! restate a fact while appearing to quote it. A CLI that formatted the
+//! hypotheses itself would be free to drift from what was stored.
+
+use colored::*;
+use reqwest::Client;
+use serde::Deserialize;
+use std::error::Error;
+
+#[derive(Deserialize, Debug)]
+pub struct IncidentView {
+    pub timestamp: i64,
+    pub event_type: String,
+    pub action: String,
+    pub target_name: Option<String>,
+    pub target_pid: Option<i64>,
+    pub psi_cpu: f32,
+    pub cpu_percent: f32,
+    /// Present only when a grounded investigation exists.
+    pub investigation_rendered: Option<String>,
+    /// The model's reply verbatim. Kept even when nothing grounded, which is
+    /// the only way to tell a broken endpoint from a model that answers badly.
+    pub llm_analysis: Option<String>,
+    pub psi_after: Option<f32>,
+    pub recovery_time_ms: Option<i64>,
+}
+
+/// Renders the incident. Returned rather than printed so tests can read it.
+pub fn render(incident: &IncidentView, id: &str, color: bool) -> String {
+    let heading = |s: &str| {
+        if color {
+            s.bold().to_string()
+        } else {
+            s.to_string()
+        }
+    };
+
+    let mut out = format!(
+        "{} #{} — {} at unix {}\n",
+        heading("Incident:"),
+        id,
+        incident.event_type,
+        incident.timestamp
+    );
+
+    let target = match (&incident.target_name, incident.target_pid) {
+        (Some(name), Some(pid)) => format!("{name} ({pid})"),
+        (Some(name), None) => name.clone(),
+        (None, Some(pid)) => format!("pid {pid}"),
+        (None, None) => "unknown target".to_string(),
+    };
+    out.push_str(&format!(
+        "  Action:   {} on {}\n  At the time: CPU {:.1}%, CPU pressure {:.1}%\n",
+        incident.action, target, incident.cpu_percent, incident.psi_cpu
+    ));
+
+    // The outcome, kept in the three states the daemon distinguishes: it
+    // recovered, it was watched and did not, or nobody measured.
+    match (incident.recovery_time_ms, incident.psi_after) {
+        (Some(ms), Some(psi)) => out.push_str(&format!(
+            "  Afterwards:  recovered after {:.1}s, pressure {:.1}%\n",
+            ms as f64 / 1000.0,
+            psi
+        )),
+        (None, Some(psi)) => out.push_str(&format!(
+            "  Afterwards:  did not recover — pressure still {psi:.1}% when the watch ended\n"
+        )),
+        _ => out.push_str("  Afterwards:  not measured\n"),
+    }
+
+    out.push('\n');
+
+    match &incident.investigation_rendered {
+        Some(rendered) => {
+            out.push_str(&format!("{}\n", heading("Investigation")));
+            out.push_str(rendered);
+        }
+        None => {
+            // Saying which of the two happened matters: an operator debugging a
+            // silent reasoner needs to know whether the model was never asked
+            // or answered in a way nothing could be checked against.
+            out.push_str(match incident.llm_analysis {
+                Some(_) => {
+                    "No hypothesis survived grounding for this incident: the model \
+                            replied, but nothing it claimed could be checked against the \
+                            facts the daemon supplied.\n"
+                }
+                None => "No analysis has run for this incident.\n",
+            });
+        }
+    }
+
+    out
+}
+
+pub async fn run_explain(
+    client: &Client,
+    base: &str,
+    id: &str,
+    color: bool,
+) -> Result<(), Box<dyn Error>> {
+    let resp = client
+        .get(format!("{}/incidents/{}", base.trim_end_matches('/'), id))
+        .send()
+        .await?;
+
+    if resp.status() == reqwest::StatusCode::NOT_FOUND {
+        return Err(format!("no incident #{id}").into());
+    }
+    if resp.status() == reqwest::StatusCode::SERVICE_UNAVAILABLE {
+        return Err("cognitod has no incident store configured".into());
+    }
+    if !resp.status().is_success() {
+        return Err(format!("incident query failed: {}", resp.status()).into());
+    }
+
+    let incident: IncidentView = resp.json().await?;
+    print!("{}", render(&incident, id, color));
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn incident() -> IncidentView {
+        IncidentView {
+            timestamp: 1_732_242_135,
+            event_type: "circuit_breaker_cpu".to_string(),
+            action: "auto_kill".to_string(),
+            target_name: Some("aggressive-stress.sh".to_string()),
+            target_pid: Some(472_693),
+            psi_cpu: 75.2,
+            cpu_percent: 96.3,
+            investigation_rendered: None,
+            llm_analysis: None,
+            psi_after: None,
+            recovery_time_ms: None,
+        }
+    }
+
+    #[test]
+    fn the_daemons_rendering_is_printed_verbatim() {
+        let mut view = incident();
+        view.investigation_rendered =
+            Some("1. [cpu_spin] A runaway loop\n   supports:    CPU usage was 96.3%\n".to_string());
+
+        let out = render(&view, "7", false);
+        assert!(out.contains("1. [cpu_spin] A runaway loop"), "{out}");
+        assert!(out.contains("supports:    CPU usage was 96.3%"), "{out}");
+    }
+
+    #[test]
+    fn a_reply_that_did_not_ground_is_distinguished_from_no_analysis() {
+        let mut answered = incident();
+        answered.llm_analysis = Some("some prose".to_string());
+        let out = render(&answered, "7", false);
+        assert!(out.contains("nothing it claimed could be checked"), "{out}");
+
+        let never = incident();
+        let out = render(&never, "7", false);
+        assert!(out.contains("No analysis has run"), "{out}");
+    }
+
+    #[test]
+    fn the_three_outcome_states_read_differently() {
+        let mut recovered = incident();
+        recovered.recovery_time_ms = Some(3_200);
+        recovered.psi_after = Some(4.1);
+        assert!(render(&recovered, "7", false).contains("recovered after 3.2s"));
+
+        let mut stuck = incident();
+        stuck.psi_after = Some(71.0);
+        assert!(render(&stuck, "7", false).contains("did not recover"));
+
+        // Never measured must not read as a finding.
+        assert!(render(&incident(), "7", false).contains("not measured"));
+    }
+}

--- a/linnix-cli/src/explain.rs
+++ b/linnix-cli/src/explain.rs
@@ -35,6 +35,31 @@ pub struct IncidentView {
     pub recovery_time_ms: Option<i64>,
 }
 
+impl IncidentView {
+    /// Strips terminal controls from every string that arrived from the
+    /// daemon, once, on the way in.
+    ///
+    /// Doing this per-field at the point of printing is what failed review:
+    /// `investigation_rendered` was sanitized and `target_name` — which is
+    /// `proc.comm`, chosen by whoever started the process — was not. Cleaning
+    /// at the boundary means a field added later cannot reintroduce the hole,
+    /// and it keeps the intended styling below safe, since that is applied
+    /// after this runs rather than being stripped by it.
+    fn sanitized(self) -> Self {
+        Self {
+            event_type: strip_terminal_controls(&self.event_type),
+            action: strip_terminal_controls(&self.action),
+            target_name: self.target_name.as_deref().map(strip_terminal_controls),
+            investigation_rendered: self
+                .investigation_rendered
+                .as_deref()
+                .map(strip_terminal_controls),
+            llm_analysis: self.llm_analysis.as_deref().map(strip_terminal_controls),
+            ..self
+        }
+    }
+}
+
 /// Renders the incident. Returned rather than printed so tests can read it.
 pub fn render(incident: &IncidentView, id: &str, color: bool) -> String {
     let heading = |s: &str| {
@@ -87,7 +112,7 @@ pub fn render(incident: &IncidentView, id: &str, color: bool) -> String {
             // hypothesis text comes from a model. Either can carry escape
             // sequences that rewrite what the terminal displays — including
             // overwriting the evidence above this line.
-            out.push_str(&strip_terminal_controls(rendered));
+            out.push_str(rendered);
         }
         None => {
             // Three distinct situations, and telling an operator the wrong one
@@ -149,7 +174,7 @@ pub async fn run_explain(
     }
 
     let incident: IncidentView = resp.json().await?;
-    print!("{}", render(&incident, id, color));
+    print!("{}", render(&incident.sanitized(), id, color));
     Ok(())
 }
 
@@ -216,6 +241,44 @@ mod tests {
     }
 
     #[test]
+    fn every_daemon_supplied_string_is_disarmed_not_just_the_evidence() {
+        // `target_name` is `proc.comm`: whoever started the process chose it.
+        // The header prints before the investigation, so an escape here can
+        // clear the screen and rewrite everything that follows.
+        let mut view = incident();
+        view.target_name = Some("\u{1b}[2J\u{1b}[Hinnocent".to_string());
+        view.event_type = "\u{1b}[31mcircuit_breaker_cpu".to_string();
+        view.action = "auto_kill\u{7}".to_string();
+        view.llm_analysis = Some("prose\u{1b}[2J".to_string());
+
+        let out = render(&view.sanitized(), "7", false);
+
+        assert!(
+            !out.contains('\u{1b}') && !out.contains('\u{7}'),
+            "no daemon-supplied string may carry terminal controls: {out:?}"
+        );
+        // The names themselves survive — an operator still needs to read them.
+        assert!(out.contains("innocent"), "{out}");
+        assert!(out.contains("circuit_breaker_cpu"), "{out}");
+        assert!(out.contains("auto_kill"), "{out}");
+    }
+
+    #[test]
+    fn sanitizing_does_not_strip_the_cli_own_styling() {
+        // `colored` disables itself when stdout is not a terminal, which it is
+        // not under a test harness, so the override is what makes this assert
+        // anything at all.
+        colored::control::set_override(true);
+        let out = render(&incident().sanitized(), "7", true);
+        colored::control::unset_override();
+
+        assert!(
+            out.contains('\u{1b}'),
+            "styling is applied after cleaning and must survive it"
+        );
+    }
+
+    #[test]
     fn terminal_controls_in_evidence_are_disarmed() {
         let mut view = incident();
         // A process name is attacker-controlled and reaches the facts verbatim.
@@ -224,7 +287,7 @@ mod tests {
                 .to_string(),
         );
 
-        let out = render(&view, "7", false);
+        let out = render(&view.sanitized(), "7", false);
         assert!(
             !out.contains('\u{1b}'),
             "escape sequences must not reach the terminal: {out:?}"

--- a/linnix-cli/src/explain.rs
+++ b/linnix-cli/src/explain.rs
@@ -21,8 +21,16 @@ pub struct IncidentView {
     pub target_pid: Option<i64>,
     pub psi_cpu: f32,
     pub cpu_percent: f32,
-    /// Present only when a grounded investigation exists.
-    pub investigation_rendered: Option<String>,
+    /// The daemon's rendering.
+    ///
+    /// Three states that have to stay distinct: a string is the rendering; an
+    /// explicit `null` means this daemon tried and could not read the stored
+    /// record; an **absent** key means the daemon predates this field. Typed
+    /// as `Value` because serde cannot otherwise tell a null from a missing
+    /// key, and collapsing those two reports a version skew as a corrupt
+    /// record.
+    #[serde(default)]
+    pub investigation_rendered: Option<serde_json::Value>,
     /// The stored investigation itself. Present-but-unrendered means the
     /// daemon kept the row and could not read it — a different situation from
     /// there being no investigation at all, and one the operator has to be
@@ -57,10 +65,12 @@ impl IncidentView {
             // The one field whose newlines *are* the daemon's layout. Its
             // scalars were already flattened server-side before being placed
             // into that layout, so only escape sequences need removing here.
-            investigation_rendered: self
-                .investigation_rendered
-                .as_deref()
-                .map(strip_terminal_controls),
+            investigation_rendered: self.investigation_rendered.map(|v| match v {
+                serde_json::Value::String(s) => {
+                    serde_json::Value::String(strip_terminal_controls(&s))
+                }
+                other => other,
+            }),
             llm_analysis: self.llm_analysis.as_deref().map(single_line),
             ..self
         }
@@ -112,7 +122,11 @@ pub fn render(incident: &IncidentView, id: i64, color: bool) -> String {
 
     out.push('\n');
 
-    match &incident.investigation_rendered {
+    match incident
+        .investigation_rendered
+        .as_ref()
+        .and_then(|v| v.as_str())
+    {
         Some(rendered) => {
             out.push_str(&format!("{}\n", heading("Investigation")));
             // Facts quote process names, which are attacker-controlled, and
@@ -122,15 +136,24 @@ pub fn render(incident: &IncidentView, id: i64, color: bool) -> String {
             out.push_str(rendered);
         }
         None => {
-            // Three distinct situations, and telling an operator the wrong one
+            // Four distinct situations, and telling an operator the wrong one
             // sends them to debug the wrong thing.
+            //
+            // An explicit null means this daemon tried and failed; an absent
+            // key means it has no such field, which is a version skew rather
+            // than a bad record.
+            let daemon_tried = incident.investigation_rendered.is_some();
+
             out.push_str(match (&incident.investigation, &incident.llm_analysis) {
-                // Stored but unrendered: the daemon kept the row and could not
-                // read it — corrupt, or written by a newer build.
-                (Some(_), _) => {
+                (Some(_), _) if daemon_tried => {
                     "This incident has a stored investigation the daemon could not read: \
                      it is corrupt, or was written by a newer version. The raw record is \
                      still on the incident.\n"
+                }
+                (Some(_), _) => {
+                    "This incident has a stored investigation, but this daemon is an older \
+                     version that cannot render it. Upgrade cognitod, or read the raw \
+                     record on the incident.\n"
                 }
                 (None, Some(_)) => {
                     "No hypothesis survived grounding for this incident: the model \
@@ -228,8 +251,9 @@ mod tests {
     #[test]
     fn the_daemons_rendering_is_printed_verbatim() {
         let mut view = incident();
-        view.investigation_rendered =
-            Some("1. [cpu_spin] A runaway loop\n   supports:    CPU usage was 96.3%\n".to_string());
+        view.investigation_rendered = Some(serde_json::json!(
+            "1. [cpu_spin] A runaway loop\n   supports:    CPU usage was 96.3%\n"
+        ));
 
         let out = render(&view, 7, false);
         assert!(out.contains("1. [cpu_spin] A runaway loop"), "{out}");
@@ -249,6 +273,25 @@ mod tests {
     }
 
     #[test]
+    fn an_older_daemon_is_not_reported_as_a_corrupt_record() {
+        // The previous daemon returns the investigation as a JSON string and
+        // has no `investigation_rendered` key at all. Telling an operator
+        // mid-upgrade that their record is corrupt sends them to fix data that
+        // is fine.
+        let mut view = incident();
+        view.llm_analysis = Some("some prose".to_string());
+        view.investigation = Some(serde_json::json!("{\"schema_version\":1}"));
+        view.investigation_rendered = None; // absent, not null
+
+        let out = render(&view.sanitized(), 7, false);
+        assert!(out.contains("older version that cannot render"), "{out}");
+        assert!(
+            !out.contains("could not read"),
+            "a version skew is not a corrupt record: {out}"
+        );
+    }
+
+    #[test]
     fn an_unreadable_investigation_is_not_reported_as_ungrounded() {
         // The daemon keeps the row and omits the rendering when it cannot
         // parse it. Reading only `llm_analysis` here would tell the operator
@@ -257,6 +300,9 @@ mod tests {
         let mut view = incident();
         view.llm_analysis = Some("some prose".to_string());
         view.investigation = Some(serde_json::json!({"schema_version": 99}));
+        // The daemon says "I tried and could not" with an explicit null, which
+        // is what separates this from a daemon that has no such field.
+        view.investigation_rendered = Some(serde_json::Value::Null);
 
         let out = render(&view, 7, false);
         assert!(out.contains("could not read"), "{out}");
@@ -353,10 +399,9 @@ mod tests {
     fn terminal_controls_in_evidence_are_disarmed() {
         let mut view = incident();
         // A process name is attacker-controlled and reaches the facts verbatim.
-        view.investigation_rendered = Some(
+        view.investigation_rendered = Some(serde_json::json!(
             "1. [cpu_spin] Runaway loop\n   supports:    process \u{1b}[2J\u{1b}[Hevil was busy\n"
-                .to_string(),
-        );
+        ));
 
         let out = render(&view.sanitized(), 7, false);
         assert!(

--- a/linnix-cli/src/explain.rs
+++ b/linnix-cli/src/explain.rs
@@ -47,14 +47,21 @@ impl IncidentView {
     /// after this runs rather than being stripped by it.
     fn sanitized(self) -> Self {
         Self {
-            event_type: strip_terminal_controls(&self.event_type),
-            action: strip_terminal_controls(&self.action),
-            target_name: self.target_name.as_deref().map(strip_terminal_controls),
+            // Header fields are interpolated into single lines, so a break in
+            // one forges a line: a process named "x\n  Afterwards: recovered"
+            // would print a header row the daemon never wrote. Same reasoning
+            // as the daemon's own renderer — layout is meaning.
+            event_type: single_line(&self.event_type),
+            action: single_line(&self.action),
+            target_name: self.target_name.as_deref().map(single_line),
+            // The one field whose newlines *are* the daemon's layout. Its
+            // scalars were already flattened server-side before being placed
+            // into that layout, so only escape sequences need removing here.
             investigation_rendered: self
                 .investigation_rendered
                 .as_deref()
                 .map(strip_terminal_controls),
-            llm_analysis: self.llm_analysis.as_deref().map(strip_terminal_controls),
+            llm_analysis: self.llm_analysis.as_deref().map(single_line),
             ..self
         }
     }
@@ -135,6 +142,25 @@ pub fn render(incident: &IncidentView, id: &str, color: bool) -> String {
         }
     }
 
+    out
+}
+
+/// Flattens a value onto one line, so it cannot forge the layout around it.
+///
+/// For every field printed inside a single line. Breaks become their escaped
+/// spelling rather than vanishing: a process name that tried to fake a header
+/// row is worth seeing as an attempt.
+fn single_line(text: &str) -> String {
+    let mut out = String::with_capacity(text.len());
+    for c in text.chars() {
+        match c {
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            c if c.is_control() => {}
+            c => out.push(c),
+        }
+    }
     out
 }
 
@@ -261,6 +287,34 @@ mod tests {
         assert!(out.contains("innocent"), "{out}");
         assert!(out.contains("circuit_breaker_cpu"), "{out}");
         assert!(out.contains("auto_kill"), "{out}");
+    }
+
+    #[test]
+    fn a_process_name_cannot_forge_a_header_row() {
+        // Removing escapes is not enough: a bare newline in `proc.comm` splits
+        // the Action line and the second half reads as a header the daemon
+        // wrote. The outcome row is the tempting target — "recovered" is the
+        // most useful lie available.
+        let mut view = incident();
+        view.target_name = Some("innocent\n  Afterwards:  recovered after 0.1s".to_string());
+
+        let out = render(&view.sanitized(), "7", false);
+
+        let forged: Vec<&str> = out
+            .lines()
+            .filter(|l| l.trim_start().starts_with("Afterwards:"))
+            .collect();
+        assert_eq!(
+            forged.len(),
+            1,
+            "only the daemon's own outcome row may appear: {out}"
+        );
+        assert!(
+            forged[0].contains("not measured"),
+            "the surviving row must be the real one: {out}"
+        );
+        // Still legible, with the attempt visible rather than trimmed away.
+        assert!(out.contains("innocent\\n"), "{out}");
     }
 
     #[test]

--- a/linnix-cli/src/main.rs
+++ b/linnix-cli/src/main.rs
@@ -8,6 +8,7 @@ mod alert;
 mod blame;
 mod doctor;
 mod event;
+mod explain;
 mod export;
 mod http;
 mod investigate;
@@ -63,6 +64,11 @@ enum Command {
         /// Time window to investigate (e.g. 20m, 1h)
         #[clap(long, default_value = "15m")]
         since: String,
+    },
+    /// Explain an incident: what was concluded, and on what evidence
+    Explain {
+        /// Incident id, as shown by /incidents
+        id: String,
     },
     /// Blame a node for performance issues (requires kubectl)
     Blame {
@@ -121,6 +127,11 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     if let Some(Command::Investigate { pod, since }) = args.command.clone() {
         investigate::run_investigate(&client, &args.url, &pod, &since, color).await?;
+        return Ok(());
+    }
+
+    if let Some(Command::Explain { id }) = args.command.clone() {
+        explain::run_explain(&client, &args.url, &id, color).await?;
         return Ok(());
     }
 

--- a/linnix-cli/src/main.rs
+++ b/linnix-cli/src/main.rs
@@ -68,7 +68,12 @@ enum Command {
     /// Explain an incident: what was concluded, and on what evidence
     Explain {
         /// Incident id, as shown by /incidents
-        id: String,
+        ///
+        /// Numeric on purpose: it is printed in the header and interpolated
+        /// into the request URL, and an id copied from a ticket or an alert
+        /// payload is not necessarily trustworthy. Parsing it here means a
+        /// forged value is rejected rather than escaped.
+        id: i64,
     },
     /// Blame a node for performance issues (requires kubectl)
     Blame {
@@ -131,7 +136,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     }
 
     if let Some(Command::Explain { id }) = args.command.clone() {
-        explain::run_explain(&client, &args.url, &id, color).await?;
+        explain::run_explain(&client, &args.url, id, color).await?;
         return Ok(());
     }
 


### PR DESCRIPTION
Roadmap A2. The grounding shipped in #73 — the daemon states the facts, the model may only *cite* them by id, and a hypothesis citing evidence that was never supplied is discarded — and then nothing showed it to anyone.

`IncidentInvestigation::render` was called **only from tests**, and `/incidents/{id}` returned the investigation as one escaped JSON string.

## Change
- The endpoint parses the column into a real object and adds `investigation_rendered` — the same text `render` produces.
- `linnix explain <id>` prints it, along with what was acted on and how it turned out.

```
Incident: #7 — circuit_breaker_cpu at unix 1732242135
  Action:   auto_kill on aggressive-stress.sh (472693)
  At the time: CPU 96.3%, CPU pressure 75.2%
  Afterwards:  recovered after 3.2s, pressure 4.1%

Investigation
1. [cpu_spin] A single runaway process held the CPU
   supports:    CPU usage was 96.3%
   supports:    CPU pressure stall was 75.2%
   proposed:    Inspect aggressive-stress.sh
```

## Why the rendering is server-side
Same rule the grounding itself follows: every citation resolves through the daemon's own wording, so a client cannot restate a fact while appearing to quote it. A CLI formatting the hypotheses itself would be free to drift from what was stored. It also keeps #66's lesson — one place for wording that must not diverge.

## Absences that must not read as findings
- An incident with **no investigation** gains no `investigation_rendered` field, rather than an empty one.
- The CLI distinguishes *the model was never asked* from *it answered and nothing it claimed could be checked* — an operator debugging a silent reasoner needs to tell those apart, and it is exactly the distinction #73's storage design preserves.
- The outcome keeps A1's three states: recovered, watched-and-did-not, never measured. "Not measured" must not read as "fine".
- A stored investigation that no longer parses is returned as-is rather than dropped — it is evidence about a past incident.

## Found while testing
`IncidentStore::insert` does not persist `investigation` or `llm_analysis`; they are written afterwards by `add_llm_analysis`. That is the real two-phase flow (an incident is recorded before analysis runs), and my first test was wrong to set them on the struct. The test now follows the real path. Worth knowing that a caller populating those fields on insert will silently lose them.

## Tests (219 pass)
Endpoint-level, not just the renderer: insert an incident, run the real analysis-recording path, GET it, and assert both the structured hypotheses and the rendered text — including that a cited fact appears in the daemon's wording. Plus the empty case, and three CLI cases covering the outcome states and the never-asked/did-not-ground distinction.

Verified end to end against a mock daemon; the block above is captured output, not a mock-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EFtVtx4BiEYyKPwkdxqHgJ