### PR TITLE
Fix incident query filtering and limits

### DIFF
--- a/cognitod/src/api/mod.rs
+++ b/cognitod/src/api/mod.rs
@@ -1965,6 +1965,19 @@ fn default_limit() -> i64 {
     10
 }
 
+const MAX_INCIDENT_LIMIT: i64 = 1_000;
+
+fn normalize_incident_limit(limit: i64) -> Result<i64, (StatusCode, String)> {
+    if limit < 1 {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            "limit must be a positive integer".to_string(),
+        ));
+    }
+
+    Ok(limit.min(MAX_INCIDENT_LIMIT))
+}
+
 /// GET /incidents - List recent incidents
 async fn get_incidents(
     Query(params): Query<IncidentQueryParams>,
@@ -1977,8 +1990,14 @@ async fn get_incidents(
         )
     })?;
 
+    let limit = normalize_incident_limit(params.limit)?;
+    let event_type = params
+        .event_type
+        .as_deref()
+        .filter(|value| !value.is_empty());
+
     let incidents = store
-        .recent(params.limit)
+        .recent_filtered(limit, event_type)
         .await
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
 
@@ -2574,6 +2593,70 @@ mod tests {
             k8s: None,
             blame_metrics: Arc::new(cognitod::attribution::BlameMetrics::new("test-node")),
         })
