### PR TITLE
fix(ci): enforce suite and script regression failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,3 +118,7 @@ jobs:
           python-version: '3.11'
       - name: Validate documentation against code
         run: python3 scripts/validate_docs.py --workspace .
+      - name: Validate package assets
+        run: python3 scripts/validate_package_assets.py
+      - name: Run Python regression tests
+        run: python3 -m unittest discover -s scripts -p 'test_*.py'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,6 +27,7 @@ cargo nextest run --workspace
 
 Recommended toolchain versions:
 - Rust stable (check `rust-toolchain.toml` if present)
+- `cargo-deny` 0.20.2 or newer (required for current CVSS 4.0 advisories)
 - `clang`/`llvm` ≥ 14 for eBPF builds
 - Linux kernel 5.12+ (x86_64) / 5.18+ (arm64) with BTF data for local testing
 

--- a/scripts/full_test_suite.sh
+++ b/scripts/full_test_suite.sh
@@ -2,7 +2,7 @@
 # Linnix Full Test Suite
 # Runs all tests and validates documentation against code
 
-set -e
+set -euo pipefail
 
 # Colors
 RED='\033[0;31m'

--- a/scripts/full_test_suite.sh
+++ b/scripts/full_test_suite.sh
@@ -98,7 +98,7 @@ run_step "4.1" "Doc Validator" \
 # Check for broken links in markdown (if markdown-link-check is installed)
 if command -v markdown-link-check &> /dev/null; then
     run_step "4.2" "Markdown Link Check" \
-        "find . -name '*.md' -not -path './target/*' | head -10 | xargs -I{} markdown-link-check {} 2>&1 | tail -20"
+        "find . -name '*.md' -not -path './target/*' -print0 | xargs -0 -r -n 1 markdown-link-check 2>&1 | tail -20"
 else
     echo -e "${YELLOW}[4.2] Markdown Link Check - Skipped (markdown-link-check not installed)${NC}"
     echo ""

