### PR TITLE
Harden Kubernetes API authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,15 +41,20 @@ Linnix uses **eBPF** + **PSI (Pressure Stall Information)** to answer this. PSI 
 Deploy Linnix as a DaemonSet to monitor your cluster.
 
 ```bash
-# Apply the manifests
+# Create the API token outside the repository, then apply the manifests.
+kubectl create secret generic linnix-api-token \
+  --namespace default \
+  --from-literal=token="$(openssl rand -base64 32)"
 kubectl apply -f k8s/
 ```
 
 **Access the API:**
 ```bash
+export LINNIX_API_TOKEN="$(kubectl get secret linnix-api-token \
+  -o jsonpath='{.data.token}' | base64 -d)"
 kubectl port-forward daemonset/linnix-agent 3000:3000
-# API available at http://localhost:3000
-# Stream events: curl http://localhost:3000/stream
+# API available at http://localhost:3000 (Bearer token required)
+# Stream events: curl -H "Authorization: Bearer $LINNIX_API_TOKEN" http://localhost:3000/stream
 ```
 
 ## Quickstart (Docker)
@@ -106,6 +111,9 @@ See [SAFETY.md](SAFETY.md) for our detailed safety model.
 Linnix exports the attribution as Prometheus counters, so the "who is stalling whom" view works in the Grafana you already run.
 
 ```bash
+kubectl create secret generic linnix-api-token \
+  --namespace default \
+  --from-literal=token="$(openssl rand -base64 32)"
 kubectl apply -f k8s/                       # scrape annotations included
 # Grafana → Dashboards → New → Import → Upload JSON file
 #   k8s/grafana/linnix-noisy-neighbor.json

--- a/cognitod/src/api/mod.rs
+++ b/cognitod/src/api/mod.rs
@@ -1758,15 +1758,15 @@ pub struct AppState {
     pub blame_metrics: Arc<cognitod::attribution::BlameMetrics>,
 }
 
-/// Every route the daemon serves, listed once.
+/// Every application route the daemon serves over the API listener.
 ///
-/// Both listeners build from this. The difference between them is the auth
+/// Both API listeners build from this. The difference between them is the auth
 /// layer, not the route set — and on an auth boundary that distinction has to
 /// be structural rather than clerical. Two hand-maintained lists meant a route
 /// added to one and forgotten in the other either vanished silently from the
 /// socket, or became reachable over TCP *without token auth*.
-fn base_router(prometheus_enabled: bool) -> Router<Arc<AppState>> {
-    let mut router = Router::new()
+fn base_router() -> Router<Arc<AppState>> {
+    Router::new()
         .route("/", get(crate::ui::dashboard_handler))
         .route("/dashboard", get(crate::ui::dashboard_handler))
         .route("/context", get(get_context_route))
@@ -1800,20 +1800,14 @@ fn base_router(prometheus_enabled: bool) -> Router<Arc<AppState>> {
         .route("/actions", get(get_actions))
         .route("/actions/{id}", get(get_action_by_id))
         .route("/actions/{id}/approve", axum::routing::post(approve_action))
-        .route("/actions/{id}/reject", axum::routing::post(reject_action));
-
-    if prometheus_enabled {
-        router = router.route("/metrics/prometheus", get(prometheus_metrics));
-    }
-
-    router
+        .route("/actions/{id}/reject", axum::routing::post(reject_action))
 }
 
 /// Build routes for the TCP listener, which requires a bearer token when one
 /// is configured.
 pub fn all_routes(app_state: Arc<AppState>) -> Router {
     let auth_token = app_state.auth_token.clone();
-    let mut router = base_router(app_state.prometheus_enabled);
+    let mut router = base_router();
 
     if auth_token.is_some() {
         router = router.layer(axum::middleware::from_fn_with_state(
@@ -1831,7 +1825,21 @@ pub fn all_routes(app_state: Arc<AppState>) -> Router {
 /// middleware: UDS connections are trusted because local process identity is
 /// verified by socket credentials (`SO_PEERCRED`).
 pub fn uds_routes(app_state: Arc<AppState>) -> Router {
-    base_router(app_state.prometheus_enabled).with_state(app_state)
+    base_router().with_state(app_state)
+}
+
+/// Build the unauthenticated operational listener. It deliberately contains no
+/// process, incident or enforcement routes; those remain on the API listener.
+pub fn metrics_routes(app_state: Arc<AppState>) -> Router {
+    let mut router = Router::new()
+        .route("/healthz", get(healthz))
+        .route("/readyz", get(readyz));
+
+    if app_state.prometheus_enabled {
+        router = router.route("/metrics/prometheus", get(prometheus_metrics));
+    }
+
+    router.with_state(app_state)
 }
 
 const CARGO_LOCK: &str = include_str!("../../../Cargo.lock");
@@ -2596,7 +2604,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn prometheus_endpoint_respects_flag() {
+    async fn metrics_listener_hides_prometheus_when_disabled() {
         let ctx = Arc::new(ContextStore::new(Duration::from_secs(60), 10, None));
         let metrics = Arc::new(Metrics::new());
         let app_state = Arc::new(AppState {
@@ -2617,7 +2625,7 @@ mod tests {
             k8s: None,
             blame_metrics: Arc::new(cognitod::attribution::BlameMetrics::new("test-node")),
         });
-        let router = super::all_routes(Arc::clone(&app_state));
+        let router = super::metrics_routes(Arc::clone(&app_state));
         let response = router
             .oneshot(
                 Request::builder()
@@ -2631,7 +2639,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn prometheus_endpoint_returns_metrics_when_enabled() {
+    async fn metrics_listener_returns_prometheus_when_enabled() {
         let ctx = Arc::new(ContextStore::new(Duration::from_secs(60), 10, None));
         let metrics = Arc::new(Metrics::new());
         metrics.events_total.fetch_add(42, Ordering::Relaxed);
@@ -2653,7 +2661,7 @@ mod tests {
             k8s: None,
             blame_metrics: Arc::new(cognitod::attribution::BlameMetrics::new("test-node")),
         });
-        let router = super::all_routes(Arc::clone(&app_state));
+        let router = super::metrics_routes(Arc::clone(&app_state));
         let response = router
             .oneshot(
                 Request::builder()
@@ -2749,6 +2757,87 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn kubernetes_api_routes_require_secret_backed_auth() {
+        let manifest = std::fs::read_to_string("../k8s/configmap.yaml")
+            .expect("cannot read k8s/configmap.yaml");
+        let document: serde_yaml::Value =
+            serde_yaml::from_str(&manifest).expect("configmap.yaml is not valid YAML");
+        let embedded_config = document["data"]["linnix.toml"]
+            .as_str()
+            .expect("configmap has no data['linnix.toml']");
+        let config: cognitod::config::Config =
+            toml::from_str(embedded_config).expect("embedded linnix.toml does not parse");
+
+        assert_eq!(config.api.listen_addr, "0.0.0.0:3000");
+        assert!(config.outputs.prometheus);
+
+        // The DaemonSet injects this value from Secret/linnix-api-token. The
+        // application router sees the resolved token, never the Secret itself.
+        let app_state = Arc::new(AppState {
+            context: Arc::new(ContextStore::new(Duration::from_secs(60), 10, None)),
+            metrics: Arc::new(Metrics::new()),
+            alerts: None,
+            insights: Arc::new(InsightStore::new(16, None)),
+            offline: Arc::new(OfflineGuard::new(false)),
+            transport: "perf",
+            probe_state: ProbeState::disabled(),
+            require_kernel_instrumentation: true,
+            enforcement: None,
+            reasoner: ReasonerConfig::default(),
+            prometheus_enabled: config.outputs.prometheus,
+            alert_history: Arc::new(AlertHistory::new(16)),
+            auth_token: Some("secret-from-kubernetes".to_string()),
+            incident_store: None,
+            k8s: None,
+            blame_metrics: Arc::new(cognitod::attribution::BlameMetrics::new("test-node")),
+        });
+
+        for request in [
+            Request::builder()
+                .uri("/processes")
+                .body(Body::empty())
+                .unwrap(),
+            Request::builder()
+                .uri("/system")
+                .body(Body::empty())
+                .unwrap(),
+            Request::builder()
+                .method("POST")
+                .uri("/actions/action-1/approve")
+                .body(Body::empty())
+                .unwrap(),
+        ] {
+            let response = super::all_routes(Arc::clone(&app_state))
+                .oneshot(request)
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+        }
+
+        let metrics_response = super::metrics_routes(Arc::clone(&app_state))
+            .oneshot(
+                Request::builder()
+                    .uri("/metrics/prometheus")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(metrics_response.status(), StatusCode::OK);
+
+        let sensitive_on_metrics = super::metrics_routes(app_state)
+            .oneshot(
+                Request::builder()
+                    .uri("/processes")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(sensitive_on_metrics.status(), StatusCode::NOT_FOUND);
     }
 
     #[tokio::test]
@@ -2936,7 +3025,7 @@ mod tests {
             blame_metrics: Arc::clone(&blame),
         });
 
-        let response = super::all_routes(app_state)
+        let response = super::metrics_routes(app_state)
             .oneshot(
                 Request::builder()
                     .uri("/metrics/prometheus")

--- a/cognitod/src/config.rs
+++ b/cognitod/src/config.rs
@@ -566,7 +566,7 @@ fn default_reasoner_timeout() -> u64 {
     30_000
 }
 
-#[derive(Debug, Deserialize, Clone, Default)]
+#[derive(Debug, Deserialize, Clone)]
 #[allow(dead_code)]
 pub struct OutputConfig {
     #[serde(default)]
@@ -575,6 +575,25 @@ pub struct OutputConfig {
     pub pagerduty: bool,
     #[serde(default)]
     pub prometheus: bool,
+    /// Unauthenticated operational listener for Prometheus and probes. The
+    /// main API listener does not serve this endpoint.
+    #[serde(default = "default_metrics_listen_addr")]
+    pub metrics_listen_addr: String,
+}
+
+impl Default for OutputConfig {
+    fn default() -> Self {
+        Self {
+            slack: false,
+            pagerduty: false,
+            prometheus: false,
+            metrics_listen_addr: default_metrics_listen_addr(),
+        }
+    }
+}
+
+fn default_metrics_listen_addr() -> String {
+    "127.0.0.1:9090".to_string()
 }
 
 #[derive(Clone)]
@@ -841,6 +860,51 @@ offline = true
         assert!(
             cfg.outputs.prometheus,
             "the DaemonSet must serve /metrics/prometheus or the dashboard is empty"
+        );
+        assert_eq!(
+            cfg.outputs.metrics_listen_addr, "0.0.0.0:9090",
+            "Kubernetes must expose unauthenticated metrics on the dedicated surface"
+        );
+    }
+
+    #[test]
+    fn the_kubernetes_daemonset_uses_a_secret_for_the_public_api_token() {
+        let manifest = std::fs::read_to_string("../k8s/daemonset.yaml")
+            .expect("cannot read k8s/daemonset.yaml");
+        let doc: serde_yaml::Value =
+            serde_yaml::from_str(&manifest).expect("daemonset.yaml is not valid YAML");
+        let container = doc["spec"]["template"]["spec"]["containers"]
+            .as_sequence()
+            .and_then(|containers| {
+                containers
+                    .iter()
+                    .find(|container| container["name"].as_str() == Some("cognitod"))
+            })
+            .expect("DaemonSet has no cognitod container");
+        let token = container["env"]
+            .as_sequence()
+            .and_then(|environment| {
+                environment
+                    .iter()
+                    .find(|entry| entry["name"].as_str() == Some("LINNIX_API_TOKEN"))
+            })
+            .expect("DaemonSet must inject LINNIX_API_TOKEN");
+
+        assert_eq!(
+            token["valueFrom"]["secretKeyRef"]["name"].as_str(),
+            Some("linnix-api-token")
+        );
+        assert_eq!(
+            token["valueFrom"]["secretKeyRef"]["key"].as_str(),
+            Some("token")
+        );
+        assert_eq!(
+            container["livenessProbe"]["httpGet"]["port"].as_str(),
+            Some("metrics")
+        );
+        assert_eq!(
+            container["readinessProbe"]["httpGet"]["port"].as_str(),
+            Some("metrics")
         );
     }
 

--- a/cognitod/src/main.rs
+++ b/cognitod/src/main.rs
@@ -14,7 +14,7 @@ use aya::{Ebpf, EbpfLoader};
 use aya_log::EbpfLogger;
 use caps::{CapSet, Capability};
 use log::{info, warn};
-use std::{convert::TryFrom, error::Error, path::PathBuf, sync::Arc, time::Duration};
+use std::{convert::TryFrom, error::Error, net::IpAddr, path::PathBuf, sync::Arc, time::Duration};
 use tokio::fs::OpenOptions;
 use tokio::io::{AsyncWriteExt, BufWriter};
 use tokio::sync::broadcast;
@@ -30,7 +30,7 @@ use linnix_ai_ebpf_common::TelemetryConfig;
 mod api;
 // mod routes; // Deleted (dead code cleanup)
 
-use crate::api::{AppState, all_routes};
+use crate::api::{AppState, all_routes, metrics_routes};
 use crate::bpf_config::{CoreRssMode, derive_telemetry_config};
 use crate::runtime::probes::{ProbeState, RssProbeMode};
 use clap::Parser;
@@ -64,6 +64,65 @@ struct BpfRuntimeGuards {
 }
 
 const INSIGHT_STORE_CAPACITY: usize = 50;
+
+fn configured_auth_token(
+    env_token: Option<String>,
+    config_token: Option<String>,
+) -> Option<String> {
+    env_token
+        .filter(|token| !token.trim().is_empty())
+        .or_else(|| config_token.filter(|token| !token.trim().is_empty()))
+}
+
+fn listener_host(listen_addr: &str) -> anyhow::Result<&str> {
+    let listen_addr = listen_addr.trim();
+
+    if let Some(bracketed) = listen_addr.strip_prefix('[') {
+        let (host, port) = bracketed
+            .split_once(']')
+            .ok_or_else(|| anyhow::anyhow!("invalid listen address {listen_addr:?}"))?;
+        if host.is_empty() || !port.starts_with(':') || port.len() == 1 {
+            anyhow::bail!("invalid listen address {listen_addr:?}");
+        }
+        return Ok(host);
+    }
+
+    let (host, port) = listen_addr
+        .rsplit_once(':')
+        .ok_or_else(|| anyhow::anyhow!("invalid listen address {listen_addr:?}"))?;
+    if port.is_empty() {
+        anyhow::bail!("invalid listen address {listen_addr:?}");
+    }
+    Ok(host)
+}
+
+fn api_listener_requires_auth(listen_addr: &str) -> anyhow::Result<bool> {
+    let host = listener_host(listen_addr)?;
+
+    if host.eq_ignore_ascii_case("localhost") {
+        return Ok(false);
+    }
+
+    match host.parse::<IpAddr>() {
+        Ok(ip) => Ok(!ip.is_loopback()),
+        // A hostname can resolve to a non-loopback address. Require a token
+        // rather than attempting name resolution before startup.
+        Err(_) => Ok(true),
+    }
+}
+
+fn validate_api_auth(listen_addr: &str, auth_token: Option<&str>) -> anyhow::Result<()> {
+    if api_listener_requires_auth(listen_addr)?
+        && auth_token.is_none_or(|token| token.trim().is_empty())
+    {
+        anyhow::bail!(
+            "refusing to start HTTP API on {listen_addr} without authentication; \
+             set LINNIX_API_TOKEN from a Kubernetes Secret, set api.auth_token, \
+             or bind api.listen_addr to a loopback address"
+        );
+    }
+    Ok(())
+}
 
 fn attach_kprobe_internal(bpf: &mut Ebpf, program: &str, symbol: &str) -> anyhow::Result<()> {
     let probe: &mut KProbe = bpf
@@ -1302,9 +1361,10 @@ async fn main() -> Result<(), Box<dyn Error>> {
         });
     }
 
-    let auth_token = std::env::var("LINNIX_API_TOKEN")
-        .ok()
-        .or(config.api.auth_token.clone());
+    let auth_token = configured_auth_token(
+        std::env::var("LINNIX_API_TOKEN").ok(),
+        config.api.auth_token.clone(),
+    );
 
     let app_state = Arc::new(AppState {
         context: Arc::clone(&context),
@@ -1325,17 +1385,29 @@ async fn main() -> Result<(), Box<dyn Error>> {
         blame_metrics: blame_metrics.clone(),
     });
 
-    let api = all_routes(app_state.clone());
     let listen_addr = std::env::var("LINNIX_LISTEN_ADDR").unwrap_or(config.api.listen_addr.clone());
+    validate_api_auth(&listen_addr, auth_token.as_deref())?;
+
+    let api = all_routes(app_state.clone());
     let listener = TcpListener::bind(&listen_addr).await?;
 
-    if listen_addr.starts_with("0.0.0.0") && auth_token.is_none() {
-        warn!(
-            "API listening on {} with NO AUTHENTICATION. \
-            Set LINNIX_API_TOKEN to secure the API.",
-            listen_addr
+    let metrics_listener = if config.outputs.prometheus {
+        let metrics_listen_addr = std::env::var("LINNIX_METRICS_LISTEN_ADDR")
+            .unwrap_or(config.outputs.metrics_listen_addr.clone());
+        let metrics_listener =
+            TcpListener::bind(&metrics_listen_addr)
+                .await
+                .with_context(|| {
+                    format!("failed to bind operational metrics listener on {metrics_listen_addr}")
+                })?;
+        info!(
+            "[cognitod] operational metrics server on http://{}",
+            metrics_listen_addr
         );
-    }
+        Some(metrics_listener)
+    } else {
+        None
+    };
 
     info!("[cognitod] HTTP server on http://{}", listen_addr);
     tokio::spawn(async move {
@@ -1343,6 +1415,15 @@ async fn main() -> Result<(), Box<dyn Error>> {
             eprintln!("server error: {e}");
         }
     });
+
+    if let Some(metrics_listener) = metrics_listener {
+        let metrics_api = metrics_routes(app_state.clone());
+        tokio::spawn(async move {
+            if let Err(e) = axum::serve(metrics_listener, metrics_api).await {
+                eprintln!("metrics server error: {e}");
+            }
+        });
+    }
 
     // ── Unix domain socket listener (bypasses token auth) ──
     let uds_path = std::env::var("LINNIX_UDS_PATH")
@@ -1416,6 +1497,17 @@ async fn main() -> Result<(), Box<dyn Error>> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn non_loopback_api_without_a_token_is_rejected() {
+        let error = validate_api_auth("0.0.0.0:3000", None)
+            .expect_err("a publicly bound API must require authentication");
+        assert!(error.to_string().contains("without authentication"));
+
+        assert!(validate_api_auth("[::]:3000", None).is_err());
+        assert!(validate_api_auth("127.0.0.1:3000", None).is_ok());
+        assert!(validate_api_auth("0.0.0.0:3000", Some("token-from-secret")).is_ok());
+    }
 
     #[test]
     fn bpf_search_paths_canonical_order() {

--- a/configs/linnix.darwin.toml
+++ b/configs/linnix.darwin.toml
@@ -4,6 +4,7 @@
 
 [api]
 listen_addr = "0.0.0.0:3000"  # Bind to all interfaces for macOS bridge network
+# Required for this non-loopback bind: set LINNIX_API_TOKEN in the environment.
 # auth_token = "your-secret-token"
 
 [runtime]
@@ -27,8 +28,9 @@ model = "linnix-3b-distilled"
 timeout_ms = 30000
 
 [outputs]
-# Serve the Prometheus text exposition at /metrics/prometheus
+# Serve Prometheus, health, and readiness on a separate operational listener.
 prometheus = true
+metrics_listen_addr = "127.0.0.1:9090"
 
 [probes]
 # eBPF probe configuration

--- a/configs/linnix.toml
+++ b/configs/linnix.toml
@@ -3,6 +3,8 @@
 
 [api]
 listen_addr = "127.0.0.1:3000"
+# Non-loopback API binds require LINNIX_API_TOKEN or this setting.
+# Prefer LINNIX_API_TOKEN in production so the token is not stored in this file.
 # auth_token = "your-secret-token"
 
 [runtime]
@@ -26,8 +28,9 @@ model = "linnix-3b-distilled"
 timeout_ms = 30000
 
 [outputs]
-# Serve the Prometheus text exposition at /metrics/prometheus
+# Serve Prometheus, health, and readiness on a separate operational listener.
 prometheus = true
+metrics_listen_addr = "127.0.0.1:9090"
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Notifications via Apprise (optional)

--- a/docs/HOW_IT_WORKS.md
+++ b/docs/HOW_IT_WORKS.md
@@ -37,7 +37,8 @@ Linnix combines eBPF probes, BTF-powered compatibility helpers, and an AI reason
 4. **APIs**:
    - `http://localhost:3000/stream` (Server-Sent Events)
    - `http://localhost:3000/insights` (AI output)