+    }
+
+    fn app_state_with_incident_store(store: Arc<cognitod::IncidentStore>) -> Arc<AppState> {
+        Arc::new(AppState {
+            context: Arc::new(ContextStore::new(Duration::from_secs(60), 10, None)),
+            metrics: Arc::new(Metrics::new()),
+            alerts: None,
+            insights: Arc::new(InsightStore::new(16, None)),
+            offline: Arc::new(OfflineGuard::new(false)),
+            transport: "perf",
+            probe_state: ProbeState::disabled(),
+            require_kernel_instrumentation: true,
+            enforcement: None,
+            reasoner: ReasonerConfig::default(),
+            prometheus_enabled: false,
+            alert_history: Arc::new(AlertHistory::new(16)),
+            auth_token: None,
+            slack_signing_secret: None,
+            incident_store: Some(store),
+            k8s: None,
+            blame_metrics: Arc::new(cognitod::attribution::BlameMetrics::new("test-node")),
+        })
+    }
+
+    fn api_test_incident(event_type: &str, timestamp: i64) -> cognitod::Incident {
+        cognitod::Incident {
+            id: None,
+            timestamp,
+            event_type: event_type.to_string(),
+            psi_cpu: 75.21,
+            psi_memory: 12.34,
+            cpu_percent: 96.3,
+            load_avg: "26.00,24.20,21.30".to_string(),
+            action: "auto_kill".to_string(),
+            target_pid: Some(472_693),
+            target_name: Some("aggressive-stress.sh".to_string()),
+            system_snapshot: None,
+            llm_analysis: None,
+            llm_analyzed_at: None,
+            investigation: None,
+            recovery_time_ms: None,
+            psi_after: None,
+        }
+    }
+
+    async fn get_incidents_json(
+        state: Arc<AppState>,
+        uri: &str,
+    ) -> (StatusCode, serde_json::Value) {
+        let response = super::all_routes(state)
+            .oneshot(Request::builder().uri(uri).body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        let status = response.status();
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json = if body.is_empty() {
+            serde_json::Value::Null
+        } else {
+            serde_json::from_slice(&body).unwrap_or(serde_json::Value::Null)
+        };
+
+        (status, json)
     }
 
     fn current_epoch_secs() -> u64 {
@@ -3951,6 +4034,92 @@ mod tests {
             reopened["attributions"].as_array().unwrap().len(),
             1,
             "an event link must stay event-specific when reopened: {link}"
+        );
+    }
+
+    #[tokio::test]
+    async fn incidents_route_filters_by_event_type_before_returning_results() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Arc::new(
+            cognitod::IncidentStore::new(dir.path().join("incidents.db"))
+                .await
+                .unwrap(),
+        );
+
+        for (event_type, timestamp) in [
+            ("circuit_breaker_cpu", 1_732_242_135),
+            ("manual_kill", 1_732_242_136),
+            ("circuit_breaker_memory", 1_732_242_137),
+        ] {
+            store
+                .insert(&api_test_incident(event_type, timestamp))
+                .await
+                .unwrap();
+        }
+
+        let app_state = app_state_with_incident_store(Arc::clone(&store));
+        let (status, json) =
+            get_incidents_json(app_state, "/incidents?event_type=manual_kill&limit=10").await;
+
+        assert_eq!(status, StatusCode::OK);
+        let incidents = json.as_array().expect("incidents response is an array");
+        assert_eq!(incidents.len(), 1, "event_type filter must be applied");
+        assert_eq!(incidents[0]["event_type"], "manual_kill");
+    }
+
+    #[tokio::test]
+    async fn incidents_route_rejects_nonpositive_limits() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Arc::new(
+            cognitod::IncidentStore::new(dir.path().join("incidents.db"))
+                .await
+                .unwrap(),
+        );
+        let app_state = app_state_with_incident_store(store);
+
+        for uri in ["/incidents?limit=-1", "/incidents?limit=0"] {
+            let response = super::all_routes(Arc::clone(&app_state))
+                .oneshot(Request::builder().uri(uri).body(Body::empty()).unwrap())
+                .await
+                .unwrap();
+
+            assert_eq!(
+                response.status(),
+                StatusCode::BAD_REQUEST,
+                "{uri} must not reach SQLite as an unbounded limit"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn incidents_route_clamps_huge_limits() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Arc::new(
+            cognitod::IncidentStore::new(dir.path().join("incidents.db"))
+                .await
+                .unwrap(),
+        );
+
+        for idx in 0..(MAX_INCIDENT_LIMIT + 1) {
+            store
+                .insert(&api_test_incident(
+                    "circuit_breaker_cpu",
+                    1_732_242_135 + idx,
+                ))
+                .await
+                .unwrap();
+        }
+
+        let app_state = app_state_with_incident_store(store);
+        let (status, json) = get_incidents_json(app_state, "/incidents?limit=999999").await;
+
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(
+            json.as_array()
+                .expect("incidents response is an array")
+                .len(),
+            MAX_INCIDENT_LIMIT as usize,
+            "oversized limits must be bounded before SQLite sees them"
         );
     }
 

--- a/cognitod/src/api/mod.rs
+++ b/cognitod/src/api/mod.rs
@@ -1997,21 +1997,11 @@ async fn get_incidents(
         .filter(|value| !value.is_empty());
 
     let incidents = store
-        .recent_filtered(limit, event_type)
+        .recent_filtered(limit, event_type, params.analyzed)
         .await
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
 
-    // Filter by analyzed status if requested
-    let filtered = if let Some(analyzed) = params.analyzed {
-        incidents
-            .into_iter()
-            .filter(|i| analyzed == i.llm_analysis.is_some())
-            .collect()
-    } else {
-        incidents
-    };
-
-    Ok(Json(filtered))
+    Ok(Json(incidents))
 }
 
 /// GET /incidents/:id - Get incident by ID
@@ -4065,6 +4055,55 @@ mod tests {
         let incidents = json.as_array().expect("incidents response is an array");
         assert_eq!(incidents.len(), 1, "event_type filter must be applied");
         assert_eq!(incidents[0]["event_type"], "manual_kill");
+    }
+
+    #[tokio::test]
+    async fn incidents_route_applies_analyzed_filter_before_limit() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Arc::new(
+            cognitod::IncidentStore::new(dir.path().join("incidents.db"))
+                .await
+                .unwrap(),
+        );
+
+        let analyzed_id = store
+            .insert(&api_test_incident("circuit_breaker_cpu", 1_732_242_100))
+            .await
+            .unwrap();
+        store
+            .add_llm_analysis(
+                analyzed_id,
+                &cognitod::incidents::AnalysisOutcome {
+                    raw_response: "older analyzed incident".to_string(),
+                    investigation: None,
+                    parse_error: None,
+                },
+            )
+            .await
+            .unwrap();
+
+        for offset in 1..=20 {
+            store
+                .insert(&api_test_incident(
+                    "circuit_breaker_cpu",
+                    1_732_242_100 + offset,
+                ))
+                .await
+                .unwrap();
+        }
+
+        let app_state = app_state_with_incident_store(store);
+        let (status, json) =
+            get_incidents_json(app_state, "/incidents?analyzed=true&limit=10").await;
+
+        assert_eq!(status, StatusCode::OK);
+        let incidents = json.as_array().expect("incidents response is an array");
+        assert_eq!(
+            incidents.len(),
+            1,
+            "analyzed filtering must happen before applying the result limit"
+        );
+        assert_eq!(incidents[0]["llm_analysis"], "older analyzed incident");
     }
 
     #[tokio::test]

