### PR TITLE
fix: address auth hardening review follow-ups

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -189,7 +189,7 @@ jobs:
           echo "Waiting for cognitod..."
           COGNITOD_READY=false
           for i in {1..30}; do
-            if curl -sf http://localhost:3000/healthz > /dev/null 2>&1; then
+            if curl -sf http://localhost:9464/healthz > /dev/null 2>&1; then
               echo "✅ Cognitod is healthy"
               COGNITOD_READY=true
               break
@@ -227,7 +227,7 @@ jobs:
           
           # Test healthz
           echo "GET /healthz"
-          curl -f http://localhost:3000/healthz || exit 1
+          curl -f http://localhost:9464/healthz || exit 1
           
           # Test status
           echo "GET /status"

--- a/Dockerfile
+++ b/Dockerfile
@@ -94,10 +94,10 @@ ENV LINNIX_BPF_PATH=/usr/local/share/linnix/linnix-ai-ebpf-ebpf
 ENV LINNIX_CONFIG=/etc/linnix/linnix.toml
 ENV RUST_LOG=info
 
-EXPOSE 3000
+EXPOSE 3000 9464
 
 HEALTHCHECK --interval=10s --timeout=5s --start-period=30s --retries=3 \
-    CMD curl -f http://localhost:3000/readyz || exit 1
+    CMD curl -f http://localhost:9464/readyz || exit 1
 
 # Security: runs as root with minimal capabilities (CAP_BPF + CAP_PERFMON)
 # Docker capabilities require root user. See SECURITY.md for details.

--- a/cognitod/src/config.rs
+++ b/cognitod/src/config.rs
@@ -593,7 +593,7 @@ impl Default for OutputConfig {
 }
 
 fn default_metrics_listen_addr() -> String {
-    "127.0.0.1:9090".to_string()
+    "127.0.0.1:9464".to_string()
 }
 
 #[derive(Clone)]
@@ -827,7 +827,10 @@ offline = true
     fn the_shipped_configs_enable_the_metrics_endpoint() {
         // Guards the actual regression: a shipped config that looks like it
         // turns metrics on but does not.
-        for path in ["../configs/linnix.toml", "../configs/linnix.darwin.toml"] {
+        for (path, expected_addr) in [
+            ("../configs/linnix.toml", "127.0.0.1:9464"),
+            ("../configs/linnix.darwin.toml", "0.0.0.0:9464"),
+        ] {
             let contents = std::fs::read_to_string(path)
                 .unwrap_or_else(|e| panic!("cannot read {}: {}", path, e));
             let mut cfg: Config = toml::from_str(&contents)
@@ -836,6 +839,11 @@ offline = true
             assert!(
                 cfg.outputs.prometheus,
                 "{} should serve /metrics/prometheus",
+                path
+            );
+            assert_eq!(
+                cfg.outputs.metrics_listen_addr, expected_addr,
+                "{} should use the dedicated operational port",
                 path
             );
         }
@@ -862,9 +870,50 @@ offline = true
             "the DaemonSet must serve /metrics/prometheus or the dashboard is empty"
         );
         assert_eq!(
-            cfg.outputs.metrics_listen_addr, "0.0.0.0:9090",
+            cfg.outputs.metrics_listen_addr, "0.0.0.0:9464",
             "Kubernetes must expose unauthenticated metrics on the dedicated surface"
         );
+    }
+
+    #[test]
+    fn the_docker_quickstart_injects_auth_and_probes_the_operational_listener() {
+        let compose = std::fs::read_to_string("../docker-compose.yml")
+            .expect("cannot read docker-compose.yml");
+        let compose: serde_yaml::Value =
+            serde_yaml::from_str(&compose).expect("docker-compose.yml is not valid YAML");
+        let cognitod = &compose["services"]["cognitod"];
+        let environment = cognitod["environment"]
+            .as_sequence()
+            .expect("cognitod environment must be a sequence");
+        assert!(
+            environment
+                .iter()
+                .any(|entry| { entry.as_str() == Some("LINNIX_API_TOKEN=${LINNIX_API_TOKEN:-}") })
+        );
+        assert!(
+            cognitod["healthcheck"]["test"]
+                .as_sequence()
+                .expect("cognitod healthcheck test must be a sequence")
+                .iter()
+                .any(|entry| entry.as_str() == Some("http://localhost:9464/readyz"))
+        );
+
+        let darwin = std::fs::read_to_string("../docker-compose.darwin.yml")
+            .expect("cannot read docker-compose.darwin.yml");
+        let darwin: serde_yaml::Value =
+            serde_yaml::from_str(&darwin).expect("docker-compose.darwin.yml is not valid YAML");
+        assert!(
+            darwin["services"]["cognitod"]["ports"]
+                .as_sequence()
+                .expect("Darwin cognitod ports must be a sequence")
+                .iter()
+                .any(|entry| entry.as_str() == Some("127.0.0.1:9464:9464"))
+        );
+
+        let quickstart =
+            std::fs::read_to_string("../quickstart.sh").expect("cannot read quickstart.sh");
+        assert!(quickstart.contains("openssl rand -hex 32"));
+        assert!(quickstart.contains("http://localhost:9464/healthz"));
     }
 
     #[test]

