### PR TITLE
Fail loudly on incident schema migration drift

### DIFF
--- a/cognitod/src/incidents.rs
+++ b/cognitod/src/incidents.rs
@@ -783,7 +783,7 @@ async fn column_exists(pool: &SqlitePool, table: &str, column: &str) -> Result<b
 
     Ok(rows
         .iter()
-        .any(|row| row.get::<String, _>("name") == column))
+        .any(|row| row.get::<String, _>("name").eq_ignore_ascii_case(column)))
 }
 
 /// Statistics about stored incidents

--- a/cognitod/src/incidents.rs
+++ b/cognitod/src/incidents.rs
@@ -84,6 +84,45 @@ pub struct IncidentStore {
     pool: SqlitePool,
 }
 
+struct RequiredColumn {
+    table: &'static str,
+    column: &'static str,
+    ddl: &'static str,
+}
+
+const REQUIRED_COLUMNS: &[RequiredColumn] = &[
+    RequiredColumn {
+        table: "stall_attributions",
+        column: "cpu_share",
+        ddl: "ALTER TABLE stall_attributions ADD COLUMN cpu_share REAL DEFAULT 0.0",
+    },
+    RequiredColumn {
+        table: "stall_attributions",
+        column: "fork_count",
+        ddl: "ALTER TABLE stall_attributions ADD COLUMN fork_count INTEGER DEFAULT 0",
+    },
+    RequiredColumn {
+        table: "stall_attributions",
+        column: "short_job_count",
+        ddl: "ALTER TABLE stall_attributions ADD COLUMN short_job_count INTEGER DEFAULT 0",
+    },
+    RequiredColumn {
+        table: "stall_attributions",
+        column: "attributed_stall_us",
+        ddl: "ALTER TABLE stall_attributions ADD COLUMN attributed_stall_us INTEGER",
+    },
+    RequiredColumn {
+        table: "stall_attributions",
+        column: "event_id",
+        ddl: "ALTER TABLE stall_attributions ADD COLUMN event_id TEXT",
+    },
+    RequiredColumn {
+        table: "incidents",
+        column: "investigation",
+        ddl: "ALTER TABLE incidents ADD COLUMN investigation TEXT",
+    },
+];
+
 impl IncidentStore {
     /// Create a new incident store
     pub async fn new<P: AsRef<Path>>(db_path: P) -> Result<Self, sqlx::Error> {
@@ -159,43 +198,15 @@ impl IncidentStore {
         .execute(&pool)
         .await?;
 
-        // Manual migration for existing databases
-        // We ignore errors because the columns might already exist
-        let _ = sqlx::query("ALTER TABLE stall_attributions ADD COLUMN cpu_share REAL DEFAULT 0.0")
-            .execute(&pool)
-            .await;
-        let _ =
-            sqlx::query("ALTER TABLE stall_attributions ADD COLUMN fork_count INTEGER DEFAULT 0")
-                .execute(&pool)
-                .await;
-        let _ = sqlx::query(
-            "ALTER TABLE stall_attributions ADD COLUMN short_job_count INTEGER DEFAULT 0",
-        )
-        .execute(&pool)
-        .await;
-        let _ =
-            sqlx::query("ALTER TABLE stall_attributions ADD COLUMN attributed_stall_us INTEGER")
-                .execute(&pool)
-                .await;
+        apply_required_column_migrations(&pool).await?;
+
         // No backfill: an id cannot be reconstructed for rows written before
         // the monitor emitted one, and grouping them by `(timestamp, stall_us)`
         // to synthesise one would bake today's ambiguity into permanent data.
         // They stay NULL and consumers keep the existing fallback.
-        let _ = sqlx::query("ALTER TABLE stall_attributions ADD COLUMN event_id TEXT")
+        sqlx::query("CREATE INDEX IF NOT EXISTS idx_attr_event ON stall_attributions(event_id)")
             .execute(&pool)
-            .await;
-        let _ = sqlx::query(
-            "CREATE INDEX IF NOT EXISTS idx_attr_event ON stall_attributions(event_id)",
-        )
-        .execute(&pool)
-        .await;
-
-        // The grounded investigation lives beside the raw reply rather than
-        // replacing it: `llm_analysis` keeps meaning exactly what it always
-        // did, so no reader has to tell prose and JSON apart by inspection.
-        let _ = sqlx::query("ALTER TABLE incidents ADD COLUMN investigation TEXT")
-            .execute(&pool)
-            .await;
+            .await?;
 
         // Rows written before the column existed stored only the victim's
         // total stall, repeated against every offender. The share each was
@@ -234,13 +245,11 @@ impl IncidentStore {
             "#,
         )
         .execute(&pool)
-        .await;
-        if let Ok(result) = backfilled
-            && result.rows_affected() > 0
-        {
+        .await?;
+        if backfilled.rows_affected() > 0 {
             info!(
                 "Backfilled attributed stall for {} historical attribution rows",
-                result.rows_affected()
+                backfilled.rows_affected()
             );
         }
 
@@ -755,6 +764,26 @@ impl IncidentStore {
             feedback_entries: feedback_count as u64,
         })
     }
+}
+
+async fn apply_required_column_migrations(pool: &SqlitePool) -> Result<(), sqlx::Error> {
+    for migration in REQUIRED_COLUMNS {
+        if !column_exists(pool, migration.table, migration.column).await? {
+            sqlx::query(migration.ddl).execute(pool).await?;
+        }
+    }
+    Ok(())
+}
+
+async fn column_exists(pool: &SqlitePool, table: &str, column: &str) -> Result<bool, sqlx::Error> {
+    let escaped_table = table.replace('"', "\"\"");
+    let rows = sqlx::query(&format!("PRAGMA table_info(\"{escaped_table}\")"))
+        .fetch_all(pool)
+        .await?;
+
+    Ok(rows
+        .iter()
+        .any(|row| row.get::<String, _>("name") == column))
 }
 
 /// Statistics about stored incidents

--- a/cognitod/tests/attribution_store_eval.rs
+++ b/cognitod/tests/attribution_store_eval.rs
@@ -215,7 +215,8 @@ async fn upgrading_an_old_database_creates_required_columns_and_indexes() {
                 offender_namespace TEXT NOT NULL,
                 stall_us INTEGER NOT NULL,
                 blame_score REAL NOT NULL,
-                timestamp INTEGER NOT NULL
+                timestamp INTEGER NOT NULL,
+                CPU_SHARE REAL DEFAULT 0.0
             )
             "#,
         )