--- a/cognitod/src/incidents.rs
+++ b/cognitod/src/incidents.rs
@@ -623,48 +623,49 @@ impl IncidentStore {
 
     /// Get recent incidents
     pub async fn recent(&self, limit: i64) -> Result<Vec<Incident>, sqlx::Error> {
-        self.recent_filtered(limit, None).await
+        self.recent_filtered(limit, None, None).await
     }
 
-    /// Get recent incidents, optionally filtered by event type
+    /// Get recent incidents, optionally filtered by event type and analysis state
     pub async fn recent_filtered(
         &self,
         limit: i64,
         event_type: Option<&str>,
+        analyzed: Option<bool>,
     ) -> Result<Vec<Incident>, sqlx::Error> {
-        let rows = if let Some(evt_type) = event_type {
-            sqlx::query(
-                r#"
-                SELECT id, timestamp, event_type, psi_cpu, psi_memory, cpu_percent, load_avg,
-                       action, target_pid, target_name, system_snapshot,
-                       llm_analysis, llm_analyzed_at, recovery_time_ms, psi_after,
-                       investigation
-                FROM incidents
-                WHERE event_type = ?
-                ORDER BY timestamp DESC
-                LIMIT ?
-                "#,
-            )
-            .bind(evt_type)
-            .bind(limit)
-            .fetch_all(&self.pool)
-            .await?
-        } else {
-            sqlx::query(
-                r#"
-                SELECT id, timestamp, event_type, psi_cpu, psi_memory, cpu_percent, load_avg,
-                       action, target_pid, target_name, system_snapshot,
-                       llm_analysis, llm_analyzed_at, recovery_time_ms, psi_after,
-                       investigation
-                FROM incidents
-                ORDER BY timestamp DESC
-                LIMIT ?
-                "#,
-            )
-            .bind(limit)
-            .fetch_all(&self.pool)
-            .await?
-        };
+        let mut sql = String::from(
+            r#"
+            SELECT id, timestamp, event_type, psi_cpu, psi_memory, cpu_percent, load_avg,
+                   action, target_pid, target_name, system_snapshot,
+                   llm_analysis, llm_analyzed_at, recovery_time_ms, psi_after,
+                   investigation
+            FROM incidents
+            "#,
+        );
+        let mut filters = Vec::new();
+
+        if event_type.is_some() {
+            filters.push("event_type = ?");
+        }
+        if let Some(analyzed) = analyzed {
+            filters.push(if analyzed {
+                "llm_analysis IS NOT NULL"
+            } else {
+                "llm_analysis IS NULL"
+            });
+        }
+        if !filters.is_empty() {
+            sql.push_str("WHERE ");
+            sql.push_str(&filters.join(" AND "));
+            sql.push('\n');
+        }
+        sql.push_str("ORDER BY timestamp DESC LIMIT ?");
+
+        let mut query = sqlx::query(&sql);
+        if let Some(evt_type) = event_type {
+            query = query.bind(evt_type);
+        }
+        let rows = query.bind(limit).fetch_all(&self.pool).await?;
 
         Ok(rows
             .into_iter()
@@ -759,7 +760,7 @@ impl IncidentStore {
         let total: i64 = total_row.get(0);
 
         let cb_row = sqlx::query(
-            "SELECT COUNT(*) FROM incidents WHERE event_type = 'circuit_breaker' OR event_type LIKE 'circuit_breaker_%'",
+            "SELECT COUNT(*) FROM incidents WHERE event_type = 'circuit_breaker' OR event_type GLOB 'circuit_breaker_*'",
         )
         .fetch_one(&self.pool)
         .await?;

--- a/cognitod/src/incidents.rs
+++ b/cognitod/src/incidents.rs
@@ -623,20 +623,48 @@ impl IncidentStore {
 
     /// Get recent incidents
     pub async fn recent(&self, limit: i64) -> Result<Vec<Incident>, sqlx::Error> {
-        let rows = sqlx::query(
-            r#"
-            SELECT id, timestamp, event_type, psi_cpu, psi_memory, cpu_percent, load_avg,
-                   action, target_pid, target_name, system_snapshot,
-                   llm_analysis, llm_analyzed_at, recovery_time_ms, psi_after,
-                   investigation
-            FROM incidents
-            ORDER BY timestamp DESC
-            LIMIT ?
-            "#,
-        )
-        .bind(limit)
-        .fetch_all(&self.pool)
-        .await?;
+        self.recent_filtered(limit, None).await
+    }
+
+    /// Get recent incidents, optionally filtered by event type
+    pub async fn recent_filtered(
+        &self,
+        limit: i64,
+        event_type: Option<&str>,
+    ) -> Result<Vec<Incident>, sqlx::Error> {
+        let rows = if let Some(evt_type) = event_type {
+            sqlx::query(
+                r#"
+                SELECT id, timestamp, event_type, psi_cpu, psi_memory, cpu_percent, load_avg,
+                       action, target_pid, target_name, system_snapshot,
+                       llm_analysis, llm_analyzed_at, recovery_time_ms, psi_after,
+                       investigation
+                FROM incidents
+                WHERE event_type = ?
+                ORDER BY timestamp DESC
+                LIMIT ?
+                "#,
+            )
+            .bind(evt_type)
+            .bind(limit)
+            .fetch_all(&self.pool)
+            .await?
+        } else {
+            sqlx::query(
+                r#"
+                SELECT id, timestamp, event_type, psi_cpu, psi_memory, cpu_percent, load_avg,
+                       action, target_pid, target_name, system_snapshot,
+                       llm_analysis, llm_analyzed_at, recovery_time_ms, psi_after,
+                       investigation
+                FROM incidents
+                ORDER BY timestamp DESC
+                LIMIT ?
+                "#,
+            )
+            .bind(limit)
+            .fetch_all(&self.pool)
+            .await?
+        };
 
         Ok(rows
             .into_iter()
@@ -730,10 +758,11 @@ impl IncidentStore {
             .await?;
         let total: i64 = total_row.get(0);
 
-        let cb_row =
-            sqlx::query("SELECT COUNT(*) FROM incidents WHERE event_type = 'circuit_breaker'")
-                .fetch_one(&self.pool)
-                .await?;
+        let cb_row = sqlx::query(
+            "SELECT COUNT(*) FROM incidents WHERE event_type = 'circuit_breaker' OR event_type LIKE 'circuit_breaker_%'",
+        )
+        .fetch_one(&self.pool)
+        .await?;
         let circuit_breaker_count: i64 = cb_row.get(0);
 
         let avg_row = sqlx::query(

--- a/cognitod/tests/incident_outcome_eval.rs
+++ b/cognitod/tests/incident_outcome_eval.rs
@@ -152,6 +152,49 @@ async fn the_stats_average_counts_only_incidents_that_recovered() {
 }
 
 #[tokio::test]
+async fn the_stats_count_circuit_breaker_event_families() {
+    let (_dir, store) = store().await;
+
+    let mut memory_breaker = incident();
+    memory_breaker.event_type = "circuit_breaker_memory".to_string();
+    let mut manual = incident();
+    manual.event_type = "manual_kill".to_string();
+
+    store.insert(&incident()).await.unwrap();
+    store.insert(&memory_breaker).await.unwrap();
+    store.insert(&manual).await.unwrap();
+
+    let stats = store.stats().await.unwrap();
+
+    assert_eq!(stats.total, 3);
+    assert_eq!(stats.circuit_breaker_triggers, 2);
+}
+
+#[tokio::test]
+async fn recent_incidents_can_be_filtered_by_event_type() {
+    let (_dir, store) = store().await;
+
+    let mut manual = incident();
+    manual.event_type = "manual_kill".to_string();
+    manual.timestamp += 1;
+    let mut warning = incident();
+    warning.event_type = "warning".to_string();
+    warning.timestamp += 2;
+
+    store.insert(&incident()).await.unwrap();
+    store.insert(&manual).await.unwrap();
+    store.insert(&warning).await.unwrap();
+
+    let filtered = store
+        .recent_filtered(10, Some("manual_kill"))
+        .await
+        .unwrap();
+
+    assert_eq!(filtered.len(), 1);
+    assert_eq!(filtered[0].event_type, "manual_kill");
+}
+
+#[tokio::test]
 async fn the_average_stays_absent_until_something_recovers() {
     let (_dir, store) = store().await;
     let id = store.insert(&incident()).await.unwrap();

--- a/cognitod/tests/incident_outcome_eval.rs
+++ b/cognitod/tests/incident_outcome_eval.rs
@@ -159,14 +159,20 @@ async fn the_stats_count_circuit_breaker_event_families() {
     memory_breaker.event_type = "circuit_breaker_memory".to_string();
     let mut manual = incident();
     manual.event_type = "manual_kill".to_string();
+    let mut wildcard_spoof = incident();
+    wildcard_spoof.event_type = "circuitXbreakerYcpu".to_string();
+    let mut case_spoof = incident();
+    case_spoof.event_type = "CIRCUIT_BREAKER_CPU".to_string();
 
     store.insert(&incident()).await.unwrap();
     store.insert(&memory_breaker).await.unwrap();
     store.insert(&manual).await.unwrap();
+    store.insert(&wildcard_spoof).await.unwrap();
+    store.insert(&case_spoof).await.unwrap();
 
     let stats = store.stats().await.unwrap();
 
-    assert_eq!(stats.total, 3);
+    assert_eq!(stats.total, 5);
     assert_eq!(stats.circuit_breaker_triggers, 2);
 }
 
@@ -186,7 +192,7 @@ async fn recent_incidents_can_be_filtered_by_event_type() {
     store.insert(&warning).await.unwrap();
 
     let filtered = store
-        .recent_filtered(10, Some("manual_kill"))
+        .recent_filtered(10, Some("manual_kill"), None)
         .await
         .unwrap();
 


### PR DESCRIPTION
## Summary
- Apply /incidents event_type filtering in the store query instead of ignoring the parameter.
- Reject nonpositive limits and clamp oversized limits before SQLite sees them.
- Count circuit_breaker_* incident types in circuit breaker stats.

## Tests
- cargo test -p cognitod incidents_route
- cargo test -p cognitod --test incident_outcome_eval
- pre-commit hook: format, clippy, unit tests, cargo-deny