--- a/cognitod/src/config.rs
+++ b/cognitod/src/config.rs
@@ -917,6 +917,24 @@ offline = true
     }
 
     #[test]
+    fn the_ec2_deployment_exposes_the_operational_listener() {
+        let user_data = std::fs::read_to_string("../terraform/ec2/user-data.sh")
+            .expect("cannot read terraform/ec2/user-data.sh");
+        assert!(user_data.contains("[outputs]"));
+        assert!(user_data.contains("prometheus = true"));
+        assert!(user_data.contains("metrics_listen_addr = \"0.0.0.0:9464\""));
+
+        let main = std::fs::read_to_string("../terraform/ec2/main.tf")
+            .expect("cannot read terraform/ec2/main.tf");
+        assert!(main.contains("from_port   = 9464"));
+        assert!(main.contains("to_port     = 9464"));
+
+        let outputs = std::fs::read_to_string("../terraform/ec2/outputs.tf")
+            .expect("cannot read terraform/ec2/outputs.tf");
+        assert!(outputs.contains(":9464/metrics/prometheus"));
+    }
+
+    #[test]
     fn the_kubernetes_daemonset_uses_a_secret_for_the_public_api_token() {
         let manifest = std::fs::read_to_string("../k8s/daemonset.yaml")
             .expect("cannot read k8s/daemonset.yaml");

--- a/cognitod/src/main.rs
+++ b/cognitod/src/main.rs
@@ -1391,23 +1391,17 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let api = all_routes(app_state.clone());
     let listener = TcpListener::bind(&listen_addr).await?;
 
-    let metrics_listener = if config.outputs.prometheus {
-        let metrics_listen_addr = std::env::var("LINNIX_METRICS_LISTEN_ADDR")
-            .unwrap_or(config.outputs.metrics_listen_addr.clone());
-        let metrics_listener =
-            TcpListener::bind(&metrics_listen_addr)
-                .await
-                .with_context(|| {
-                    format!("failed to bind operational metrics listener on {metrics_listen_addr}")
-                })?;
-        info!(
-            "[cognitod] operational metrics server on http://{}",
-            metrics_listen_addr
-        );
-        Some(metrics_listener)
-    } else {
-        None
-    };
+    let metrics_listen_addr = std::env::var("LINNIX_METRICS_LISTEN_ADDR")
+        .unwrap_or(config.outputs.metrics_listen_addr.clone());
+    let metrics_listener = TcpListener::bind(&metrics_listen_addr)
+        .await
+        .with_context(|| {
+            format!("failed to bind operational metrics listener on {metrics_listen_addr}")
+        })?;
+    info!(
+        "[cognitod] operational metrics server on http://{}",
+        metrics_listen_addr
+    );
 
     info!("[cognitod] HTTP server on http://{}", listen_addr);
     tokio::spawn(async move {
@@ -1416,14 +1410,12 @@ async fn main() -> Result<(), Box<dyn Error>> {
         }
     });
 
-    if let Some(metrics_listener) = metrics_listener {
-        let metrics_api = metrics_routes(app_state.clone());
-        tokio::spawn(async move {
-            if let Err(e) = axum::serve(metrics_listener, metrics_api).await {
-                eprintln!("metrics server error: {e}");
-            }
-        });
-    }
+    let metrics_api = metrics_routes(app_state.clone());
+    tokio::spawn(async move {
+        if let Err(e) = axum::serve(metrics_listener, metrics_api).await {
+            eprintln!("metrics server error: {e}");
+        }
+    });
 
     // ── Unix domain socket listener (bypasses token auth) ──
     let uds_path = std::env::var("LINNIX_UDS_PATH")

--- a/configs/linnix.darwin.toml
+++ b/configs/linnix.darwin.toml
@@ -30,7 +30,7 @@ timeout_ms = 30000
 [outputs]
 # Serve Prometheus, health, and readiness on a separate operational listener.
 prometheus = true
-metrics_listen_addr = "127.0.0.1:9090"
+metrics_listen_addr = "0.0.0.0:9464"
 
 [probes]
 # eBPF probe configuration

--- a/configs/linnix.toml
+++ b/configs/linnix.toml
@@ -30,7 +30,7 @@ timeout_ms = 30000
 [outputs]
 # Serve Prometheus, health, and readiness on a separate operational listener.
 prometheus = true
-metrics_listen_addr = "127.0.0.1:9090"
+metrics_listen_addr = "127.0.0.1:9464"
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Notifications via Apprise (optional)

--- a/docker-compose.darwin.yml
+++ b/docker-compose.darwin.yml
@@ -13,9 +13,10 @@ services:
     # Override network mode from host to bridge
     network_mode: bridge
     
-    # Map port 3000 to macOS host
+    # Keep the unauthenticated operational listener local to the macOS host.
     ports:
       - "3000:3000"
+      - "127.0.0.1:9464:9464"
     
     # Can't use pid: host on macOS
     pid: null

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,6 +60,7 @@ services:
     environment:
       - RUST_LOG=info
       - LINNIX_CONFIG=/etc/linnix/linnix.toml
+      - LINNIX_API_TOKEN=${LINNIX_API_TOKEN:-}
 
     # Demo mode: Run all demo scenarios on startup
     # Uncomment the line below to enable demo mode
@@ -68,7 +69,7 @@ services:
     restart: unless-stopped
 
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:3000/readyz"]
+      test: ["CMD", "curl", "-f", "http://localhost:9464/readyz"]
       interval: 10s
       timeout: 5s
       retries: 3

--- a/docs/AWS_EC2_DEPLOYMENT.md
+++ b/docs/AWS_EC2_DEPLOYMENT.md
@@ -451,9 +451,9 @@ enabled = true  # Enable if you have LLM installed via Docker
 endpoint = "http://127.0.0.1:8090/v1/chat/completions"
 model = "linnix-3b-distilled"
 
-[prometheus]
-enabled = true  # Enable Prometheus metrics
-listen_addr = "0.0.0.0:9090"
+[outputs]
+prometheus = true  # Enable Prometheus metrics
+metrics_listen_addr = "0.0.0.0:9464"
 
 [alerts]
 # Add Apprise notification URLs

--- a/docs/AWS_EC2_DEPLOYMENT.md
+++ b/docs/AWS_EC2_DEPLOYMENT.md
@@ -389,7 +389,7 @@ curl -fsSL https://raw.githubusercontent.com/linnix-os/linnix/main/docs/examples
 | SSH | TCP | 22 | Your IP | SSH access |
 | Custom TCP | TCP | 3000 | Your IP / VPC CIDR | Linnix API/Dashboard |
 | Custom TCP | TCP | 8090 | Localhost only | LLM Server (internal) |
-| Custom TCP | TCP | 9090 | Your IP (optional) | Prometheus metrics |
+| Custom TCP | TCP | 9464 | Your IP (optional) | Prometheus metrics |
 
 **Note:** Port 8090 (LLM server) should typically only be accessible from localhost. The cognitod service connects to it internally via `http://127.0.0.1:8090`.
 

--- a/docs/HOW_IT_WORKS.md
+++ b/docs/HOW_IT_WORKS.md
@@ -38,7 +38,7 @@ Linnix combines eBPF probes, BTF-powered compatibility helpers, and an AI reason
    - `http://localhost:3000/stream` (Server-Sent Events)
    - `http://localhost:3000/insights` (AI output)
    - `http://localhost:3000/metrics` (JSON) and
-     `http://localhost:9090/metrics/prometheus`
+     `http://localhost:9464/metrics/prometheus`
 5. **Prometheus integration** is just a config flag; no sidecar required.
 
 ## 4. AI Reasoning Loop

--- a/docs/examples/install-ec2.sh
+++ b/docs/examples/install-ec2.sh
@@ -379,10 +379,10 @@ enabled = ${INSTALL_LLM}
 endpoint = "http://127.0.0.1:8090/v1/chat/completions"
 model = "linnix-qwen-v1"
 
-[prometheus]
+[outputs]
 # Prometheus metrics export
-enabled = false
-listen_addr = "0.0.0.0:9090"
+prometheus = false
+metrics_listen_addr = "0.0.0.0:9464"
 
 [alerts]
 # Alert destinations

--- a/docs/prometheus-integration.md
+++ b/docs/prometheus-integration.md
@@ -11,11 +11,11 @@ Set the Prometheus flag in the Cognitod config (usually `/etc/linnix/linnix.toml
 ```toml
 [outputs]
 prometheus = true
-metrics_listen_addr = "127.0.0.1:9090"
+metrics_listen_addr = "127.0.0.1:9464"
 ```
 
 Restart Cognitod if it is already running. The daemon serves Prometheus text
-exposition at `http://<host>:9090/metrics/prometheus`. This operational listener
+exposition at `http://<host>:9464/metrics/prometheus`. This operational listener
 also serves health and readiness, but it does not expose the JSON `/metrics`
 endpoint or any process, incident, or action routes.
 
@@ -79,7 +79,7 @@ scrape_configs:
   - job_name: 'linnix'
     metrics_path: /metrics/prometheus
     static_configs:
-      - targets: ['127.0.0.1:9090']
+      - targets: ['127.0.0.1:9464']
 ```
 
 Reload Prometheus:
@@ -95,7 +95,7 @@ Verify in the UI (`http://localhost:9090 → Status → Targets`) that the `linn
 1. Tail the exporter directly:
 
    ```bash
-   curl -H 'Accept: text/plain' http://127.0.0.1:9090/metrics/prometheus
+   curl -H 'Accept: text/plain' http://127.0.0.1:9464/metrics/prometheus
    ```
 
    You should see counters such as `linnix_events_total`, `linnix_alerts_emitted_total`, and gauges for process CPU/RSS.

--- a/docs/wiki/API-Reference.md
+++ b/docs/wiki/API-Reference.md
@@ -121,10 +121,10 @@ curl http://localhost:3000/metrics | jq
 
 #### GET /metrics/prometheus (operational listener)
 Returns metrics in Prometheus text exposition format from the separate
-operational listener, which defaults to `http://localhost:9090`.
+operational listener, which defaults to `http://localhost:9464`.
 
 ```bash
-curl http://localhost:9090/metrics/prometheus
+curl http://localhost:9464/metrics/prometheus
 ```
 
 ---

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -29,7 +29,7 @@ must have label `linnix.io/api-access: "true"`, be in the same namespace, and
 send `Authorization: Bearer <token>`.
 
 Prometheus, liveness, and readiness use the separate unauthenticated
-operational listener on port 9090. It exposes only `/metrics/prometheus`,
+operational listener on port 9464. It exposes only `/metrics/prometheus`,
 `/healthz`, and `/readyz`; it cannot serve process, incident, or action data.
 The included NetworkPolicy allows this port from pods in any namespace. Narrow
 the Prometheus rule to your collector's labels if your cluster policy supports

--- a/k8s/configmap.yaml
+++ b/k8s/configmap.yaml
@@ -32,7 +32,7 @@ data:
     # Prometheus and kubelet probes use a separate, unauthenticated operational
     # listener. It never exposes process, system, incident, or action routes.
     prometheus = true
-    metrics_listen_addr = "0.0.0.0:9090"
+    metrics_listen_addr = "0.0.0.0:9464"
 
     [psi]
     # Seconds of sustained pressure before a stall is attributed to neighbours.

--- a/k8s/daemonset.yaml
+++ b/k8s/daemonset.yaml
@@ -22,7 +22,7 @@ spec:
         # Metrics are intentionally exposed only by the operational listener;
         # the host-privileged API listener on 3000 always requires a token.
         prometheus.io/scrape: "true"
-        prometheus.io/port: "9090"
+        prometheus.io/port: "9464"
         prometheus.io/path: "/metrics/prometheus"
     spec:
       serviceAccountName: linnix-agent
@@ -66,7 +66,7 @@ spec:
           ports:
             - containerPort: 3000
               name: api
-            - containerPort: 9090
+            - containerPort: 9464
               name: metrics
           # Liveness only asks "is the process alive?". It deliberately does NOT
           # check eBPF: a kernel that cannot load our programs never will, so

--- a/k8s/grafana/README.md
+++ b/k8s/grafana/README.md
@@ -24,7 +24,7 @@ purpose. Don't sum across the two.
 ## Metrics listener
 
 The Kubernetes DaemonSet serves Prometheus on its separate operational listener
-at port 9090. This endpoint is intentionally unauthenticated so Prometheus and
+at port 9464. This endpoint is intentionally unauthenticated so Prometheus and
 Kubernetes probes can scrape it, but it exposes no process, incident, system,
 or enforcement routes. The API remains on port 3000 and requires the
 Secret-backed bearer token.
@@ -45,7 +45,7 @@ explicit scrape job can use the same dedicated port without API credentials:
       regex: linnix
     - source_labels: [__meta_kubernetes_pod_ip]
       target_label: __address__
-      replacement: $1:9090
+      replacement: $1:9464
     - target_label: __metrics_path__
       replacement: /metrics/prometheus
     - source_labels: [__meta_kubernetes_pod_node_name]
@@ -71,13 +71,13 @@ spec:
 ## If the panels are empty
 
 1. **Is the endpoint on?** `kubectl exec` into an agent pod and
-   `curl localhost:9090/metrics/prometheus`. A 404 means `[outputs] prometheus`
+   `curl localhost:9464/metrics/prometheus`. A 404 means `[outputs] prometheus`
    is not set — check the ConfigMap.
 2. **Is Prometheus scraping it?** The DaemonSet carries `prometheus.io/scrape`
    annotations, which the standard `kubernetes-pods` job honours. Prometheus
    Operator ignores annotations; add a `PodMonitor` selecting `app: linnix` on
-   port 9090, path `/metrics/prometheus`.
-3. **Are the probes attached?** `curl localhost:9090/readyz`. Attribution is
+   port 9464, path `/metrics/prometheus`.
+3. **Are the probes attached?** `curl localhost:9464/readyz`. Attribution is
    kernel-derived, so a node running userspace-only reports nothing to blame.
 4. **Has anything stalled yet?** The offender metric only appears once a pod
    sustains pressure for `sustained_pressure_seconds`. On an idle cluster both

--- a/k8s/networkpolicy.yaml
+++ b/k8s/networkpolicy.yaml
@@ -17,7 +17,7 @@ spec:
         - namespaceSelector: {}
       ports:
         - protocol: TCP
-          port: 9090
+          port: 9464
     # API consumers must opt in with this label and authenticate with the
     # Secret-backed bearer token. Adjust this selector for your API client.
     - from:

--- a/quickstart.sh
+++ b/quickstart.sh
@@ -14,6 +14,7 @@ NC='\033[0m' # No Color
 # --- Globals ---
 COMPOSE_CMD=""
 ACTION="start"
+API_TOKEN_FILE=""
 # The LLM is optional: attribution works without it. Opt in with --with-ai.
 WITH_AI=false
 
@@ -92,6 +93,38 @@ detect_compose() {
     if [ "$WITH_AI" = true ] || [ "$ACTION" = "stop" ]; then
         COMPOSE_CMD="$COMPOSE_CMD --profile ai"
     fi
+}
+
+# Docker Desktop requires the API to bind beyond container loopback. Persist a
+# generated token so repeated quickstart runs keep the same API credentials.
+ensure_macos_api_token() {
+    if [[ "$OSTYPE" != "darwin"* ]]; then
+        return
+    fi
+
+    if [ -n "${LINNIX_API_TOKEN:-}" ]; then
+        echo -e "${GREEN}✅ Using LINNIX_API_TOKEN from the environment.${NC}"
+        return
+    fi
+
+    local config_home="${XDG_CONFIG_HOME:-$HOME/.config}"
+    API_TOKEN_FILE="$config_home/linnix/quickstart-api-token"
+    if [ -s "$API_TOKEN_FILE" ]; then
+        LINNIX_API_TOKEN="$(<"$API_TOKEN_FILE")"
+    else
+        mkdir -p "$(dirname "$API_TOKEN_FILE")"
+        if command -v openssl &> /dev/null; then
+            LINNIX_API_TOKEN="$(openssl rand -hex 32)"
+        elif command -v od &> /dev/null; then
+            LINNIX_API_TOKEN="$(od -An -N32 -tx1 /dev/urandom | tr -d ' \n')"
+        else
+            echo -e "${RED}❌ Cannot generate an API token: openssl and od are unavailable.${NC}"
+            exit 1
+        fi
+        (umask 077 && printf '%s\n' "$LINNIX_API_TOKEN" > "$API_TOKEN_FILE")
+        echo -e "${GREEN}✅ Generated an API token at $API_TOKEN_FILE.${NC}"
+    fi
+    export LINNIX_API_TOKEN
 }
 
 # Check for all necessary prerequisites
@@ -182,7 +215,7 @@ check_model() {
 check_ports() {
     echo -e "\n${BLUE}[3/5]${NC} Checking port availability..."
     local ports_in_use=()
-    local required_ports=(3000)
+    local required_ports=(3000 9464)
     [ "$WITH_AI" = true ] && required_ports+=(8090)
     
     for port in "${required_ports[@]}"; do
@@ -292,7 +325,7 @@ wait_for_health() {
     echo -e "\n${BLUE}[5/5]${NC} Waiting for services to become healthy..."
     echo -n "   Cognitod: "
     for i in {1..30}; do
-        if curl -sf http://localhost:3000/healthz > /dev/null; then
+        if curl -sf http://localhost:9464/healthz > /dev/null; then
             echo -e "${GREEN}✅ Running${NC}"
             break
         fi
@@ -335,11 +368,22 @@ show_summary() {
     if [ "$WITH_AI" = true ]; then
         echo "   • LLM Server:               http://localhost:8090"
     fi
-    echo "   • Prometheus Metrics:       http://localhost:3000/metrics/prometheus"
+    echo "   • Prometheus Metrics:       http://localhost:9464/metrics/prometheus"
     echo ""
     echo -e "${GREEN}Quick Commands:${NC}"
-    echo "   • Watch alerts:             curl -N http://localhost:3000/stream"
-    echo "   • Get LLM insights:         curl http://localhost:3000/insights | jq"
+    if [ -n "${LINNIX_API_TOKEN:-}" ]; then
+        if [ -n "$API_TOKEN_FILE" ]; then
+            echo "   • API token:                $API_TOKEN_FILE"
+            echo "   • Watch alerts:             curl -H \"Authorization: Bearer \$(cat '$API_TOKEN_FILE')\" -N http://localhost:3000/stream"
+            echo "   • Get LLM insights:         curl -H \"Authorization: Bearer \$(cat '$API_TOKEN_FILE')\" http://localhost:3000/insights | jq"
+        else
+            echo '   • Watch alerts:             curl -H "Authorization: Bearer $LINNIX_API_TOKEN" -N http://localhost:3000/stream'
+            echo '   • Get LLM insights:         curl -H "Authorization: Bearer $LINNIX_API_TOKEN" http://localhost:3000/insights | jq'
+        fi
+    else
+        echo "   • Watch alerts:             curl -N http://localhost:3000/stream"
+        echo "   • Get LLM insights:         curl http://localhost:3000/insights | jq"
+    fi
     echo "   • View all logs:            $COMPOSE_CMD logs -f"
     echo "   • Stop services:            ./quickstart.sh stop"
     echo ""
@@ -372,6 +416,7 @@ main() {
         exit 0
     fi
 
+    ensure_macos_api_token
     banner
     check_prerequisites
     check_model

--- a/terraform/ec2/main.tf
+++ b/terraform/ec2/main.tf
@@ -77,8 +77,8 @@ resource "aws_security_group" "linnix" {
     for_each = var.enable_prometheus ? [1] : []
     content {
       description = "Prometheus metrics"
-      from_port   = 9090
-      to_port     = 9090
+      from_port   = 9464
+      to_port     = 9464
       protocol    = "tcp"
       cidr_blocks = var.prometheus_cidr_blocks
     }

--- a/terraform/ec2/outputs.tf
+++ b/terraform/ec2/outputs.tf
@@ -32,7 +32,7 @@ output "api_healthz_url" {
 
 output "prometheus_url" {
   description = "URL to access Prometheus metrics"
-  value       = var.enable_prometheus ? "http://${var.allocate_elastic_ip ? aws_eip.linnix[0].public_ip : aws_instance.linnix.public_ip}:9090/metrics" : null
+  value       = var.enable_prometheus ? "http://${var.allocate_elastic_ip ? aws_eip.linnix[0].public_ip : aws_instance.linnix.public_ip}:9464/metrics/prometheus" : null
 }
 
 output "ssh_command" {

--- a/terraform/ec2/user-data.sh
+++ b/terraform/ec2/user-data.sh
@@ -44,9 +44,9 @@ fi
 if [ "${enable_prometheus}" = "true" ]; then
     cat >> /etc/linnix/linnix.toml <<EOF
 
-[prometheus]
-enabled = true
-listen_addr = "0.0.0.0:9090"
+[outputs]
+prometheus = true
+metrics_listen_addr = "0.0.0.0:9464"
 EOF
     systemctl restart linnix-cognitod
 fi


### PR DESCRIPTION
## Summary
- generate and inject a persistent API token for the macOS quickstart path
- move the unauthenticated operational listener from Prometheus's port 9090 to 9464 across packaged configs and deployment manifests
- probe health on the operational listener and add regression coverage for Compose and shipped configs

Follow-up to #85 and review threads:
- https://github.com/linnix-os/linnix/pull/85#discussion_r3810084261
- https://github.com/linnix-os/linnix/pull/85#discussion_r3810084266

## Validation
- cargo fmt --all -- --check
- cargo test -p cognitod --lib
- cargo test -p cognitod --bin cognitod
- cargo clippy -p cognitod --bin cognitod -- -D warnings
- bash -n quickstart.sh
- docker-compose -f docker-compose.yml -f docker-compose.darwin.yml config
- kubectl apply --server-side --dry-run=server --validate=strict against a temporary Kind cluster
- repository pre-commit hook: 236 tests passed