### PR TITLE
Bound listener event processing queue

### DIFF
--- a/cognitod/src/api/mod.rs
+++ b/cognitod/src/api/mod.rs
@@ -1507,6 +1507,8 @@ pub struct MetricsResponse {
     subscribers: usize,
     queue_depth: usize,
     dropped_events_total: u64,
+    listener_queue_depth: usize,
+    listener_queue_drops: u64,
     alerts_active: usize,
     uptime_seconds: u64,
     events_per_sec: u64,
@@ -1532,6 +1534,8 @@ pub async fn prometheus_metrics(State(app_state): State<Arc<AppState>>) -> Respo
 
     let events_total = metrics.events_total.load(Ordering::Relaxed);
     let dropped_total = metrics.dropped_events_total.load(Ordering::Relaxed);
+    let listener_queue_depth = metrics.listener_queue_depth();
+    let listener_queue_drops = metrics.listener_queue_drops();
     let alerts_emitted = metrics.alerts_emitted();
     let rb_overflows = metrics.rb_overflows();
     let rate_limited = metrics.rate_limited_events();
@@ -1613,6 +1617,24 @@ pub async fn prometheus_metrics(State(app_state): State<Arc<AppState>>) -> Respo
     );
     let _ = writeln!(body, "# TYPE linnix_rate_limited_total counter");
     let _ = writeln!(body, "linnix_rate_limited_total {}", rate_limited);
+
+    let _ = writeln!(
+        body,
+        "# HELP linnix_listener_queue_depth Current BPF listener event queue depth."
+    );
+    let _ = writeln!(body, "# TYPE linnix_listener_queue_depth gauge");
+    let _ = writeln!(body, "linnix_listener_queue_depth {}", listener_queue_depth);
+
+    let _ = writeln!(
+        body,
+        "# HELP linnix_listener_queue_dropped_total Events dropped because the BPF listener queue was full."
+    );
+    let _ = writeln!(body, "# TYPE linnix_listener_queue_dropped_total counter");
+    let _ = writeln!(
+        body,
+        "linnix_listener_queue_dropped_total {}",
+        listener_queue_drops
+    );
 
     let _ = writeln!(
         body,
@@ -1722,6 +1744,8 @@ pub async fn metrics_handler(State(app_state): State<Arc<AppState>>) -> Json<Met
         subscribers: metrics.subscribers.load(Ordering::Relaxed),
         queue_depth: app_state.context.queue_depth(),
         dropped_events_total: metrics.dropped_events_total.load(Ordering::Relaxed),
+        listener_queue_depth: metrics.listener_queue_depth(),
+        listener_queue_drops: metrics.listener_queue_drops(),
         alerts_active: metrics.alerts_active.load(Ordering::Relaxed),
         uptime_seconds: metrics.uptime_seconds(),
         events_per_sec: metrics.events_per_sec(),

--- a/cognitod/src/config.rs
+++ b/cognitod/src/config.rs
@@ -435,6 +435,8 @@ pub struct RuntimeConfig {
     pub rss_cap_mb: u64,
     #[serde(default = "default_events_rate_cap")]
     pub events_rate_cap: u64,
+    #[serde(default = "default_event_queue_capacity")]
+    pub event_queue_capacity: usize,
 }
 
 impl Default for RuntimeConfig {
@@ -444,6 +446,7 @@ impl Default for RuntimeConfig {
             cpu_target_pct: default_cpu_target_pct(),
             rss_cap_mb: default_rss_cap_mb(),
             events_rate_cap: default_events_rate_cap(),
+            event_queue_capacity: default_event_queue_capacity(),
         }
     }
 }
@@ -459,6 +462,9 @@ fn default_rss_cap_mb() -> u64 {
 }
 fn default_events_rate_cap() -> u64 {
     100_000
+}
+fn default_event_queue_capacity() -> usize {
+    4096
 }
 
 #[derive(Debug, Deserialize, Clone)]
@@ -780,6 +786,7 @@ offline = true
 "#;
         let cfg: Config = toml::from_str(toml).unwrap();
         assert!(cfg.runtime.offline);
+        assert_eq!(cfg.runtime.event_queue_capacity, 4096);
         assert_eq!(cfg.api.listen_addr, "127.0.0.1:3000");
         assert!(cfg.api.auth_token.is_none());
     }

--- a/cognitod/src/main.rs
+++ b/cognitod/src/main.rs
@@ -988,6 +988,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
             Arc::clone(&handlers),
             Arc::clone(&offline_guard),
             config.runtime.events_rate_cap,