@@ -248,7 +249,9 @@ async fn upgrading_an_old_database_creates_required_columns_and_indexes() {
         "event_id",
     ] {
         assert!(
-            attribution_columns.iter().any(|column| column == expected),
+            attribution_columns
+                .iter()
+                .any(|column| column.eq_ignore_ascii_case(expected)),
             "stall_attributions migration must add {expected}"
         );
     }

--- a/cognitod/tests/attribution_store_eval.rs
+++ b/cognitod/tests/attribution_store_eval.rs
@@ -8,7 +8,7 @@
 
 use cognitod::collectors::psi::BlameAttribution;
 use cognitod::incidents::IncidentStore;
-use sqlx::sqlite::SqlitePoolOptions;
+use sqlx::{Row, sqlite::SqlitePoolOptions};
 
 fn attribution(offender: &str, blame: f64, attributed_us: u64) -> BlameAttribution {
     BlameAttribution {
@@ -32,6 +32,28 @@ fn now_secs() -> u64 {
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap()
         .as_secs()
+}
+
+async fn table_columns(pool: &sqlx::SqlitePool, table: &str) -> Vec<String> {
+    let escaped_table = table.replace('"', "\"\"");
+    sqlx::query(&format!("PRAGMA table_info(\"{escaped_table}\")"))
+        .fetch_all(pool)
+        .await
+        .unwrap()
+        .into_iter()
+        .map(|row| row.get("name"))
+        .collect()
+}
+
+async fn index_names(pool: &sqlx::SqlitePool, table: &str) -> Vec<String> {
+    let escaped_table = table.replace('"', "\"\"");
+    sqlx::query(&format!("PRAGMA index_list(\"{escaped_table}\")"))
+        .fetch_all(pool)
+        .await
+        .unwrap()
+        .into_iter()
+        .map(|row| row.get("name"))
+        .collect()
 }
 
 #[tokio::test]
@@ -149,6 +171,131 @@ async fn upgrading_an_old_database_backfills_the_offender_share() {
         .insert_stall_attribution(&attribution("late-arrival", 1.0, 100_000))
         .await
         .expect("insert should succeed after migration");
+}
+
+#[tokio::test]
+async fn upgrading_an_old_database_creates_required_columns_and_indexes() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("incidents.db");
+    let db_url = format!("sqlite://{}?mode=rwc", db_path.display());
+
+    {
+        let pool = SqlitePoolOptions::new().connect(&db_url).await.unwrap();
+        sqlx::query(
+            r#"
+            CREATE TABLE incidents (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                timestamp INTEGER NOT NULL,
+                event_type TEXT NOT NULL,
+                psi_cpu REAL NOT NULL,
+                psi_memory REAL NOT NULL,
+                cpu_percent REAL NOT NULL,
+                load_avg TEXT NOT NULL,
+                action TEXT NOT NULL,
+                target_pid INTEGER,
+                target_name TEXT,
+                system_snapshot TEXT,
+                llm_analysis TEXT,
+                llm_analyzed_at INTEGER,
+                recovery_time_ms INTEGER,
+                psi_after REAL
+            )
+            "#,
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            r#"
+            CREATE TABLE stall_attributions (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                victim_pod TEXT NOT NULL,
+                victim_namespace TEXT NOT NULL,
+                offender_pod TEXT NOT NULL,
+                offender_namespace TEXT NOT NULL,
+                stall_us INTEGER NOT NULL,
+                blame_score REAL NOT NULL,
+                timestamp INTEGER NOT NULL
+            )
+            "#,
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+        pool.close().await;
+    }
+
+    let store = IncidentStore::new(&db_path)
+        .await
+        .expect("an old but valid schema should upgrade");
+    drop(store);
+
+    let pool = SqlitePoolOptions::new().connect(&db_url).await.unwrap();
+    let incident_columns = table_columns(&pool, "incidents").await;
+    assert!(
+        incident_columns
+            .iter()
+            .any(|column| column == "investigation"),
+        "incident migration must add investigation column"
+    );
+
+    let attribution_columns = table_columns(&pool, "stall_attributions").await;
+    for expected in [
+        "cpu_share",
+        "fork_count",
+        "short_job_count",
+        "attributed_stall_us",
+        "event_id",
+    ] {
+        assert!(
+            attribution_columns.iter().any(|column| column == expected),
+            "stall_attributions migration must add {expected}"
+        );
+    }
+
+    let indexes = index_names(&pool, "stall_attributions").await;
+    assert!(
+        indexes.iter().any(|index| index == "idx_attr_event"),
+        "event_id index must exist after migration"
+    );
+    pool.close().await;
+
+    IncidentStore::new(&db_path)
+        .await
+        .expect("migrations must be idempotent once columns already exist");
+}
+
+#[tokio::test]
+async fn malformed_historical_schema_fails_instead_of_masking_migration_drift() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("incidents.db");
+    let db_url = format!("sqlite://{}?mode=rwc", db_path.display());
+
+    {
+        let pool = SqlitePoolOptions::new().connect(&db_url).await.unwrap();
+        sqlx::query(
+            r#"
+            CREATE TABLE stall_attributions (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                victim_pod TEXT NOT NULL
+            )
+            "#,
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+        pool.close().await;
+    }
+
+    let err = match IncidentStore::new(&db_path).await {
+        Ok(_) => panic!("schema drift must fail loudly"),
+        Err(err) => err,
+    };
+
+    assert!(
+        err.to_string().contains("stall_us") || err.to_string().contains("no such column"),
+        "unexpected migration error: {err}"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- Replace ignored ALTER TABLE attempts with explicit required-column checks and propagated migration errors.
- Propagate event_id index and attribution backfill failures instead of silently continuing.
- Add historical-schema tests for required columns/indexes, idempotency, and malformed drift failure.

## Tests
- cargo test -p cognitod --test attribution_store_eval upgrading_an_old_database
- cargo test -p cognitod --test attribution_store_eval malformed_historical_schema
- cargo test -p cognitod --test investigation_store_eval an_old_database_gains_the_column
- pre-commit hook: format, clippy, unit tests, cargo-deny