-   - `http://localhost:3000/metrics` (JSON) and `/metrics/prometheus`
+   - `http://localhost:3000/metrics` (JSON) and
+     `http://localhost:9090/metrics/prometheus`
 5. **Prometheus integration** is just a config flag; no sidecar required.
 
 ## 4. AI Reasoning Loop

--- a/docs/prometheus-integration.md
+++ b/docs/prometheus-integration.md
@@ -11,9 +11,13 @@ Set the Prometheus flag in the Cognitod config (usually `/etc/linnix/linnix.toml
 ```toml
 [outputs]
 prometheus = true
+metrics_listen_addr = "127.0.0.1:9090"
 ```
 
-Restart Cognitod if it is already running. The daemon will now serve a text exposition at `http://<host>:3000/metrics/prometheus` alongside the JSON `/metrics` endpoint.
+Restart Cognitod if it is already running. The daemon serves Prometheus text
+exposition at `http://<host>:9090/metrics/prometheus`. This operational listener
+also serves health and readiness, but it does not expose the JSON `/metrics`
+endpoint or any process, incident, or action routes.
 
 ## 2. Install & run Cognitod via systemd
 
@@ -75,7 +79,7 @@ scrape_configs:
   - job_name: 'linnix'
     metrics_path: /metrics/prometheus
     static_configs:
-      - targets: ['127.0.0.1:3000']
+      - targets: ['127.0.0.1:9090']
 ```
 
 Reload Prometheus:
@@ -91,7 +95,7 @@ Verify in the UI (`http://localhost:9090 → Status → Targets`) that the `linn
 1. Tail the exporter directly:
 
    ```bash
-   curl -H 'Accept: text/plain' http://127.0.0.1:3000/metrics/prometheus
+   curl -H 'Accept: text/plain' http://127.0.0.1:9090/metrics/prometheus
    ```
 
    You should see counters such as `linnix_events_total`, `linnix_alerts_emitted_total`, and gauges for process CPU/RSS.

--- a/docs/wiki/API-Reference.md
+++ b/docs/wiki/API-Reference.md
@@ -4,7 +4,8 @@ Base URL: `http://localhost:3000`
 
 ## Authentication
 
-Set the `LINNIX_API_TOKEN` environment variable to enable Bearer token authentication.
+Set `LINNIX_API_TOKEN` to authenticate the API. The daemon refuses to start a
+TCP API bound outside loopback without this token (or `api.auth_token`).
 
 ```bash
 # With auth enabled
@@ -39,7 +40,6 @@ curl -H "Authorization: Bearer <token>" http://localhost:3000/status
 | `/insights/recent` | GET | - |
 | `/insights/schema` | GET | - |
 | `/metrics` | GET | - |
-| `/metrics/prometheus` | GET | - |
 | `/metrics/system` | GET | - |
 | `/ppid/{ppid}` | GET | - |
 | `/processes` | GET | - |
@@ -119,11 +119,12 @@ Returns metrics in JSON format.
 curl http://localhost:3000/metrics | jq
 ```
 
-#### GET /metrics/prometheus
-Returns metrics in Prometheus text exposition format.
+#### GET /metrics/prometheus (operational listener)
+Returns metrics in Prometheus text exposition format from the separate
+operational listener, which defaults to `http://localhost:9090`.
 
 ```bash
-curl http://localhost:3000/metrics/prometheus
+curl http://localhost:9090/metrics/prometheus
 ```
 
 ---

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -5,17 +5,36 @@ This directory contains manifests to deploy Linnix as a DaemonSet on your Kubern
 ## Quick Start
 
 ```bash
+kubectl create secret generic linnix-api-token \
+  --namespace default \
+  --from-literal=token="$(openssl rand -base64 32)"
 kubectl apply -f k8s/
 ```
 
 This will create:
-- `ConfigMap/linnix-config`: Default configuration (monitor mode).
+- `Secret/linnix-api-token`: Operator-created bearer token for the API.
+- `ConfigMap/linnix-config`: Default configuration (monitor mode, no secrets).
 - `ServiceAccount/linnix-agent`: Identity for the agent.
 - `DaemonSet/linnix-agent`: The agent pod on every node.
+- `NetworkPolicy/linnix-agent-ingress`: Restricts access to the privileged API.
 
 ## Configuration
 
 Edit `k8s/configmap.yaml` to change settings.
+
+The API on port 3000 binds to all pod interfaces and requires
+`LINNIX_API_TOKEN`, which the DaemonSet reads from `Secret/linnix-api-token`
+key `token`. Do not add the token to the ConfigMap. Workloads that need the API
+must have label `linnix.io/api-access: "true"`, be in the same namespace, and
+send `Authorization: Bearer <token>`.
+
+Prometheus, liveness, and readiness use the separate unauthenticated
+operational listener on port 9090. It exposes only `/metrics/prometheus`,
+`/healthz`, and `/readyz`; it cannot serve process, incident, or action data.
+The included NetworkPolicy allows this port from pods in any namespace. Narrow
+the Prometheus rule to your collector's labels if your cluster policy supports
+that selector. It takes effect only with a CNI that enforces Kubernetes
+NetworkPolicy.
 
 ### Capabilities & Privileges
 
@@ -49,7 +68,7 @@ We provide a configuration file to spin up a compatible cluster (Amazon Linux 20
 # Create cluster (takes ~15 mins)
 eksctl create cluster -f infrastructure/eks-cluster.yaml
 
-# Deploy Linnix
+# Create the Secret from Quick Start, then deploy Linnix
 kubectl apply -f k8s/
 ```
 
@@ -66,5 +85,6 @@ kubectl apply -f k8s/
 
 3. **Deploy**:
    ```bash
+   # Create the Secret from Quick Start, then deploy Linnix
    kubectl apply -f k8s/
    ```

--- a/k8s/configmap.yaml
+++ b/k8s/configmap.yaml
@@ -9,7 +9,7 @@ data:
   linnix.toml: |
     [api]
     listen_addr = "0.0.0.0:3000"
-    # auth_token = "your-secret-token"  # IMPORTANT: Set this for production!
+    # LINNIX_API_TOKEN is injected from Secret/linnix-api-token by the DaemonSet.
 
     [runtime]
     offline = false
@@ -29,9 +29,10 @@ data:
     endpoint = "http://localhost:8090/v1/chat/completions"
 
     [outputs]
-    # Serves the Prometheus text exposition at /metrics/prometheus, including
-    # the per-pod stall attribution metrics the Grafana dashboard charts.
+    # Prometheus and kubelet probes use a separate, unauthenticated operational
+    # listener. It never exposes process, system, incident, or action routes.
     prometheus = true
+    metrics_listen_addr = "0.0.0.0:9090"
 
     [psi]
     # Seconds of sustained pressure before a stall is attributed to neighbours.

--- a/k8s/daemonset.yaml
+++ b/k8s/daemonset.yaml
@@ -19,11 +19,10 @@ spec:
         # stays empty. Prometheus Operator users should add a PodMonitor
         # instead; these annotations are ignored by it.
         #
-        # If you set api.auth_token in the ConfigMap, the metrics route requires
-        # it too and this annotation-based scrape gets 401. See
-        # k8s/grafana/README.md for a scrape job that sends the token.
+        # Metrics are intentionally exposed only by the operational listener;
+        # the host-privileged API listener on 3000 always requires a token.
         prometheus.io/scrape: "true"
-        prometheus.io/port: "3000"
+        prometheus.io/port: "9090"
         prometheus.io/path: "/metrics/prometheus"
     spec:
       serviceAccountName: linnix-agent
@@ -36,6 +35,14 @@ spec:
             privileged: true  # Simplest for eBPF. Can be refined with caps.
             # capabilities:
             #   add: ["BPF", "PERFMON", "SYS_RESOURCE", "SYS_ADMIN"]
+          env:
+            # Required for the non-loopback API listener. Do not put this
+            # token in the ConfigMap.
+            - name: LINNIX_API_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: linnix-api-token
+                  key: token
           volumeMounts:
             - name: config
               mountPath: /etc/linnix
@@ -58,14 +65,16 @@ spec:
               cpu: 100m
           ports:
             - containerPort: 3000
-              name: http
+              name: api
+            - containerPort: 9090
+              name: metrics
           # Liveness only asks "is the process alive?". It deliberately does NOT
           # check eBPF: a kernel that cannot load our programs never will, so
           # failing liveness would CrashLoopBackOff and bury the real reason.
           livenessProbe:
             httpGet:
               path: /healthz
-              port: http
+              port: metrics
             initialDelaySeconds: 15
             periodSeconds: 20
           # Readiness reflects whether this agent is actually producing
@@ -76,7 +85,7 @@ spec:
           readinessProbe:
             httpGet:
               path: /readyz
-              port: http
+              port: metrics
             initialDelaySeconds: 20
             periodSeconds: 30
             failureThreshold: 2

--- a/k8s/grafana/README.md
+++ b/k8s/grafana/README.md
@@ -21,21 +21,22 @@ The victim metric is in microseconds and the offender metric is in seconds —
 they come from different sources, so the panels carry different units on
 purpose. Don't sum across the two.
 
-## If you set an API token
+## Metrics listener
 
-`api.auth_token` protects every route, `/metrics/prometheus` included, and the
-scrape annotations carry no credential — so an authenticated deployment returns
-401 to the annotation-based job and the dashboard stays empty. Point Prometheus
-at the same token instead of relying on annotations:
+The Kubernetes DaemonSet serves Prometheus on its separate operational listener
+at port 9090. This endpoint is intentionally unauthenticated so Prometheus and
+Kubernetes probes can scrape it, but it exposes no process, incident, system,
+or enforcement routes. The API remains on port 3000 and requires the
+Secret-backed bearer token.
+
+The included annotations work with Prometheus' standard pod discovery. An
+explicit scrape job can use the same dedicated port without API credentials:
 
 ```yaml
 # prometheus.yml — replaces the annotation-driven job for Linnix
 - job_name: linnix
   kubernetes_sd_configs:
     - role: pod
-  authorization:
-    type: Bearer
-    credentials_file: /etc/prometheus/secrets/linnix-token/token
   # The metric's own victim_* labels never collide with the target labels
   # Prometheus attaches, so honor_labels is not needed.
   relabel_configs:
@@ -44,7 +45,7 @@ at the same token instead of relying on annotations:
       regex: linnix
     - source_labels: [__meta_kubernetes_pod_ip]
       target_label: __address__
-      replacement: $1:3000
+      replacement: $1:9090
     - target_label: __metrics_path__
       replacement: /metrics/prometheus
     - source_labels: [__meta_kubernetes_pod_node_name]
@@ -63,24 +64,20 @@ spec:
     matchLabels:
       app: linnix
   podMetricsEndpoints:
-    - port: api
+    - port: metrics
       path: /metrics/prometheus
-      authorization:
-        credentials:
-          name: linnix-api-token
-          key: token
 ```
 
 ## If the panels are empty
 
 1. **Is the endpoint on?** `kubectl exec` into an agent pod and
-   `curl localhost:3000/metrics/prometheus`. A 404 means `[outputs] prometheus`
+   `curl localhost:9090/metrics/prometheus`. A 404 means `[outputs] prometheus`
    is not set — check the ConfigMap.
 2. **Is Prometheus scraping it?** The DaemonSet carries `prometheus.io/scrape`
    annotations, which the standard `kubernetes-pods` job honours. Prometheus
    Operator ignores annotations; add a `PodMonitor` selecting `app: linnix` on
-   port 3000, path `/metrics/prometheus`.
-3. **Are the probes attached?** `curl localhost:3000/readyz`. Attribution is
+   port 9090, path `/metrics/prometheus`.
+3. **Are the probes attached?** `curl localhost:9090/readyz`. Attribution is
    kernel-derived, so a node running userspace-only reports nothing to blame.
 4. **Has anything stalled yet?** The offender metric only appears once a pod
    sustains pressure for `sustained_pressure_seconds`. On an idle cluster both

--- a/k8s/networkpolicy.yaml
+++ b/k8s/networkpolicy.yaml
@@ -1,0 +1,29 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: linnix-agent-ingress
+  namespace: default
+  labels:
+    app: linnix
+spec:
+  podSelector:
+    matchLabels:
+      app: linnix
+  policyTypes:
+    - Ingress
+  ingress:
+    # Prometheus scrapers need only the dedicated operational listener.
+    - from:
+        - namespaceSelector: {}
+      ports:
+        - protocol: TCP
+          port: 9090
+    # API consumers must opt in with this label and authenticate with the
+    # Secret-backed bearer token. Adjust this selector for your API client.
+    - from:
+        - podSelector:
+            matchLabels:
+              linnix.io/api-access: "true"
+      ports:
+        - protocol: TCP
+          port: 3000


### PR DESCRIPTION
## Summary

- refuse non-loopback API startup unless a non-empty bearer token is configured
- inject `LINNIX_API_TOKEN` from `Secret/linnix-api-token` in the DaemonSet
- move Prometheus, liveness, and readiness to a dedicated unauthenticated operational listener on port 9090
- add a NetworkPolicy that restricts port 3000 to explicitly labeled API clients
- update Kubernetes, Prometheus, and API documentation

## Why

The shipped Kubernetes configuration bound the API to `0.0.0.0:3000` without authentication while the pod used `hostPID: true` and privileged mode. A reachable pod could expose process, system, and incident data and allow approval of host-PID kill actions.

The previous startup path only logged a warning. This change fails closed and structurally separates the narrow operational surface from sensitive API routes.

## Deployment impact

Operators must create `Secret/linnix-api-token` with key `token` before applying the manifests. API clients must send `Authorization: Bearer <token>` and match the NetworkPolicy selector. Prometheus and Kubernetes probes use port 9090 without API credentials.

## Validation

- `cargo test -p cognitod --bin cognitod` (37 passed)
- `cargo test -p cognitod --lib` (111 passed)
- `cargo clippy -p cognitod --bin cognitod -- -D warnings`
- repository pre-commit formatting, clippy, and unit-test checks
- strict client-side Kubernetes OpenAPI validation against Kind Kubernetes 1.27
- strict server-side Kubernetes dry-run against Kind Kubernetes 1.27
- offline YAML parsing and `git diff --check`