--- a/scripts/test_full_test_suite.py
+++ b/scripts/test_full_test_suite.py
@@ -35,6 +35,20 @@ fi
 exit 0
 """,
         )
+        self.markdown_log = self.repo / "markdown-checks.log"
+        self._write_executable(
+            self.fake_bin / "markdown-link-check",
+            """#!/bin/bash
+set -u
+
+printf '%s\n' "$1" >> "$FAKE_MARKDOWN_LOG"
+status="${FAKE_MARKDOWN_STATUS:-0}"
+if [ "$status" -ne 0 ]; then
+    echo "simulated markdown-link-check failure: $1" >&2
+fi
+exit "$status"
+""",
+        )
         (self.repo / "scripts" / "validate_docs.py").write_text(
             "raise SystemExit(0)\n", encoding="utf-8"
         )
@@ -47,10 +61,15 @@ exit 0
         (self.repo / "cognitod" / "src" / "config.rs").write_text(
             "pub struct ApiConfig {}\n", encoding="utf-8"
         )
+        docs_dir = self.repo / "docs"
+        docs_dir.mkdir()
+        for index in range(12):
+            (docs_dir / f"doc-{index}.md").write_text("# Test\n", encoding="utf-8")
 
         self.suite = suite
         self.env = os.environ.copy()
         self.env["PATH"] = f"{self.fake_bin}:/usr/bin:/bin"
+        self.env["FAKE_MARKDOWN_LOG"] = str(self.markdown_log)
 
     def tearDown(self) -> None:
         self.temp_dir.cleanup()
@@ -60,10 +79,13 @@ exit 0
         path.write_text(content, encoding="utf-8")
         path.chmod(0o755)
 
-    def _run_suite(self, failure_match: str | None = None) -> subprocess.CompletedProcess[str]:
+    def _run_suite(
+        self, failure_match: str | None = None, **env_overrides: str
+    ) -> subprocess.CompletedProcess[str]:
         env = self.env.copy()
         if failure_match is not None:
             env["FAKE_CARGO_FAIL_MATCH"] = failure_match
+        env.update(env_overrides)
         return subprocess.run(
             [str(self.suite)],
             cwd=self.repo,
@@ -79,6 +101,8 @@ exit 0
 
         self.assertEqual(result.returncode, 0, result.stdout)
         self.assertIn("All tests passed", result.stdout)
+        checked_files = self.markdown_log.read_text(encoding="utf-8").splitlines()
+        self.assertEqual(len(checked_files), 12)
 
     def test_piped_cargo_failures_fail_the_suite(self) -> None:
         commands = (
@@ -96,6 +120,12 @@ exit 0
 
                 self.assertNotEqual(result.returncode, 0, result.stdout)
                 self.assertIn("Some tests failed", result.stdout)
+
+    def test_markdown_link_failure_fails_the_suite(self) -> None:
+        result = self._run_suite(FAKE_MARKDOWN_STATUS="23")
+
+        self.assertNotEqual(result.returncode, 0, result.stdout)
+        self.assertIn("Some tests failed", result.stdout)
 
 
 if __name__ == "__main__":

--- a/scripts/test_full_test_suite.py
+++ b/scripts/test_full_test_suite.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Regression tests for full-test-suite pipeline status handling."""
+
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+
+FULL_SUITE = Path(__file__).resolve().with_name("full_test_suite.sh")
+
+
+class FullTestSuiteTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.repo = Path(self.temp_dir.name)
+        self.fake_bin = self.repo / "fake-bin"
+        self.fake_bin.mkdir()
+        (self.repo / "scripts").mkdir()
+        (self.repo / "cognitod" / "src").mkdir(parents=True)
+
+        suite = self.repo / "scripts" / "full_test_suite.sh"
+        shutil.copy2(FULL_SUITE, suite)
+        self._write_executable(
+            self.fake_bin / "cargo",
+            """#!/bin/bash
+set -u
+
+if [ -n "${FAKE_CARGO_FAIL_MATCH:-}" ] && [[ "$*" == *"$FAKE_CARGO_FAIL_MATCH"* ]]; then
+    echo "simulated cargo failure: $*" >&2
+    exit 23
+fi
+exit 0
+""",
+        )
+        (self.repo / "scripts" / "validate_docs.py").write_text(
+            "raise SystemExit(0)\n", encoding="utf-8"
+        )
+        (self.repo / "cognitod" / "src" / "api" / "mod.rs").parent.mkdir(
+            parents=True, exist_ok=True
+        )
+        (self.repo / "cognitod" / "src" / "api" / "mod.rs").write_text(
+            '.route("/healthz")\n', encoding="utf-8"
+        )
+        (self.repo / "cognitod" / "src" / "config.rs").write_text(
+            "pub struct ApiConfig {}\n", encoding="utf-8"
+        )
+
+        self.suite = suite
+        self.env = os.environ.copy()
+        self.env["PATH"] = f"{self.fake_bin}:/usr/bin:/bin"
+
+    def tearDown(self) -> None:
+        self.temp_dir.cleanup()
+
+    @staticmethod
+    def _write_executable(path: Path, content: str) -> None:
+        path.write_text(content, encoding="utf-8")
+        path.chmod(0o755)
+
+    def _run_suite(self, failure_match: str | None = None) -> subprocess.CompletedProcess[str]:
+        env = self.env.copy()
+        if failure_match is not None:
+            env["FAKE_CARGO_FAIL_MATCH"] = failure_match
+        return subprocess.run(
+            [str(self.suite)],
+            cwd=self.repo,
+            env=env,
+            check=False,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+        )
+
+    def test_successful_commands_pass_the_suite(self) -> None:
+        result = self._run_suite()
+
+        self.assertEqual(result.returncode, 0, result.stdout)
+        self.assertIn("All tests passed", result.stdout)
+
+    def test_piped_cargo_failures_fail_the_suite(self) -> None:
+        commands = (
+            "nextest run --workspace --profile default",
+            "nextest run --workspace --profile e2e",
+            "clippy --all-targets --all-features",
+            "deny check",
+            "build --release",
+            "xtask build-ebpf",
+        )
+
+        for command in commands:
+            with self.subTest(command=command):
+                result = self._run_suite(command)
+
+                self.assertNotEqual(result.returncode, 0, result.stdout)
+                self.assertIn("Some tests failed", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Enable `pipefail` in the full test suite so piped nextest, Clippy, cargo-deny, build, and eBPF failures cannot be hidden by `tail`.
- Traverse every Markdown file with null-delimited paths, avoiding early-closing SIGPIPE failures while preserving link-check failures.
- Add deterministic fake-command regression coverage for Cargo pipelines and Markdown link checks.
- Run package metadata validation and all `scripts/test_*.py` regression tests in CI.
- Document cargo-deny 0.20.2 or newer for CVSS 4.0 advisory support.

## Verification

- `cargo nextest run --workspace --profile default` (275 passed)
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `python3 scripts/validate_docs.py --workspace .` (30 passed)
- `python3 scripts/validate_package_assets.py`
- `python3 -m unittest discover -s scripts -p 'test_*.py'` (10 passed)
- `bash -n scripts/full_test_suite.sh`
- `git diff --check`

The local cargo-deny 0.18.5 installation cannot parse current CVSS 4.0 advisories. This PR documents the supported version; the existing CI job installs the current cargo-deny release and provides the authoritative dependency audit.