+            config.runtime.event_queue_capacity,
         );
     }
 

--- a/cognitod/src/metrics.rs
+++ b/cognitod/src/metrics.rs
@@ -23,6 +23,8 @@ pub struct Metrics {
     lineage_hits: AtomicU64,
     lineage_misses: AtomicU64,
     drops_by_type: [AtomicU64; EVENT_TYPE_SLOTS],
+    listener_queue_depth: AtomicUsize,
+    listener_queue_drops: AtomicU64,
     alerts_emitted_total: AtomicU64,
     perf_poll_errors: AtomicU64,
     active_rules: AtomicUsize,
@@ -66,6 +68,8 @@ impl Metrics {
             lineage_hits: AtomicU64::new(0),
             lineage_misses: AtomicU64::new(0),
             drops_by_type: std::array::from_fn(|_| AtomicU64::new(0)),
+            listener_queue_depth: AtomicUsize::new(0),
+            listener_queue_drops: AtomicU64::new(0),
             alerts_emitted_total: AtomicU64::new(0),
             perf_poll_errors: AtomicU64::new(0),
             active_rules: AtomicUsize::new(0),
@@ -157,6 +161,25 @@ impl Metrics {
         (0..self.drops_by_type.len())
             .map(|idx| (idx as u32, self.drops_by_type[idx].load(Ordering::Relaxed)))
             .collect()
+    }
+
+    pub fn set_listener_queue_depth(&self, depth: usize) {
+        self.listener_queue_depth.store(depth, Ordering::Relaxed);
+    }
+
+    pub fn listener_queue_depth(&self) -> usize {
+        self.listener_queue_depth.load(Ordering::Relaxed)
+    }
+
+    pub fn record_listener_queue_drop(&self, event_type: u32) {
+        let idx = Self::event_index(event_type);
+        self.drops_by_type[idx].fetch_add(1, Ordering::Relaxed);
+        self.dropped_events_total.fetch_add(1, Ordering::Relaxed);
+        self.listener_queue_drops.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn listener_queue_drops(&self) -> u64 {
+        self.listener_queue_drops.load(Ordering::Relaxed)
     }
 
     pub fn inc_alerts_emitted(&self) {

--- a/cognitod/src/runtime/stream_listener.rs
+++ b/cognitod/src/runtime/stream_listener.rs
@@ -11,7 +11,12 @@ use bytes::BytesMut;
 use linnix_ai_ebpf_common::EventType;
 use std::{io, mem, ptr, sync::Arc, thread, time::Duration};
 use tokio::io::unix::AsyncFd;
-use tokio::runtime::Handle;
+use tokio::sync::mpsc::{self, error::TrySendError};
+
+struct QueuedEvent {
+    event: ProcessEvent,
+    comm: String,
+}
 
 fn event_label(kind: u32) -> &'static str {
     match kind {
@@ -35,16 +40,23 @@ pub fn start_listener(
     handlers: Arc<HandlerList>,
     _offline: Arc<OfflineGuard>,
     rate_cap: u64,
+    event_queue_capacity: usize,
 ) {
     println!("[cognitod] Starting listener for BPF ring buffer...");
+    let (event_tx, event_rx) = mpsc::channel(listener_queue_capacity(event_queue_capacity));
+    spawn_event_worker(
+        context.clone(),
+        metrics.clone(),
+        handlers.clone(),
+        None,
+        event_rx,
+    );
+
     tokio::task::spawn_blocking(move || {
-        let rt_handle = Handle::current();
-        let handlers = handlers.clone();
         loop {
             if let Some(data) = ringbuf.next() {
                 if let Some(event) = parse_event(data.as_ref()) {
-                    let metrics_clone = metrics.clone();
-                    if !metrics_clone.record_event(rate_cap, event.event_type) {
+                    if !metrics.record_event(rate_cap, event.event_type) {
                         continue;
                     }
                     let comm = std::str::from_utf8(&event.comm)
@@ -52,23 +64,7 @@ pub fn start_listener(
                         .trim_end_matches('\0')
                         .to_string();
 
-                    // Process event asynchronously
-                    let context_clone = context.clone();
-                    let event_for_llm = event.clone();
-                    let handlers_clone = handlers.clone();
-                    rt_handle.spawn(async move {
-                        println!(
-                            "[event] type={:?} pid={} ppid={} uid={} gid={} comm={}",
-                            event_label(event_for_llm.event_type),
-                            event_for_llm.pid,
-                            event_for_llm.ppid,
-                            event_for_llm.uid,
-                            event_for_llm.gid,
-                            comm
-                        );
-                        handlers_clone.on_event(&event_for_llm).await;
-                        context_clone.add(event_for_llm);
-                    });
+                    try_enqueue_event(&event_tx, &metrics, QueuedEvent { event, comm });
                 } else {
                     metrics.inc_rb_overflow();
                     println!("[cognitod] Failed to parse event");
@@ -88,16 +84,23 @@ pub fn start_perf_listener(
     handlers: Arc<HandlerList>,
     _offline: Arc<OfflineGuard>,
     rate_cap: u64,
+    event_queue_capacity: usize,
 ) {
     println!("[cognitod] Starting listener for BPF perf buffers...");
 
     let lineage_cache: Arc<LineageCache> = Arc::new(LineageCache::default());
+    let (event_tx, event_rx) = mpsc::channel(listener_queue_capacity(event_queue_capacity));
+    spawn_event_worker(
+        context.clone(),
+        metrics.clone(),
+        handlers.clone(),
+        Some(Arc::clone(&lineage_cache)),
+        event_rx,
+    );
 
     for buffer in buffers {
-        let context = Arc::clone(&context);
         let metrics = Arc::clone(&metrics);
-        let handlers = Arc::clone(&handlers);
-        let lineage = Arc::clone(&lineage_cache);
+        let event_tx = event_tx.clone();
 
         tokio::spawn(async move {
             let mut async_buffer = match AsyncFd::new(buffer) {
@@ -163,58 +166,116 @@ pub fn start_perf_listener(
                         continue;
                     }
 
-                    let mut event_for_llm = ProcessEvent::new(event_wire);
-                    let comm = std::str::from_utf8(&event_for_llm.comm)
+                    let event = ProcessEvent::new(event_wire);
+                    let comm = std::str::from_utf8(&event.comm)
                         .unwrap_or("invalid")
                         .trim_end_matches('\0')
                         .to_string();
 
                     log::debug!(
                         "[perf] received event type={:?} pid={} ppid={} comm={}",
-                        event_label(event_for_llm.event_type),
-                        event_for_llm.pid,
-                        event_for_llm.ppid,
+                        event_label(event.event_type),
+                        event.pid,
+                        event.ppid,
                         comm
                     );
 
-                    let metrics_for_llm = Arc::clone(&metrics);
-                    let handlers_clone = Arc::clone(&handlers);
-                    let context_clone = Arc::clone(&context);
-                    let lineage_clone = Arc::clone(&lineage);
-
-                    tokio::spawn(async move {
-                        if event_for_llm.event_type == EventType::Fork as u32 {
-                            lineage_clone
-                                .record_fork(event_for_llm.pid, event_for_llm.ppid)
-                                .await;
-                        } else if event_for_llm.ppid == 0 {
-                            match lineage_clone.lookup(event_for_llm.pid).await {
-                                Some(ppid) => {
-                                    event_for_llm.ppid = ppid;
-                                    metrics_for_llm.inc_lineage_hit();
-                                }
-                                None => {
-                                    metrics_for_llm.inc_lineage_miss();
-                                }
-                            }
-                        }
-
-                        println!(
-                            "[event] type={:?} pid={} ppid={} uid={} gid={} comm={}",
-                            event_label(event_for_llm.event_type),
-                            event_for_llm.pid,
-                            event_for_llm.ppid,
-                            event_for_llm.uid,
-                            event_for_llm.gid,
-                            comm
-                        );
-                        handlers_clone.on_event(&event_for_llm).await;
-                        context_clone.add(event_for_llm);
-                    });
+                    try_enqueue_event(&event_tx, &metrics, QueuedEvent { event, comm });
                 }
             }
         });
     }
+}
+
+fn listener_queue_capacity(configured: usize) -> usize {
+    if configured == 0 {
+        log::warn!("[config] runtime.event_queue_capacity=0 is invalid; using 1");
+        1
+    } else {
+        configured
+    }
+}
+
+fn spawn_event_worker(
+    context: Arc<ContextStore>,
+    metrics: Arc<Metrics>,
+    handlers: Arc<HandlerList>,
+    lineage: Option<Arc<LineageCache>>,
+    mut event_rx: mpsc::Receiver<QueuedEvent>,
+) {
+    tokio::spawn(async move {
+        while let Some(queued) = event_rx.recv().await {
+            metrics.set_listener_queue_depth(event_rx.len());
+            process_queued_event(
+                queued,
+                Arc::clone(&context),
+                Arc::clone(&metrics),
+                Arc::clone(&handlers),
+                lineage.clone(),
+            )
+            .await;
+            metrics.set_listener_queue_depth(event_rx.len());
+        }
+        metrics.set_listener_queue_depth(0);
+    });
+}
+
+fn try_enqueue_event(event_tx: &mpsc::Sender<QueuedEvent>, metrics: &Metrics, queued: QueuedEvent) {
+    let event_type = queued.event.event_type;
+    match event_tx.try_send(queued) {
+        Ok(()) => {
+            metrics.set_listener_queue_depth(
+                event_tx.max_capacity().saturating_sub(event_tx.capacity()),
+            );
+        }
+        Err(TrySendError::Full(_)) => {
+            metrics.record_listener_queue_drop(event_type);
+            metrics.set_listener_queue_depth(event_tx.max_capacity());
+        }
+        Err(TrySendError::Closed(_)) => {
+            metrics.record_listener_queue_drop(event_type);
+            metrics.set_listener_queue_depth(0);
+            log::warn!("listener event worker is closed; dropping event");
+        }
+    }
+}
+
+async fn process_queued_event(
+    queued: QueuedEvent,
+    context: Arc<ContextStore>,
+    metrics: Arc<Metrics>,
+    handlers: Arc<HandlerList>,
+    lineage: Option<Arc<LineageCache>>,
+) {
+    let QueuedEvent { mut event, comm } = queued;
+
+    if let Some(lineage) = lineage {
+        if event.event_type == EventType::Fork as u32 {
+            lineage.record_fork(event.pid, event.ppid).await;
+        } else if event.ppid == 0 {
+            match lineage.lookup(event.pid).await {
+                Some(ppid) => {
+                    event.ppid = ppid;
+                    metrics.inc_lineage_hit();
+                }
+                None => {
+                    metrics.inc_lineage_miss();
+                }
+            }
+        }
+    }
+
+    println!(
+        "[event] type={:?} pid={} ppid={} uid={} gid={} comm={}",
+        event_label(event.event_type),
+        event.pid,
+        event.ppid,
+        event.uid,
+        event.gid,
+        comm
+    );
+    handlers.on_event(&event).await;
+    context.add(event);
 }
 
 #[allow(dead_code)]
@@ -225,4 +286,133 @@ fn parse_event(bytes: &[u8]) -> Option<ProcessEvent> {
     let ptr = bytes.as_ptr() as *const ProcessEventWire;
     let raw = unsafe { *ptr };
     Some(ProcessEvent::new(raw))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::PERCENT_MILLI_UNKNOWN;
+    use crate::handler::Handler;
+    use crate::types::SystemSnapshot;
+    use async_trait::async_trait;
+    use std::sync::Mutex;
+    use tokio::sync::Notify;
+
+    fn event(pid: u32, sequence: u64) -> ProcessEvent {
+        ProcessEvent::new(ProcessEventWire {
+            pid,
+            ppid: 0,
+            uid: 0,
+            gid: 0,
+            event_type: EventType::Net as u32,
+            ts_ns: sequence,
+            seq: sequence,
+            comm: [0; 16],
+            exit_time_ns: 0,
+            cpu_pct_milli: PERCENT_MILLI_UNKNOWN,
+            mem_pct_milli: PERCENT_MILLI_UNKNOWN,
+            data: sequence,
+            data2: 0,
+            aux: 0,
+            aux2: 0,
+        })
+    }
+
+    #[test]
+    fn burst_enqueue_is_bounded_and_accounted() {
+        let metrics = Metrics::new();
+        let (tx, _rx) = mpsc::channel(2);
+
+        for sequence in 0..10 {
+            try_enqueue_event(
+                &tx,
+                &metrics,
+                QueuedEvent {
+                    event: event(42, sequence),
+                    comm: "burst".to_string(),
+                },
+            );
+        }
+
+        assert_eq!(metrics.listener_queue_depth(), 2);
+        assert_eq!(metrics.listener_queue_drops(), 8);
+        assert_eq!(
+            metrics
+                .dropped_events_total
+                .load(std::sync::atomic::Ordering::Relaxed),
+            8
+        );
+        assert_eq!(
+            metrics
+                .drops_by_type()
+                .into_iter()
+                .find(|(event_type, _)| *event_type == EventType::Net as u32)
+                .map(|(_, drops)| drops),
+            Some(8)
+        );
+    }
+
+    #[derive(Clone)]
+    struct RecordingHandler {
+        seen: Arc<Mutex<Vec<u64>>>,
+        notify: Arc<Notify>,
+    }
+
+    #[async_trait]
+    impl Handler for RecordingHandler {
+        fn name(&self) -> &'static str {
+            "recording"
+        }
+
+        async fn on_event(&self, event: &ProcessEvent) {
+            self.seen.lock().unwrap().push(event.data);
+            self.notify.notify_waiters();
+        }
+
+        async fn on_snapshot(&self, _snapshot: &SystemSnapshot) {}
+    }
+
+    #[tokio::test]
+    async fn worker_preserves_per_pid_enqueue_order() {
+        let context = Arc::new(ContextStore::new(Duration::from_secs(60), 64, None));
+        let metrics = Arc::new(Metrics::new());
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let notify = Arc::new(Notify::new());
+        let handler = RecordingHandler {
+            seen: Arc::clone(&seen),
+            notify: Arc::clone(&notify),
+        };
+        let mut handler_list = HandlerList::new();
+        handler_list.register(handler);
+        let handlers = Arc::new(handler_list);
+        let (tx, rx) = mpsc::channel(8);
+        spawn_event_worker(context, Arc::clone(&metrics), handlers, None, rx);
+
+        for sequence in 0..6 {
+            try_enqueue_event(
+                &tx,
+                &metrics,
+                QueuedEvent {
+                    event: event(42, sequence),
+                    comm: "ordered".to_string(),
+                },
+            );
+        }
+
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(1);
+        loop {
+            if seen.lock().unwrap().len() == 6 {
+                break;
+            }
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "worker did not process the synthetic burst"
+            );
+            notify.notified().await;
+        }
+
+        assert_eq!(*seen.lock().unwrap(), vec![0, 1, 2, 3, 4, 5]);
+        assert!(metrics.listener_queue_depth() <= 8);
+        assert_eq!(metrics.listener_queue_drops(), 0);
+    }
 }

--- a/cognitod/src/runtime/stream_listener.rs
+++ b/cognitod/src/runtime/stream_listener.rs
@@ -401,14 +401,15 @@ mod tests {
 
         let deadline = tokio::time::Instant::now() + Duration::from_secs(1);
         loop {
+            let notified = notify.notified();
             if seen.lock().unwrap().len() == 6 {
                 break;
             }
-            assert!(
-                tokio::time::Instant::now() < deadline,
-                "worker did not process the synthetic burst"
-            );
-            notify.notified().await;
+            let now = tokio::time::Instant::now();
+            assert!(now < deadline, "worker did not process the synthetic burst");
+            tokio::time::timeout(deadline - now, notified)
+                .await
+                .expect("worker did not process the synthetic burst");
         }
 
         assert_eq!(*seen.lock().unwrap(), vec![0, 1, 2, 3, 4, 5]);

--- a/cognitod/tests/fixtures/metrics_prometheus.txt
+++ b/cognitod/tests/fixtures/metrics_prometheus.txt
@@ -22,6 +22,12 @@ linnix_ringbuf_overflows_total 1
 # HELP linnix_rate_limited_total Events skipped due to configured rate caps.
 # TYPE linnix_rate_limited_total counter
 linnix_rate_limited_total 0
+# HELP linnix_listener_queue_depth Current BPF listener event queue depth.
+# TYPE linnix_listener_queue_depth gauge
+linnix_listener_queue_depth 0
+# HELP linnix_listener_queue_dropped_total Events dropped because the BPF listener queue was full.
+# TYPE linnix_listener_queue_dropped_total counter
+linnix_listener_queue_dropped_total 0
 # HELP linnix_perf_poll_errors_total Perf buffer polling errors.
 # TYPE linnix_perf_poll_errors_total counter
 linnix_perf_poll_errors_total 1


### PR DESCRIPTION
## Summary
- Replace per-event Tokio task spawning in ring/perf listeners with a bounded mpsc queue and ordered worker.
- Add listener queue depth/drop accounting, metrics exposure, config default, and Prometheus fixture updates.

## Tests
- cargo test -p cognitod burst_enqueue_is_bounded_and_accounted
- cargo test -p cognitod worker_preserves_per_pid_enqueue_order
- cargo test -p cognitod parse_config_defaults
- cargo test -p cognitod metrics_prometheus_matches_the_recorded_contract --bin cognitod
- pre-commit hook: format, clippy, unit tests, cargo-deny