### PR TITLE
fix: keep secrets out of Docker build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -63,6 +63,12 @@ venv/
 .env*
 !.env.distilled
 
+# Secrets and local workflow state
+_workflow/
+*.pem
+*.key
+.ssh/
+
 # Database
 *.db
 *.sqlite

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -35,10 +35,10 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p _workflow/ssh .ssh
-          printf '%s\n' 'docker-context-secret-sentinel' > _workflow/ssh/docker-context-secret-check.pem
+          printf '%s\n' 'docker-context-secret-sentinel' > _workflow/ssh/docker-context-secret-check
           printf '%s\n' 'docker-context-secret-sentinel' > docker-context-secret-check.key
-          printf '%s\n' 'docker-context-secret-sentinel' > .ssh/docker-context-secret-check.key
-          trap 'rm -f _workflow/ssh/docker-context-secret-check.pem docker-context-secret-check.key .ssh/docker-context-secret-check.key' EXIT
+          printf '%s\n' 'docker-context-secret-sentinel' > .ssh/docker-context-secret-check
+          trap 'rm -f _workflow/ssh/docker-context-secret-check docker-context-secret-check.key .ssh/docker-context-secret-check' EXIT
 
           mapfile -t secret_candidates < <(
             find . \

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -31,6 +31,52 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Verify Docker context excludes local secrets
+        run: |
+          set -euo pipefail
+          mkdir -p _workflow/ssh .ssh
+          printf '%s\n' 'docker-context-secret-sentinel' > _workflow/ssh/docker-context-secret-check.pem
+          printf '%s\n' 'docker-context-secret-sentinel' > docker-context-secret-check.key
+          printf '%s\n' 'docker-context-secret-sentinel' > .ssh/docker-context-secret-check.key
+          trap 'rm -f _workflow/ssh/docker-context-secret-check.pem docker-context-secret-check.key .ssh/docker-context-secret-check.key' EXIT
+
+          mapfile -t secret_candidates < <(
+            find . \
+              -path './.git' -prune -o \
+              -type f \( \
+                -path './_workflow/*' -o \
+                -path './.ssh/*' -o \
+                -name '*.pem' -o \
+                -name '*.key' \
+              \) -printf '%P\n'
+          )
+
+          if [ "${#secret_candidates[@]}" -lt 3 ]
+          then
+            echo "::error::Docker context secret sentinel setup failed"
+            exit 1
+          fi
+
+          for path in "${secret_candidates[@]}"
+          do
+            dockerfile="$(mktemp)"
+            printf 'FROM scratch\nCOPY %s /leak\n' "${path}" > "${dockerfile}"
+            if output="$(docker buildx build --progress=plain -f "${dockerfile}" . 2>&1)"
+            then
+              echo "::error file=.dockerignore::${path} is available to the Docker build context"
+              exit 1
+            fi
+            if ! grep -Eq 'excluded by \.dockerignore|not found|failed to (calculate checksum|compute cache key)' <<<"${output}"
+            then
+              echo "${output}"
+              echo "::error::Docker context check failed before verifying ${path}"
+              exit 1
+            fi
+            rm -f "${dockerfile}"
+          done
+
+          echo "Docker context excludes local secret sentinels."
+
       - name: Log in to Container Registry
         if: github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork
         uses: docker/login-action@v3

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,15 +23,22 @@ WORKDIR /build
 
 # Copy Cargo files for dependency caching
 COPY Cargo.toml Cargo.lock ./
+COPY .cargo/config.toml ./.cargo/config.toml
 COPY linnix-ai-ebpf/linnix-ai-ebpf-common/Cargo.toml ./linnix-ai-ebpf/linnix-ai-ebpf-common/
 COPY linnix-ai-ebpf/linnix-ai-ebpf-ebpf/Cargo.toml ./linnix-ai-ebpf/linnix-ai-ebpf-ebpf/
 COPY linnix-ai-ebpf/linnix-ai-ebpf-ebpf/rust-toolchain.toml ./linnix-ai-ebpf/linnix-ai-ebpf-ebpf/
 COPY cognitod/Cargo.toml ./cognitod/
 COPY linnix-cli/Cargo.toml ./linnix-cli/
 COPY linnix-reasoner/Cargo.toml ./linnix-reasoner/
+COPY xtask/Cargo.toml ./xtask/
 
-# Copy source code
-COPY . .
+# Copy only workspace source trees needed for target discovery and build.
+COPY cognitod/src ./cognitod/src
+COPY linnix-ai-ebpf/linnix-ai-ebpf-common/src ./linnix-ai-ebpf/linnix-ai-ebpf-common/src
+COPY linnix-ai-ebpf/linnix-ai-ebpf-ebpf/src ./linnix-ai-ebpf/linnix-ai-ebpf-ebpf/src
+COPY linnix-cli/src ./linnix-cli/src
+COPY linnix-reasoner/src ./linnix-reasoner/src
+COPY xtask/src ./xtask/src
 
 # Build eBPF programs.
 # Use the xtask entrypoint so this shares one build path (and one set of
@@ -48,13 +55,22 @@ WORKDIR /build
 
 # Copy Cargo files
 COPY Cargo.toml Cargo.lock ./
+COPY .cargo/config.toml ./.cargo/config.toml
 COPY linnix-ai-ebpf/linnix-ai-ebpf-common/Cargo.toml ./linnix-ai-ebpf/linnix-ai-ebpf-common/
+COPY linnix-ai-ebpf/linnix-ai-ebpf-ebpf/Cargo.toml ./linnix-ai-ebpf/linnix-ai-ebpf-ebpf/
+COPY linnix-ai-ebpf/linnix-ai-ebpf-ebpf/rust-toolchain.toml ./linnix-ai-ebpf/linnix-ai-ebpf-ebpf/
 COPY cognitod/Cargo.toml ./cognitod/
 COPY linnix-cli/Cargo.toml ./linnix-cli/
 COPY linnix-reasoner/Cargo.toml ./linnix-reasoner/
+COPY xtask/Cargo.toml ./xtask/
 
-# Copy source
-COPY . .
+# Copy only workspace source trees needed for target discovery and build.
+COPY cognitod/src ./cognitod/src
+COPY linnix-ai-ebpf/linnix-ai-ebpf-common/src ./linnix-ai-ebpf/linnix-ai-ebpf-common/src
+COPY linnix-ai-ebpf/linnix-ai-ebpf-ebpf/src ./linnix-ai-ebpf/linnix-ai-ebpf-ebpf/src
+COPY linnix-cli/src ./linnix-cli/src
+COPY linnix-reasoner/src ./linnix-reasoner/src
+COPY xtask/src ./xtask/src
 
 # Build release binaries with demo feature
 RUN cargo build --release -p cognitod


### PR DESCRIPTION
## Summary

- exclude local workflow state, PEM files, key files, and SSH directories from the Docker build context
- replace broad `COPY . .` instructions with explicit Cargo manifests and workspace source directories
- add a CI sentinel test that scans ignored and untracked Docker-context inputs, not only Git-tracked files

## Root cause

Git ignore rules do not restrict files sent to Docker. The builder stages used `COPY . .`, so an ignored private key under `_workflow/` could still enter the build context and image layers.

## Impact

Local credentials matching these paths can no longer be copied into Docker builds. The CI sentinel check fails if future `.dockerignore` changes expose any protected secret path.

## Validation

- repository pre-commit hook: formatting, clippy, and 237 tests passed
- `git diff --check`
- Docker context sentinel scan
- `docker build --target rust-builder .`
- full `docker build .`
- runtime image scan confirmed no private key or protected directory was present

## Operational note

The discovered local private-key file was deleted. Any credential that may have been used outside this repository still needs to be revoked or rotated at its authorization point.