### PR TITLE
Fix kill action PID identity revalidation

### DIFF
--- a/cognitod/src/api/mod.rs
+++ b/cognitod/src/api/mod.rs
@@ -2438,7 +2438,11 @@ async fn handle_slack_interaction(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::enforcement::{ActionStatus, ActionType, EnforcementQueue};
+    use crate::enforcement::{
+        ActionStatus, ActionType, EnforcementQueue, ProcessCgroupIdentity, ProcessIdentity,
+        ProcessIdentityError, ProcessIdentityProvider, ProcessNamespaceIdentity, SignalHandle,
+        SignalSender,
+    };
     use crate::insights::InsightStore;
     use crate::runtime::probes::{ProbeState, RssProbeMode};
     use crate::{PERCENT_MILLI_UNKNOWN, ProcessEvent};
@@ -2448,6 +2452,56 @@ mod tests {
     use std::sync::Arc;
     use std::sync::atomic::Ordering;
     use tower::ServiceExt;
+
+    #[derive(Debug)]
+    struct ApiTestIdentityProvider;
+
+    impl ProcessIdentityProvider for ApiTestIdentityProvider {
+        fn identity_for_pid(&self, pid: u32) -> Result<ProcessIdentity, ProcessIdentityError> {
+            Ok(ProcessIdentity {
+                pid,
+                start_time_ticks: 42,
+                stat_comm: "api-test-process".to_string(),
+                cgroups: vec![ProcessCgroupIdentity {
+                    hierarchy: 0,
+                    controllers: vec![],
+                    pathname: "/api-test.slice".to_string(),
+                }],
+                pid_namespaces: vec![ProcessNamespaceIdentity {
+                    namespace_type: "pid".to_string(),
+                    device_id: 1,
+                    inode: 2,
+                }],
+                captured_at_ms: 0,
+            })
+        }
+    }
+
+    #[derive(Debug)]
+    struct ApiTestSignalSender;
+
+    impl SignalSender for ApiTestSignalSender {
+        fn open_handle(&self, _pid: u32) -> Result<Box<dyn SignalHandle>, std::io::Error> {
+            Ok(Box::new(ApiTestSignalHandle))
+        }
+    }
+
+    #[derive(Debug)]
+    struct ApiTestSignalHandle;
+
+    impl SignalHandle for ApiTestSignalHandle {
+        fn send_signal(&self, _signal: i32) -> Result<(), std::io::Error> {
+            Ok(())
+        }
+    }
+
+    fn test_enforcement_queue(ttl_secs: u64) -> EnforcementQueue {
+        EnforcementQueue::new_with_components(
+            ttl_secs,
+            Arc::new(ApiTestIdentityProvider),
+            Arc::new(ApiTestSignalSender),
+        )
+    }
 
     fn minimal_app_state(
         auth_token: Option<String>,
@@ -3155,7 +3209,7 @@ mod tests {
 
     #[tokio::test]
     async fn valid_slack_signature_bypasses_bearer_auth_and_approves_action() {
-        let enforcement = Arc::new(EnforcementQueue::new(300));
+        let enforcement = Arc::new(test_enforcement_queue(300));
         let action_id = propose_test_action(&enforcement).await;
         let app_state = minimal_app_state(
             Some("api-secret".to_string()),
@@ -3182,7 +3236,7 @@ mod tests {
 
     #[tokio::test]
     async fn missing_slack_signature_is_rejected_before_action_processing() {
-        let enforcement = Arc::new(EnforcementQueue::new(300));
+        let enforcement = Arc::new(test_enforcement_queue(300));
         let action_id = propose_test_action(&enforcement).await;
         let app_state = minimal_app_state(
             Some("api-secret".to_string()),
@@ -3203,7 +3257,7 @@ mod tests {
 
     #[tokio::test]
     async fn invalid_slack_signature_is_rejected_before_action_processing() {
-        let enforcement = Arc::new(EnforcementQueue::new(300));
+        let enforcement = Arc::new(test_enforcement_queue(300));
         let action_id = propose_test_action(&enforcement).await;
         let app_state = minimal_app_state(
             Some("api-secret".to_string()),
@@ -3241,7 +3295,7 @@ mod tests {
 
     #[tokio::test]
     async fn stale_slack_signature_is_rejected_before_action_processing() {
-        let enforcement = Arc::new(EnforcementQueue::new(300));
+        let enforcement = Arc::new(test_enforcement_queue(300));
         let action_id = propose_test_action(&enforcement).await;
         let app_state = minimal_app_state(
             Some("api-secret".to_string()),

--- a/cognitod/src/enforcement.rs
+++ b/cognitod/src/enforcement.rs
@@ -1,5 +1,8 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::fmt;
+use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
+use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
 use tokio::sync::RwLock;
@@ -10,6 +13,273 @@ mod safety;
 #[serde(rename_all = "snake_case", tag = "type")]
 pub enum ActionType {
     KillProcess { pid: u32, signal: i32 },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ProcessIdentity {
+    pub pid: u32,
+    pub start_time_ticks: u64,
+    pub stat_comm: String,
+    pub cgroups: Vec<ProcessCgroupIdentity>,
+    pub pid_namespaces: Vec<ProcessNamespaceIdentity>,
+    pub captured_at_ms: u64,
+}
+
+impl ProcessIdentity {
+    fn same_process_as(&self, other: &Self) -> bool {
+        self.pid == other.pid
+            && self.start_time_ticks == other.start_time_ticks
+            && self.stat_comm == other.stat_comm
+            && self.cgroups == other.cgroups
+            && self.pid_namespaces == other.pid_namespaces
+    }
+
+    #[cfg(test)]
+    fn for_test(pid: u32) -> Self {
+        Self {
+            pid,
+            start_time_ticks: 42,
+            stat_comm: "test-process".to_string(),
+            cgroups: vec![ProcessCgroupIdentity {
+                hierarchy: 0,
+                controllers: vec![],
+                pathname: "/test.slice".to_string(),
+            }],
+            pid_namespaces: vec![ProcessNamespaceIdentity {
+                namespace_type: "pid".to_string(),
+                device_id: 1,
+                inode: 2,
+            }],
+            captured_at_ms: current_epoch_millis(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+pub struct ProcessCgroupIdentity {
+    pub hierarchy: u32,
+    pub controllers: Vec<String>,
+    pub pathname: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+pub struct ProcessNamespaceIdentity {
+    pub namespace_type: String,
+    pub device_id: u64,
+    pub inode: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ProcessIdentityError {
+    Missing {
+        pid: u32,
+    },
+    Unreadable {
+        pid: u32,
+        detail: String,
+    },
+    Mismatch {
+        pid: u32,
+        expected: Box<ProcessIdentity>,
+        actual: Box<ProcessIdentity>,
+    },
+    Expired {
+        pid: u32,
+        expires_at: u64,
+        now: u64,
+    },
+}
+
+impl fmt::Display for ProcessIdentityError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Missing { pid } => write!(f, "process {pid} is missing"),
+            Self::Unreadable { pid, detail } => {
+                write!(f, "process {pid} identity is unreadable: {detail}")
+            }
+            Self::Mismatch { pid, .. } => {
+                write!(f, "process {pid} identity changed before kill")
+            }
+            Self::Expired {
+                pid,
+                expires_at,
+                now,
+            } => write!(
+                f,
+                "process {pid} identity expired before kill: expires_at={expires_at} now={now}"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for ProcessIdentityError {}
+
+pub trait ProcessIdentityProvider: Send + Sync {
+    fn identity_for_pid(&self, pid: u32) -> Result<ProcessIdentity, ProcessIdentityError>;
+}
+
+#[derive(Debug, Default)]
+struct ProcProcessIdentityProvider;
+
+impl ProcProcessIdentityProvider {
+    fn map_proc_error(pid: u32, context: &str, err: procfs::ProcError) -> ProcessIdentityError {
+        match err {
+            procfs::ProcError::NotFound(_) => ProcessIdentityError::Missing { pid },
+            other => ProcessIdentityError::Unreadable {
+                pid,
+                detail: format!("{context}: {other}"),
+            },
+        }
+    }
+}
+
+impl ProcessIdentityProvider for ProcProcessIdentityProvider {
+    fn identity_for_pid(&self, pid: u32) -> Result<ProcessIdentity, ProcessIdentityError> {
+        use procfs::process::Process;
+
+        let process = Process::new(pid as i32)
+            .map_err(|err| Self::map_proc_error(pid, "open /proc entry", err))?;
+        let stat = process
+            .stat()
+            .map_err(|err| Self::map_proc_error(pid, "read stat", err))?;
+
+        if matches!(stat.state, 'Z' | 'X') {
+            return Err(ProcessIdentityError::Missing { pid });
+        }
+
+        let mut cgroups: Vec<ProcessCgroupIdentity> = process
+            .cgroups()
+            .map_err(|err| Self::map_proc_error(pid, "read cgroup", err))?
+            .into_iter()
+            .map(|group| {
+                let mut controllers = group.controllers;
+                controllers.sort();
+                ProcessCgroupIdentity {
+                    hierarchy: group.hierarchy,
+                    controllers,
+                    pathname: group.pathname,
+                }
+            })
+            .collect();
+        cgroups.sort();
+
+        let mut pid_namespaces: Vec<ProcessNamespaceIdentity> = process
+            .namespaces()
+            .map_err(|err| Self::map_proc_error(pid, "read namespaces", err))?
+            .0
+            .into_iter()
+            .filter_map(|(namespace_type, namespace)| {
+                let namespace_type = namespace_type.to_string_lossy().into_owned();
+                (namespace_type == "pid" || namespace_type == "pid_for_children").then_some(
+                    ProcessNamespaceIdentity {
+                        namespace_type,
+                        device_id: namespace.device_id,
+                        inode: namespace.identifier,
+                    },
+                )
+            })
+            .collect();
+        pid_namespaces.sort();
+
+        if !pid_namespaces
+            .iter()
+            .any(|namespace| namespace.namespace_type == "pid")
+        {
+            return Err(ProcessIdentityError::Unreadable {
+                pid,
+                detail: "missing pid namespace identity".to_string(),
+            });
+        }
+
+        Ok(ProcessIdentity {
+            pid,
+            start_time_ticks: stat.starttime,
+            stat_comm: stat.comm,
+            cgroups,
+            pid_namespaces,
+            captured_at_ms: current_epoch_millis(),
+        })
+    }
+}
+
+pub trait SignalHandle: Send {
+    fn send_signal(&self, signal: i32) -> Result<(), std::io::Error>;
+}
+
+pub trait SignalSender: Send + Sync {
+    fn open_handle(&self, pid: u32) -> Result<Box<dyn SignalHandle>, std::io::Error>;
+}
+
+#[derive(Debug, Default)]
+struct PidfdSignalSender;
+
+#[derive(Debug)]
+struct PidfdSignalHandle {
+    pidfd: OwnedFd,
+}
+
+impl SignalSender for PidfdSignalSender {
+    fn open_handle(&self, pid: u32) -> Result<Box<dyn SignalHandle>, std::io::Error> {
+        let fd = unsafe { libc::syscall(libc::SYS_pidfd_open, pid as libc::pid_t, 0) };
+        if fd < 0 {
+            Err(std::io::Error::last_os_error())
+        } else {
+            let pidfd = unsafe { OwnedFd::from_raw_fd(fd as i32) };
+            Ok(Box::new(PidfdSignalHandle { pidfd }))
+        }
+    }
+}
+
+impl SignalHandle for PidfdSignalHandle {
+    fn send_signal(&self, signal: i32) -> Result<(), std::io::Error> {
+        let sent = unsafe {
+            libc::syscall(
+                libc::SYS_pidfd_send_signal,
+                self.pidfd.as_raw_fd(),
+                signal,
+                std::ptr::null::<libc::siginfo_t>(),
+                0,
+            )
+        };
+        if sent == 0 {
+            Ok(())
+        } else {
+            Err(std::io::Error::last_os_error())
+        }
+    }
+}
+
+#[cfg(test)]
+#[derive(Debug)]
+struct TestProcessIdentityProvider;
+
+#[cfg(test)]
+impl ProcessIdentityProvider for TestProcessIdentityProvider {
+    fn identity_for_pid(&self, pid: u32) -> Result<ProcessIdentity, ProcessIdentityError> {
+        Ok(ProcessIdentity::for_test(pid))
+    }
+}
+
+#[cfg(test)]
+#[derive(Debug)]
+struct TestSignalSender;
+
+#[cfg(test)]
+impl SignalSender for TestSignalSender {
+    fn open_handle(&self, _pid: u32) -> Result<Box<dyn SignalHandle>, std::io::Error> {
+        Ok(Box::new(TestSignalHandle))
+    }
+}
+
+#[cfg(test)]
+#[derive(Debug)]
+struct TestSignalHandle;
+
+#[cfg(test)]
+impl SignalHandle for TestSignalHandle {
+    fn send_signal(&self, _signal: i32) -> Result<(), std::io::Error> {
+        Ok(())
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -33,6 +303,8 @@ pub enum ActionStatus {
 pub struct EnforcementAction {
     pub id: String,
     pub action: ActionType,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub target_identity: Option<ProcessIdentity>,
     pub reason: String,
     pub source: String,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -60,17 +332,52 @@ pub struct EnforcementQueue {
     executions: AtomicU64,
     next_id: AtomicU64,
     actions: RwLock<HashMap<String, EnforcementAction>>,
+    identity_provider: Arc<dyn ProcessIdentityProvider>,
+    signal_sender: Arc<dyn SignalSender>,
     ttl_secs: u64,
 }
 
 impl EnforcementQueue {
     pub fn new(ttl_secs: u64) -> Self {
+        Self::new_with_components(
+            ttl_secs,
+            Arc::new(ProcProcessIdentityProvider),
+            Arc::new(PidfdSignalSender),
+        )
+    }
+
+    #[doc(hidden)]
+    pub fn new_with_components(
+        ttl_secs: u64,
+        identity_provider: Arc<dyn ProcessIdentityProvider>,
+        signal_sender: Arc<dyn SignalSender>,
+    ) -> Self {
         Self {
             executions: AtomicU64::new(0),
             next_id: AtomicU64::new(1),
             actions: RwLock::new(HashMap::new()),
+            identity_provider,
+            signal_sender,
             ttl_secs,
         }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn new_for_test(ttl_secs: u64) -> Self {
+        Self::new_with_components(
+            ttl_secs,
+            Arc::new(TestProcessIdentityProvider),
+            Arc::new(TestSignalSender),
+        )
+    }
+
+    #[cfg(test)]
+    fn new_for_test_with_components(
+        ttl_secs: u64,
+        identity_provider: Arc<dyn ProcessIdentityProvider>,
+        signal_sender: Arc<dyn SignalSender>,
+    ) -> Self {
+        Self::new_with_components(ttl_secs, identity_provider, signal_sender)
     }
 
     pub async fn propose(
@@ -108,12 +415,17 @@ impl EnforcementQueue {
         confidence: Option<f64>,
         auto_approve: bool,
     ) -> Result<String, String> {
-        // Safety checks ALWAYS run, even for auto-approved actions
-        match &action {
+        // Safety and identity capture ALWAYS run, even for auto-approved actions.
+        let target_identity = match &action {
             ActionType::KillProcess { pid, .. } => {
                 safety::SafetyGuard::is_safe_to_kill(*pid)?;
+                Some(
+                    self.identity_provider
+                        .identity_for_pid(*pid)
+                        .map_err(|err| err.to_string())?,
+                )
             }
-        }
+        };
 
         let id = format!("action-{}", self.next_id.fetch_add(1, Ordering::SeqCst));
         let now = current_epoch_secs();
@@ -131,6 +443,7 @@ impl EnforcementQueue {
         let enforcement_action = EnforcementAction {
             id: id.clone(),
             action,
+            target_identity,
             reason: reason.clone(),
             source: source.clone(),
             confidence,
@@ -158,6 +471,109 @@ impl EnforcementQueue {
         }
 
         Ok(id)
+    }
+
+    pub async fn execute_approved(&self, id: &str) -> Result<(), String> {
+        self.execute_approved_at(id, current_epoch_secs()).await
+    }
+
+    async fn execute_approved_at(&self, id: &str, now: u64) -> Result<(), String> {
+        let action = self.get_by_id(id).await.ok_or("action not found")?;
+
+        if action.status != ActionStatus::Approved {
+            return Err(format!("not approved: {:?}", action.status));
+        }
+
+        match action.action {
+            ActionType::KillProcess { pid, signal } => {
+                self.execute_approved_kill(&action, pid, signal, now).await
+            }
+        }
+    }
+
+    async fn execute_approved_kill(
+        &self,
+        action: &EnforcementAction,
+        pid: u32,
+        signal: i32,
+        now: u64,
+    ) -> Result<(), String> {
+        let expected = match action.target_identity.as_ref() {
+            Some(identity) => identity,
+            None => {
+                return self
+                    .fail_execution(
+                        &action.id,
+                        "kill action has no captured process identity".to_string(),
+                    )
+                    .await;
+            }
+        };
+
+        if now > action.expires_at {
+            return self
+                .fail_execution(
+                    &action.id,
+                    ProcessIdentityError::Expired {
+                        pid,
+                        expires_at: action.expires_at,
+                        now,
+                    }
+                    .to_string(),
+                )
+                .await;
+        }
+
+        let signal_handle = match self.signal_sender.open_handle(pid) {
+            Ok(handle) => handle,
+            Err(err) => {
+                return self
+                    .fail_execution(&action.id, format!("pidfd open failed: {err}"))
+                    .await;
+            }
+        };
+
+        if let Err(err) = safety::SafetyGuard::is_safe_to_kill(pid) {
+            return self
+                .fail_execution(&action.id, format!("unsafe immediately before kill: {err}"))
+                .await;
+        }
+
+        let current = match self.identity_provider.identity_for_pid(pid) {
+            Ok(identity) => identity,
+            Err(err) => return self.fail_execution(&action.id, err.to_string()).await,
+        };
+
+        if !expected.same_process_as(&current) {
+            return self
+                .fail_execution(
+                    &action.id,
+                    ProcessIdentityError::Mismatch {
+                        pid,
+                        expected: Box::new(expected.clone()),
+                        actual: Box::new(current),
+                    }
+                    .to_string(),
+                )
+                .await;
+        }
+
+        log::info!("[enforcement] EXECUTING KILL pid={pid} signal={signal}");
+        match signal_handle.send_signal(signal) {
+            Ok(()) => self.complete(&action.id).await,
+            Err(err) => {
+                // The process was already gone, or the signal was refused.
+                // Marking this executed would let a later fall in pressure be
+                // credited to a kill that never landed.
+                self.fail_execution(&action.id, format!("kill failed: {err}"))
+                    .await
+            }
+        }
+    }
+
+    async fn fail_execution(&self, id: &str, why: String) -> Result<(), String> {
+        let _ = self.fail(id, why.clone()).await;
+        Err(why)
     }
 
     pub async fn approve(&self, id: &str, approver: String) -> Result<EnforcementAction, String> {
@@ -287,11 +703,103 @@ fn current_epoch_secs() -> u64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::VecDeque;
+    use std::sync::Mutex;
+
+    #[derive(Debug)]
+    struct ScriptedIdentityProvider {
+        responses: Mutex<VecDeque<Result<ProcessIdentity, ProcessIdentityError>>>,
+    }
+
+    impl ScriptedIdentityProvider {
+        fn new(responses: Vec<Result<ProcessIdentity, ProcessIdentityError>>) -> Self {
+            Self {
+                responses: Mutex::new(responses.into()),
+            }
+        }
+    }
+
+    impl ProcessIdentityProvider for ScriptedIdentityProvider {
+        fn identity_for_pid(&self, pid: u32) -> Result<ProcessIdentity, ProcessIdentityError> {
+            self.responses
+                .lock()
+                .unwrap()
+                .pop_front()
+                .unwrap_or_else(|| panic!("no scripted identity response for pid {pid}"))
+        }
+    }
+
+    #[derive(Debug, Default)]
+    struct RecordingSignalSender {
+        opened: Mutex<Vec<u32>>,
+        sent: Arc<Mutex<Vec<(u32, i32)>>>,
+    }
+
+    impl RecordingSignalSender {
+        fn opened(&self) -> Vec<u32> {
+            self.opened.lock().unwrap().clone()
+        }
+
+        fn sent(&self) -> Vec<(u32, i32)> {
+            self.sent.lock().unwrap().clone()
+        }
+    }
+
+    impl SignalSender for RecordingSignalSender {
+        fn open_handle(&self, pid: u32) -> Result<Box<dyn SignalHandle>, std::io::Error> {
+            self.opened.lock().unwrap().push(pid);
+            Ok(Box::new(RecordingSignalHandle {
+                pid,
+                sent: Arc::clone(&self.sent),
+            }))
+        }
+    }
+
+    #[derive(Debug)]
+    struct RecordingSignalHandle {
+        pid: u32,
+        sent: Arc<Mutex<Vec<(u32, i32)>>>,
+    }
+
+    impl SignalHandle for RecordingSignalHandle {
+        fn send_signal(&self, signal: i32) -> Result<(), std::io::Error> {
+            self.sent.lock().unwrap().push((self.pid, signal));
+            Ok(())
+        }
+    }
+
+    fn queue_with_components(
+        ttl_secs: u64,
+        responses: Vec<Result<ProcessIdentity, ProcessIdentityError>>,
+    ) -> (EnforcementQueue, Arc<RecordingSignalSender>) {
+        let signal_sender = Arc::new(RecordingSignalSender::default());
+        (
+            EnforcementQueue::new_for_test_with_components(
+                ttl_secs,
+                Arc::new(ScriptedIdentityProvider::new(responses)),
+                signal_sender.clone(),
+            ),
+            signal_sender,
+        )
+    }
+
+    async fn propose_auto_kill(queue: &EnforcementQueue, pid: u32) -> String {
+        queue
+            .propose_auto(
+                ActionType::KillProcess { pid, signal: 9 },
+                "test".to_string(),
+                "circuit_breaker".to_string(),
+                None,
+                true,
+            )
+            .await
+            .unwrap()
+    }
 
     #[tokio::test]
     async fn kill_action_requires_approval_by_operator() {
         // Given: An SRE proposes killing a noisy process
-        let queue = EnforcementQueue::new(300);
+        let queue = EnforcementQueue::new_for_test(300);
         let action_id = queue
             .propose(
                 ActionType::KillProcess {
@@ -318,7 +826,7 @@ mod tests {
     #[tokio::test]
     async fn expired_actions_cannot_be_approved() {
         // Given: A kill action with a 0-second TTL (expires immediately)
-        let queue = EnforcementQueue::new(0);
+        let queue = EnforcementQueue::new_for_test(0);
         let action_id = queue
             .propose(
                 ActionType::KillProcess {
@@ -344,7 +852,7 @@ mod tests {
     #[tokio::test]
     async fn rejected_actions_cannot_be_approved_later() {
         // Given: A proposed kill action
-        let queue = EnforcementQueue::new(300);
+        let queue = EnforcementQueue::new_for_test(300);
         let action_id = queue
             .propose(
                 ActionType::KillProcess {
@@ -373,7 +881,7 @@ mod tests {
     #[tokio::test]
     async fn approved_actions_cannot_be_rejected() {
         // Given: A kill action approved by an operator
-        let queue = EnforcementQueue::new(300);
+        let queue = EnforcementQueue::new_for_test(300);
         let action_id = queue
             .propose(
                 ActionType::KillProcess {
@@ -397,5 +905,80 @@ mod tests {
         // Then: Rejection fails because the action is no longer pending
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("not pending"));
+    }
+
+    #[tokio::test]
+    async fn pid_reuse_fails_before_signal_is_sent() {
+        let pid = 123;
+        let original = ProcessIdentity::for_test(pid);
+        let mut reused = original.clone();
+        reused.start_time_ticks += 1;
+        reused.stat_comm = "reused-process".to_string();
+        let (queue, signal_sender) = queue_with_components(60, vec![Ok(original), Ok(reused)]);
+        let action_id = propose_auto_kill(&queue, pid).await;
+
+        let err = queue.execute_approved(&action_id).await.unwrap_err();
+
+        assert!(err.contains("identity changed"));
+        assert_eq!(signal_sender.opened(), vec![pid]);
+        assert_eq!(signal_sender.sent(), Vec::<(u32, i32)>::new());
+        let action = queue.get_by_id(&action_id).await.unwrap();
+        assert_eq!(action.status, ActionStatus::Failed);
+    }
+
+    #[tokio::test]
+    async fn expired_identity_fails_before_signal_is_sent() {
+        let pid = 123;
+        let original = ProcessIdentity::for_test(pid);
+        let (queue, signal_sender) = queue_with_components(60, vec![Ok(original)]);
+        let action_id = propose_auto_kill(&queue, pid).await;
+        let expires_at = queue.get_by_id(&action_id).await.unwrap().expires_at;
+
+        let err = queue
+            .execute_approved_at(&action_id, expires_at + 1)
+            .await
+            .unwrap_err();
+
+        assert!(err.contains("expired"));
+        assert_eq!(signal_sender.opened(), Vec::<u32>::new());
+        assert_eq!(signal_sender.sent(), Vec::<(u32, i32)>::new());
+        let action = queue.get_by_id(&action_id).await.unwrap();
+        assert_eq!(action.status, ActionStatus::Failed);
+    }
+
+    #[tokio::test]
+    async fn missing_process_before_kill_fails_before_signal_is_sent() {
+        let pid = 123;
+        let original = ProcessIdentity::for_test(pid);
+        let (queue, signal_sender) = queue_with_components(
+            60,
+            vec![Ok(original), Err(ProcessIdentityError::Missing { pid })],
+        );
+        let action_id = propose_auto_kill(&queue, pid).await;
+
+        let err = queue.execute_approved(&action_id).await.unwrap_err();
+
+        assert!(err.contains("missing"));
+        assert_eq!(signal_sender.opened(), vec![pid]);
+        assert_eq!(signal_sender.sent(), Vec::<(u32, i32)>::new());
+        let action = queue.get_by_id(&action_id).await.unwrap();
+        assert_eq!(action.status, ActionStatus::Failed);
+    }
+
+    #[tokio::test]
+    async fn matching_identity_is_signaled_once_and_completed() {
+        let pid = 123;
+        let original = ProcessIdentity::for_test(pid);
+        let (queue, signal_sender) =
+            queue_with_components(60, vec![Ok(original.clone()), Ok(original)]);
+        let action_id = propose_auto_kill(&queue, pid).await;
+
+        queue.execute_approved(&action_id).await.unwrap();
+
+        assert_eq!(signal_sender.opened(), vec![pid]);
+        assert_eq!(signal_sender.sent(), vec![(pid, 9)]);
+        let action = queue.get_by_id(&action_id).await.unwrap();
+        assert_eq!(action.status, ActionStatus::Executed);
+        assert!(action.executed_at_ms.is_some());
     }
 }

--- a/cognitod/src/incidents/outcome.rs
+++ b/cognitod/src/incidents/outcome.rs
@@ -416,7 +416,7 @@ mod tests {
     async fn an_action_that_never_executes_is_never_credited() {
         use crate::enforcement::{ActionType, EnforcementQueue};
 
-        let queue = Arc::new(EnforcementQueue::new(5));
+        let queue = Arc::new(EnforcementQueue::new_for_test(5));
         // The default posture: proposed, awaiting a human.
         let id = queue
             .propose_auto(
@@ -446,7 +446,7 @@ mod tests {
     async fn a_rejected_action_stops_the_wait_immediately() {
         use crate::enforcement::{ActionType, EnforcementQueue};
 
-        let queue = Arc::new(EnforcementQueue::new(3_600));
+        let queue = Arc::new(EnforcementQueue::new_for_test(3_600));
         let id = queue
             .propose_auto(
                 ActionType::KillProcess {
@@ -474,7 +474,7 @@ mod tests {
     async fn a_pending_action_is_never_measured_however_calm_the_machine_gets() {
         use crate::enforcement::{ActionType, EnforcementQueue};
 
-        let queue = Arc::new(EnforcementQueue::new(5));
+        let queue = Arc::new(EnforcementQueue::new_for_test(5));
         let id = queue
             .propose_auto(
                 ActionType::KillProcess {
@@ -518,7 +518,7 @@ mod tests {
         // only scans once a second. Exiting on the proposal's expiry would
         // abandon an action that is about to really run, leaving a real kill
         // permanently unverifiable.
-        let queue = Arc::new(EnforcementQueue::new(2));
+        let queue = Arc::new(EnforcementQueue::new_for_test(2));
         let id = queue
             .propose_auto(
                 ActionType::KillProcess {
@@ -555,7 +555,7 @@ mod tests {
     async fn a_kill_that_failed_is_never_treated_as_executed() {
         use crate::enforcement::{ActionType, EnforcementQueue};
 
-        let queue = Arc::new(EnforcementQueue::new(60));
+        let queue = Arc::new(EnforcementQueue::new_for_test(60));
         let id = queue
             .propose_auto(
                 ActionType::KillProcess {
@@ -588,7 +588,7 @@ mod tests {
     async fn an_approved_action_the_executor_never_runs_does_not_wait_forever() {
         use crate::enforcement::{ActionType, EnforcementQueue};
 
-        let queue = Arc::new(EnforcementQueue::new(3_600));
+        let queue = Arc::new(EnforcementQueue::new_for_test(3_600));
         let id = queue
             .propose_auto(
                 ActionType::KillProcess {
@@ -620,7 +620,7 @@ mod tests {
         // within the action's life, and that incident must still get an
         // outcome — borrowing the watch duration as the execution deadline
         // would abandon it at two minutes, permanently.
-        let queue = Arc::new(EnforcementQueue::new(300));
+        let queue = Arc::new(EnforcementQueue::new_for_test(300));
         let id = queue
             .propose_auto(
                 ActionType::KillProcess {
@@ -668,7 +668,7 @@ mod tests {
     async fn an_overlapping_execution_invalidates_the_measurement() {
         use crate::enforcement::{ActionType, EnforcementQueue};
 
-        let queue = Arc::new(EnforcementQueue::new(60));
+        let queue = Arc::new(EnforcementQueue::new_for_test(60));
         let propose = |queue: Arc<EnforcementQueue>| async move {
             queue
                 .propose_auto(
@@ -738,7 +738,7 @@ mod tests {
     async fn recovery_is_timed_from_the_kill_and_counted_once() {
         use crate::enforcement::{ActionType, EnforcementQueue};
 
-        let queue = Arc::new(EnforcementQueue::new(60));
+        let queue = Arc::new(EnforcementQueue::new_for_test(60));
         let id = queue
             .propose_auto(
                 ActionType::KillProcess {
@@ -796,7 +796,7 @@ mod tests {
     async fn an_executed_action_is_measured() {
         use crate::enforcement::{ActionType, EnforcementQueue};
 
-        let queue = Arc::new(EnforcementQueue::new(3_600));
+        let queue = Arc::new(EnforcementQueue::new_for_test(3_600));
         let id = queue
             .propose_auto(
                 ActionType::KillProcess {
@@ -833,7 +833,7 @@ mod tests {
     async fn an_executed_action_with_unreadable_pressure_records_nothing() {
         use crate::enforcement::{ActionType, EnforcementQueue};
 
-        let queue = Arc::new(EnforcementQueue::new(3_600));
+        let queue = Arc::new(EnforcementQueue::new_for_test(3_600));
         let id = queue
             .propose_auto(
                 ActionType::KillProcess {
@@ -870,7 +870,7 @@ mod tests {
     async fn an_executed_action_starts_the_watch() {
         use crate::enforcement::{ActionType, EnforcementQueue};
 
-        let queue = Arc::new(EnforcementQueue::new(3_600));
+        let queue = Arc::new(EnforcementQueue::new_for_test(3_600));
         let id = queue
             .propose_auto(
                 ActionType::KillProcess {

--- a/cognitod/src/main.rs
+++ b/cognitod/src/main.rs
@@ -1317,34 +1317,10 @@ async fn main() -> Result<(), Box<dyn Error>> {
         tokio::spawn(async move {
             loop {
                 for action in queue_clone.get_all().await {
-                    if action.status == cognitod::enforcement::ActionStatus::Approved {
-                        match action.action {
-                            cognitod::enforcement::ActionType::KillProcess { pid, signal } => {
-                                info!("[enforcement] EXECUTING KILL pid={} signal={}", pid, signal);
-                                let sent = unsafe { libc::kill(pid as i32, signal) };
-                                if sent == 0 {
-                                    let _ = queue_clone.complete(&action.id).await;
-                                } else {
-                                    // The process was already gone, or the
-                                    // signal was refused. Marking this executed
-                                    // would let a later fall in pressure be
-                                    // credited to a kill that never landed.
-                                    let err = std::io::Error::last_os_error();
-                                    warn!(
-                                        "[enforcement] kill pid={} signal={} failed: {}",
-                                        pid, signal, err
-                                    );
-                                    // `reject` is the operator's path and only
-                                    // applies to pending proposals; this action
-                                    // is Approved, so rejecting it fails and
-                                    // leaves it to be retried every second
-                                    // against a pid that may be reused.
-                                    let _ = queue_clone
-                                        .fail(&action.id, format!("kill failed: {err}"))
-                                        .await;
-                                }
-                            }
-                        }
+                    if action.status == cognitod::enforcement::ActionStatus::Approved
+                        && let Err(err) = queue_clone.execute_approved(&action.id).await
+                    {
+                        warn!("[enforcement] action {} failed: {}", action.id, err);
                     }
                 }
                 sleep(Duration::from_secs(1)).await;


### PR DESCRIPTION
## Summary
- capture process start time, exe, cgroup, and PID namespace identity on kill proposals
- revalidate safety, TTL, and process identity immediately before sending a signal
- fail approved kill actions on missing, expired, or mismatched process identity before signal delivery
- add mock identity-provider tests for PID reuse, expired identity, missing process, and matched identity execution

## Verification
- cargo fmt --all -- --check
- cargo check -p cognitod
- cargo clippy -p cognitod --all-targets -- -D warnings
- cargo test -p cognitod
- pre-commit hook: 246 tests passed, cargo deny passed