### PR TITLE
Phase 3: kernel/topology matrix (capture path + episode fixes + Terraform module)

### DIFF
--- a/cognitod/src/cell.rs
+++ b/cognitod/src/cell.rs
@@ -1,0 +1,95 @@
+//! Detects the kernel/topology cell the daemon is running on.
+//!
+//! Only used to stamp `episode::Cell` onto a captured `VmCapture` episode --
+//! Phase 3's kernel/topology matrix scores accuracy per cell, so a capture
+//! that can't say what it ran on is not useful data. Detection is
+//! best-effort: a field that can't be determined is `None`/a fallback string
+//! rather than a hard error, since a stall attribution scan must never fail
+//! because of missing capture metadata.
+
+use std::path::Path;
+use std::process::Command;
+
+use crate::episode::Cell;
+
+const BTF_PATH: &str = "/sys/kernel/btf/vmlinux";
+const CGROUP_V2_MARKER: &str = "/sys/fs/cgroup/cgroup.controllers";
+
+/// Detects the current cell against real system paths (`/proc`, `/sys`, and
+/// `PATH`). Call once per process -- none of this changes while a daemon
+/// runs.
+pub fn detect_cell() -> Cell {
+    detect_cell_with_root(Path::new("/"))
+}
+
+/// Same as [`detect_cell`], but reading `/proc` and `/sys` under `root`
+/// instead of the real filesystem root, so tests can exercise this without
+/// depending on the host kernel.
+fn detect_cell_with_root(root: &Path) -> Cell {
+    let is_cgroup_v2 = root.join(CGROUP_V2_MARKER.trim_start_matches('/')).exists();
+    Cell {
+        kernel_release: read_kernel_release(root),
+        arch: std::env::consts::ARCH.to_string(),
+        btf_present: root.join(BTF_PATH.trim_start_matches('/')).exists(),
+        cgroup_driver: if is_cgroup_v2 { "cgroupv2" } else { "cgroupv1" }.to_string(),
+        k3s_version: detect_k3s_version(),
+    }
+}
+
+fn read_kernel_release(root: &Path) -> String {
+    std::fs::read_to_string(root.join("proc/sys/kernel/osrelease"))
+        .map(|s| s.trim().to_string())
+        .unwrap_or_else(|_| "unknown".to_string())
+}
+
+/// `k3s --version`'s first line (e.g. "k3s version v1.30.2+k3s1 ..."), or
+/// `None` when the binary isn't on `PATH` or the command fails -- the daemon
+/// itself doesn't require k3s, only the Phase 3 matrix VMs do.
+fn detect_k3s_version() -> Option<String> {
+    let output = Command::new("k3s").arg("--version").output().ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    String::from_utf8(output.stdout)
+        .ok()?
+        .lines()
+        .next()
+        .map(|line| line.trim().to_string())
+        .filter(|line| !line.is_empty())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    #[test]
+    fn falls_back_to_unknown_kernel_release_when_proc_is_absent() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cell = detect_cell_with_root(tmp.path());
+        assert_eq!(cell.kernel_release, "unknown");
+        assert_eq!(cell.cgroup_driver, "cgroupv1");
+        assert!(!cell.btf_present);
+    }
+
+    #[test]
+    fn reads_kernel_release_and_detects_cgroup_v2_and_btf() {
+        let tmp = tempfile::tempdir().unwrap();
+        fs::create_dir_all(tmp.path().join("proc/sys/kernel")).unwrap();
+        fs::write(
+            tmp.path().join("proc/sys/kernel/osrelease"),
+            "5.15.0-1053-aws\n",
+        )
+        .unwrap();
+        fs::create_dir_all(tmp.path().join("sys/fs/cgroup")).unwrap();
+        fs::write(tmp.path().join("sys/fs/cgroup/cgroup.controllers"), "").unwrap();
+        fs::create_dir_all(tmp.path().join("sys/kernel/btf")).unwrap();
+        fs::write(tmp.path().join("sys/kernel/btf/vmlinux"), "").unwrap();
+
+        let cell = detect_cell_with_root(tmp.path());
+        assert_eq!(cell.kernel_release, "5.15.0-1053-aws");
+        assert_eq!(cell.cgroup_driver, "cgroupv2");
+        assert!(cell.btf_present);
+        assert_eq!(cell.arch, std::env::consts::ARCH);
+    }
+}

--- a/cognitod/src/collectors/psi.rs
+++ b/cognitod/src/collectors/psi.rs
@@ -337,6 +337,19 @@ fn onset_offset_ms(now: Instant, start: Instant) -> i64 {
 /// the victim (its own retained signal series), and one per offender still
 /// tracked in `consumer_busy_since`. Free-standing and pure so it can be
 /// tested without driving the scan loop.
+/// An offender candidate's identity plus the three signals
+/// `Episode::to_stall_event` reads back via `candidate_signal` -- an episode
+/// captured from a real `StallEvent` must replay to the same attribution,
+/// and that equality only holds if these land in the candidate's window
+/// rather than the empty windows this used to leave behind.
+struct OffenderSignal {
+    pod: PodRef,
+    onset_ms: Option<i64>,
+    cpu_percent: f32,
+    fork_count: Option<u64>,
+    short_job_count: Option<u64>,
+}
+
 fn build_candidate_windows(
     victim: PodRef,
     victim_owner_kind: Option<String>,
@@ -344,7 +357,7 @@ fn build_candidate_windows(
     victim_pre_window: BTreeMap<String, Vec<f64>>,
     victim_onset_ms: Option<i64>,
     sample_interval_ms: u64,
-    offenders: &[(PodRef, Option<i64>)],
+    offenders: &[OffenderSignal],
 ) -> Vec<CandidateWindow> {
     let mut candidates = Vec::with_capacity(1 + offenders.len());
     candidates.push(CandidateWindow {
@@ -356,15 +369,23 @@ fn build_candidate_windows(
         sample_interval_ms,
         first_deviation_offset_ms: victim_onset_ms,
     });
-    for (pod, onset_ms) in offenders.iter().take(MAX_CANDIDATE_OFFENDERS) {
+    for offender in offenders.iter().take(MAX_CANDIDATE_OFFENDERS) {
+        let mut pre_window: BTreeMap<String, Vec<f64>> = BTreeMap::new();
+        pre_window.insert("cpu_percent".to_string(), vec![offender.cpu_percent as f64]);
+        if let Some(fork_count) = offender.fork_count {
+            pre_window.insert("fork_count".to_string(), vec![fork_count as f64]);
+        }
+        if let Some(short_job_count) = offender.short_job_count {
+            pre_window.insert("short_job_count".to_string(), vec![short_job_count as f64]);
+        }
         candidates.push(CandidateWindow {
-            pod: pod.clone(),
+            pod: offender.pod.clone(),
             owner_kind: None,
             owner_name: None,
-            pre_window: BTreeMap::new(),
+            pre_window,
             post_window: BTreeMap::new(),
             sample_interval_ms,
-            first_deviation_offset_ms: *onset_ms,
+            first_deviation_offset_ms: offender.onset_ms,
         });
     }
     candidates
@@ -780,22 +801,68 @@ impl PsiMonitor {
                                     .unwrap_or_default(),
                             );
 
-                            let offenders: Vec<(PodRef, Option<i64>)> = consumers
-                                .iter()
-                                .filter(|c| format!("{}/{}", c.namespace, c.pod) != key)
-                                .map(|c| {
-                                    let consumer_key = format!("{}/{}", c.namespace, c.pod);
-                                    let onset_ms = self
-                                        .consumer_busy_since
-                                        .get(&consumer_key)
-                                        .map(|start| onset_offset_ms(now, *start));
+                            // Union of everything `calculate_blame_attributions` treats
+                            // as a candidate offender -- CPU consumers, forkers, and
+                            // short-job spawners -- not just the CPU consumer list.
+                            // A pod that forks hard without being a top CPU consumer
+                            // (a fork-storm scenario) is blamed live from
+                            // `event.fork_counts` alone; leaving it out here would
+                            // silently drop it from the captured episode entirely.
+                            let mut offender_cpu: HashMap<String, (PodRef, f32)> = HashMap::new();
+                            for c in &consumers {
+                                let consumer_key = format!("{}/{}", c.namespace, c.pod);
+                                if consumer_key == key {
+                                    continue;
+                                }
+                                let entry = offender_cpu.entry(consumer_key).or_insert_with(|| {
                                     (
                                         PodRef {
                                             namespace: c.namespace.clone(),
                                             pod: c.pod.clone(),
                                         },
-                                        onset_ms,
+                                        0.0,
                                     )
+                                });
+                                entry.1 += c.cpu_percent;
+                            }
+                            let mut offender_keys: std::collections::BTreeSet<String> =
+                                offender_cpu.keys().cloned().collect();
+                            offender_keys
+                                .extend(fork_counts.keys().filter(|k| **k != key).cloned());
+                            offender_keys
+                                .extend(short_job_counts.keys().filter(|k| **k != key).cloned());
+
+                            let offenders: Vec<OffenderSignal> = offender_keys
+                                .into_iter()
+                                .map(|offender_key| {
+                                    let (pod, cpu_percent) = offender_cpu
+                                        .get(&offender_key)
+                                        .cloned()
+                                        .unwrap_or_else(|| {
+                                            let (ns, pod_name) = offender_key
+                                                .split_once('/')
+                                                .unwrap_or(("", offender_key.as_str()));
+                                            (
+                                                PodRef {
+                                                    namespace: ns.to_string(),
+                                                    pod: pod_name.to_string(),
+                                                },
+                                                0.0,
+                                            )
+                                        });
+                                    let onset_ms = self
+                                        .consumer_busy_since
+                                        .get(&offender_key)
+                                        .map(|start| onset_offset_ms(now, *start));
+                                    OffenderSignal {
+                                        pod,
+                                        onset_ms,
+                                        cpu_percent,
+                                        fork_count: fork_counts.get(&offender_key).copied(),
+                                        short_job_count: short_job_counts
+                                            .get(&offender_key)
+                                            .copied(),
+                                    }
                                 })
                                 .collect();
 
@@ -1294,20 +1361,26 @@ mod tests {
         victim_pre_window.insert("cpu_stall_us".to_string(), vec![0.0, 50_000.0, 120_000.0]);
 
         let offenders = vec![
-            (
-                PodRef {
+            OffenderSignal {
+                pod: PodRef {
                     namespace: "prod".to_string(),
                     pod: "image-resize-worker".to_string(),
                 },
-                Some(-9_000i64),
-            ),
-            (
-                PodRef {
+                onset_ms: Some(-9_000i64),
+                cpu_percent: 87.5,
+                fork_count: Some(12),
+                short_job_count: None,
+            },
+            OffenderSignal {
+                pod: PodRef {
                     namespace: "prod".to_string(),
                     pod: "sidecar-proxy".to_string(),
                 },
-                None,
-            ),
+                onset_ms: None,
+                cpu_percent: 3.0,
+                fork_count: None,
+                short_job_count: None,
+            },
         ];
 
         let candidates = build_candidate_windows(
@@ -1331,11 +1404,16 @@ mod tests {
 
         let hog_window = &candidates[1];
         assert_eq!(hog_window.pod.pod, "image-resize-worker");
-        assert!(hog_window.pre_window.is_empty());
+        assert_eq!(hog_window.pre_window.get("cpu_percent"), Some(&vec![87.5]));
+        assert_eq!(hog_window.pre_window.get("fork_count"), Some(&vec![12.0]));
         assert_eq!(hog_window.first_deviation_offset_ms, Some(-9_000));
 
         let untracked_window = &candidates[2];
         assert_eq!(untracked_window.pod.pod, "sidecar-proxy");
+        assert_eq!(
+            untracked_window.pre_window.get("cpu_percent"),
+            Some(&vec![3.0])
+        );
         assert_eq!(untracked_window.first_deviation_offset_ms, None);
     }
 
@@ -1345,15 +1423,16 @@ mod tests {
             namespace: "prod".to_string(),
             pod: "payment-api".to_string(),
         };
-        let offenders: Vec<(PodRef, Option<i64>)> = (0..MAX_CANDIDATE_OFFENDERS + 5)
-            .map(|i| {
-                (
-                    PodRef {
-                        namespace: "prod".to_string(),
-                        pod: format!("neighbour-{i}"),
-                    },
-                    None,
-                )
+        let offenders: Vec<OffenderSignal> = (0..MAX_CANDIDATE_OFFENDERS + 5)
+            .map(|i| OffenderSignal {
+                pod: PodRef {
+                    namespace: "prod".to_string(),
+                    pod: format!("neighbour-{i}"),
+                },
+                onset_ms: None,
+                cpu_percent: 0.0,
+                fork_count: None,
+                short_job_count: None,
             })
             .collect();
 
@@ -1362,6 +1441,122 @@ mod tests {
 
         // +1 for the victim's own window.
         assert_eq!(candidates.len(), MAX_CANDIDATE_OFFENDERS + 1);
+    }
+
+    /// The invariant `episode.rs`'s module doc claims: an episode captured
+    /// from a real `StallEvent` must replay in-process to the same
+    /// attribution `calculate_blame_attributions` produced live. This is
+    /// what would have caught offenders losing their `cpu_percent`/
+    /// `fork_count`/`short_job_count` series on the way into `Episode`.
+    #[test]
+    fn a_captured_episode_replays_to_the_same_attribution_as_the_live_stall_event() {
+        let victim = PodRef {
+            namespace: "prod".to_string(),
+            pod: "payment-api".to_string(),
+        };
+        let offender = PodRef {
+            namespace: "prod".to_string(),
+            pod: "fork-bomb".to_string(),
+        };
+        // Present in both the CPU-consumer list and fork_counts.
+        let cpu_offender = PodRef {
+            namespace: "prod".to_string(),
+            pod: "cpu-hog".to_string(),
+        };
+        let mut fork_counts = HashMap::new();
+        fork_counts.insert("prod/fork-bomb".to_string(), 200u64);
+        let short_job_counts = HashMap::new();
+
+        let candidates = build_candidate_windows(
+            victim.clone(),
+            Some("Deployment".to_string()),
+            Some("payment-api".to_string()),
+            BTreeMap::new(),
+            Some(-5_000),
+            1000,
+            &[
+                // Blamed live purely via fork_counts -- never appears as a
+                // CPU consumer, so `cpu_percent` defaults to 0.0 here too.
+                OffenderSignal {
+                    pod: offender.clone(),
+                    onset_ms: Some(-4_000),
+                    cpu_percent: 0.0,
+                    fork_count: Some(200),
+                    short_job_count: None,
+                },
+                OffenderSignal {
+                    pod: cpu_offender.clone(),
+                    onset_ms: Some(-3_000),
+                    cpu_percent: 60.0,
+                    fork_count: None,
+                    short_job_count: None,
+                },
+            ],
+        );
+
+        let stall_event = StallEvent {
+            event_id: "live-event".to_string(),
+            victim_pod: victim.pod.clone(),
+            victim_namespace: victim.namespace.clone(),
+            stall_delta_us: 1_500_000,
+            timestamp: Instant::now(),
+            concurrent_consumers: vec![CpuConsumer {
+                pod: cpu_offender.pod.clone(),
+                namespace: cpu_offender.namespace.clone(),
+                cpu_percent: 60.0,
+            }],
+            fork_counts,
+            short_job_counts,
+            memory_stall_delta_us: 0,
+            io_stall_delta_us: 0,
+            memory_bytes: 0,
+            io_bytes: 0,
+            memory_anon_bytes: None,
+            memory_file_bytes: None,
+            memory_slab_bytes: None,
+            memory_pgmajfault_delta: None,
+            workingset_refault_delta: None,
+            candidates,
+        };
+
+        let live_attributions = calculate_blame_attributions(&stall_event);
+        assert_eq!(
+            live_attributions.len(),
+            2,
+            "test setup should blame both the fork-only and CPU offenders"
+        );
+
+        let episode = crate::episode::Episode::from_capture(&stall_event, None);
+        let replayed = episode.to_stall_event();
+        let replayed_attributions = calculate_blame_attributions(&replayed);
+
+        // Compare on everything but `timestamp` (wall-clock-at-call, not part
+        // of the replay invariant), sorted by offender since both sides are
+        // built by iterating a HashMap in unspecified order.
+        let normalize = |attrs: &[BlameAttribution]| {
+            let mut rows: Vec<_> = attrs
+                .iter()
+                .map(|a| {
+                    (
+                        a.offender_pod.clone(),
+                        a.offender_namespace.clone(),
+                        a.blame_score,
+                        a.stall_us,
+                        a.attributed_stall_us,
+                        a.cpu_share,
+                        a.fork_count,
+                    )
+                })
+                .collect();
+            rows.sort_by(|a, b| a.0.cmp(&b.0));
+            rows
+        };
+
+        assert_eq!(
+            normalize(&live_attributions),
+            normalize(&replayed_attributions),
+            "an episode captured from a live StallEvent must replay to the same attribution"
+        );
     }
 
     #[test]

--- a/cognitod/src/collectors/psi.rs
+++ b/cognitod/src/collectors/psi.rs
@@ -992,7 +992,7 @@ impl PsiMonitor {
     /// keep attributing stalls whether or not the matrix's capture disk is
     /// healthy.
     fn write_episode_capture(&self, capture: &EpisodeCaptureConfig, stall_event: &StallEvent) {
-        let episode = Episode::from_capture(stall_event, self.cell.clone());
+        let episode = Episode::from_capture(stall_event, self.cell.clone(), None);
         let path = Path::new(&capture.output_dir).join(format!("{}.json", episode.episode_id));
 
         if let Err(e) = std::fs::create_dir_all(&capture.output_dir) {
@@ -1526,7 +1526,7 @@ mod tests {
             "test setup should blame both the fork-only and CPU offenders"
         );
 
-        let episode = crate::episode::Episode::from_capture(&stall_event, None);
+        let episode = crate::episode::Episode::from_capture(&stall_event, None, None);
         let replayed = episode.to_stall_event();
         let replayed_attributions = calculate_blame_attributions(&replayed);
 

--- a/cognitod/src/collectors/psi.rs
+++ b/cognitod/src/collectors/psi.rs
@@ -8,8 +8,9 @@ use tokio::time::sleep;
 use walkdir::WalkDir;
 
 use crate::attribution::AttributionSink;
+use crate::config::EpisodeCaptureConfig;
 use crate::context::ContextStore;
-use crate::episode::{CandidateWindow, PodRef};
+use crate::episode::{CandidateWindow, Episode, PodRef};
 use crate::k8s::K8sContext;
 
 #[derive(Debug, Clone, PartialEq)]
@@ -441,6 +442,15 @@ pub struct PsiMonitor {
     cgroup_root: PathBuf,
     /// When set, `run` stops after this many scans instead of looping forever.
     max_iterations: Option<u64>,
+    /// When set, every `StallEvent` is also written to disk as a `VmCapture`
+    /// episode -- the Phase 3 kernel/topology matrix's capture path. `None`
+    /// on every real customer fleet; only a matrix VM's config turns this on.
+    episode_capture: Option<EpisodeCaptureConfig>,
+    /// The kernel/topology cell stamped onto each captured episode. Detected
+    /// once at construction, since none of it changes while the daemon runs;
+    /// only computed when `episode_capture` is set, to keep the common path
+    /// free of the `k3s --version` subprocess call.
+    cell: Option<crate::episode::Cell>,
 }
 
 struct PodPsiDelta {
@@ -487,6 +497,8 @@ impl PsiMonitor {
             history_capacity: compute_history_capacity(sustained_pressure_seconds),
             cgroup_root: PathBuf::from("/sys/fs/cgroup"),
             max_iterations: None,
+            episode_capture: None,
+            cell: None,
         }
     }
 
@@ -494,6 +506,18 @@ impl PsiMonitor {
     /// loop can be driven against a fixture tree rather than the live kernel.
     pub fn with_cgroup_root(mut self, root: impl Into<PathBuf>) -> Self {
         self.cgroup_root = root.into();
+        self
+    }
+
+    /// Turns on episode capture: every `StallEvent` from here on is also
+    /// written to `config.output_dir` as a `VmCapture` episode. No-op (aside
+    /// from detecting the cell once) when `config.enabled` is false, so a
+    /// caller can pass `config.episode_capture` unconditionally.
+    pub fn with_episode_capture(mut self, config: EpisodeCaptureConfig) -> Self {
+        if config.enabled {
+            self.cell = Some(crate::cell::detect_cell());
+            self.episode_capture = Some(config);
+        }
         self
     }
 
@@ -840,6 +864,10 @@ impl PsiMonitor {
                             // leave through here.
                             self.sink.emit(&attributions);
 
+                            if let Some(capture) = &self.episode_capture {
+                                self.write_episode_capture(capture, &stall_event);
+                            }
+
                             // Persist to database if available
                             if let Some(ref store) = self.incident_store {
                                 for attr in &attributions {
@@ -888,6 +916,33 @@ impl PsiMonitor {
             }
 
             sleep(Duration::from_secs(1)).await;
+        }
+    }
+
+    /// Writes `stall_event` to `capture.output_dir` as a `VmCapture` episode,
+    /// one JSON file per stall event named `<episode_id>.json`. Best-effort:
+    /// a write failure is logged, never propagated, since the scan loop must
+    /// keep attributing stalls whether or not the matrix's capture disk is
+    /// healthy.
+    fn write_episode_capture(&self, capture: &EpisodeCaptureConfig, stall_event: &StallEvent) {
+        let episode = Episode::from_capture(stall_event, self.cell.clone());
+        let path = Path::new(&capture.output_dir).join(format!("{}.json", episode.episode_id));
+
+        if let Err(e) = std::fs::create_dir_all(&capture.output_dir) {
+            warn!(
+                "[psi] failed to create episode capture dir {}: {e}",
+                capture.output_dir
+            );
+            return;
+        }
+
+        match serde_json::to_vec_pretty(&episode) {
+            Ok(bytes) => {
+                if let Err(e) = std::fs::write(&path, bytes) {
+                    warn!("[psi] failed to write captured episode {path:?}: {e}");
+                }
+            }
+            Err(e) => warn!("[psi] failed to serialize captured episode: {e}"),
         }
     }
 

--- a/cognitod/src/config.rs
+++ b/cognitod/src/config.rs
@@ -213,6 +213,8 @@ pub struct Config {
     #[serde(default)]
     pub psi: PsiConfig,
     #[serde(default)]
+    pub episode_capture: EpisodeCaptureConfig,
+    #[serde(default)]
     pub telemetry: TelemetrySettings,
     /// Top-level sections/keys no field matches. Captured so `--check-config`
     /// can name them; a typo'd `[reasner]` is otherwise indistinguishable from
@@ -661,6 +663,32 @@ impl Default for PsiConfig {
 
 fn default_psi_sustained_pressure_seconds() -> u64 {
     15
+}
+
+/// Off by default: writing an episode to disk for every stall event is only
+/// wanted on a Phase 3 kernel/topology matrix VM, never a real customer
+/// fleet, where it would mean an unbounded write path nobody asked for.
+#[derive(Debug, Deserialize, Clone)]
+pub struct EpisodeCaptureConfig {
+    #[serde(default)]
+    pub enabled: bool,
+    /// Directory episode JSON files are written to, one file per stall
+    /// event, named `<episode_id>.json`.
+    #[serde(default = "default_episode_capture_output_dir")]
+    pub output_dir: String,
+}
+
+impl Default for EpisodeCaptureConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            output_dir: default_episode_capture_output_dir(),
+        }
+    }
+}
+
+fn default_episode_capture_output_dir() -> String {
+    "/var/lib/linnix/episodes".to_string()
 }
 
 fn default_attribution_threshold_ms() -> u64 {

--- a/cognitod/src/episode.rs
+++ b/cognitod/src/episode.rs
@@ -198,6 +198,7 @@ impl Episode {
     pub fn from_capture(
         stall_event: &crate::collectors::psi::StallEvent,
         cell: Option<Cell>,
+        ground_truth: Option<GroundTruth>,
     ) -> Episode {
         let mut pod_graph = Vec::new();
         for candidate in &stall_event.candidates {
@@ -231,7 +232,7 @@ impl Episode {
             candidates: stall_event.candidates.clone(),
             pod_graph,
             diagnosis: None,
-            ground_truth: None,
+            ground_truth,
             evidence_cited: Vec::new(),
             outcome: None,
         }

--- a/cognitod/src/episode.rs
+++ b/cognitod/src/episode.rs
@@ -25,7 +25,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::schema::{Insight, InsightReason};
 
-pub const EPISODE_FORMAT_VERSION: &str = "0.2";
+pub const EPISODE_FORMAT_VERSION: &str = "0.3";
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct PodRef {
@@ -45,6 +45,33 @@ pub enum EpisodeSource {
     VmCapture,
     /// A design partner's correction on a live insight (Phase 5).
     DesignPartner,
+}
+
+/// The kernel/topology cell a `VmCapture` episode was captured on. `None` for
+/// `Synthetic`/`DesignPartner` episodes, which run in no real kernel at all.
+/// Added on the v0.3 format bump: Phase 3's kernel/topology matrix needs
+/// `xtask lab score` to break accuracy down per cell (e.g. "arm64 without
+/// BTF" vs "x86_64 5.15"), which is the whole point of running the matrix
+/// rather than one box.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Cell {
+    /// `uname -r`, e.g. "5.15.0-1053-aws".
+    pub kernel_release: String,
+    /// `std::env::consts::ARCH`, e.g. "x86_64" or "aarch64".
+    pub arch: String,
+    /// Whether `/sys/kernel/btf/vmlinux` exists. Attribution needs BTF to
+    /// attach; a cell without it is expected to degrade to PSI-only, and a
+    /// captured episode should say so rather than leave the reader to infer
+    /// it from an empty `diagnosis`.
+    pub btf_present: bool,
+    /// "cgroupv2" or "cgroupv1", read from which hierarchy is mounted. The
+    /// collectors require v2 (`/sys/fs/cgroup/*.pressure`), so a v1 cell is
+    /// expected to run PSI-only too.
+    pub cgroup_driver: String,
+    /// `k3s --version`'s first line, when the binary is on `PATH`. `None`
+    /// rather than a default string -- a capture that could not determine
+    /// this should say so, not claim an unknown version.
+    pub k3s_version: Option<String>,
 }
 
 /// The rule and trigger version that opened the incident this episode
@@ -128,6 +155,11 @@ pub struct Episode {
     /// weight blame against, and nothing else in the record carries one (a
     /// candidate's own series records *its* signals, not the victim's).
     pub victim_stall_us: u64,
+    /// The kernel/topology cell this was captured on. Added on the v0.3
+    /// format bump; `#[serde(default)]` so v0.2 episodes (`Synthetic`, which
+    /// never had one anyway) still deserialize.
+    #[serde(default)]
+    pub cell: Option<Cell>,
     pub candidates: Vec<CandidateWindow>,
     /// The pod/ownership graph as a flat edge list (owner -> pod), rather
     /// than a nested tree, so it round-trips through JSON without a custom
@@ -154,6 +186,57 @@ pub struct PodGraphEdge {
 }
 
 impl Episode {
+    /// Builds a `VmCapture` episode from a live `StallEvent`, the same shape
+    /// `ScenarioManifest::to_episode` produces for `Synthetic` ones.
+    ///
+    /// `diagnosis`/`ground_truth`/`outcome` are left empty here: a capture
+    /// happens at the exact seam where `StallEvent`/`BlameAttribution` are
+    /// computed, before the reasoner (if any) has run, and before either a
+    /// scenario's asserted truth or a design partner's correction exists.
+    /// Callers that know a ground truth (a scenario driving a real VM in the
+    /// matrix) attach it separately, the same way `to_episode` does.
+    pub fn from_capture(
+        stall_event: &crate::collectors::psi::StallEvent,
+        cell: Option<Cell>,
+    ) -> Episode {
+        let mut pod_graph = Vec::new();
+        for candidate in &stall_event.candidates {
+            if let (Some(owner_kind), Some(owner_name)) =
+                (&candidate.owner_kind, &candidate.owner_name)
+            {
+                pod_graph.push(PodGraphEdge {
+                    owner_kind: owner_kind.clone(),
+                    owner_name: owner_name.clone(),
+                    pod: candidate.pod.clone(),
+                });
+            }
+        }
+
+        Episode {
+            version: EPISODE_FORMAT_VERSION.to_string(),
+            episode_id: stall_event.event_id.clone(),
+            captured_at: chrono::Utc::now().to_rfc3339(),
+            source: EpisodeSource::VmCapture,
+            scenario: None,
+            trigger: TriggerInfo {
+                rule_name: "psi_stall_attribution".to_string(),
+                rule_version: "1".to_string(),
+            },
+            victim: PodRef {
+                namespace: stall_event.victim_namespace.clone(),
+                pod: stall_event.victim_pod.clone(),
+            },
+            victim_stall_us: stall_event.stall_delta_us,
+            cell,
+            candidates: stall_event.candidates.clone(),
+            pod_graph,
+            diagnosis: None,
+            ground_truth: None,
+            evidence_cited: Vec::new(),
+            outcome: None,
+        }
+    }
+
     /// Reconstructs the `StallEvent` this episode was captured from (or, for
     /// a synthetic episode, the one a scenario asserts) well enough to run it
     /// back through `calculate_blame_attributions`.

--- a/cognitod/src/lib.rs
+++ b/cognitod/src/lib.rs
@@ -4,6 +4,7 @@
 pub mod alerts;
 pub mod attribution;
 pub mod bpf_config;
+pub mod cell;
 pub mod collectors;
 pub mod config;
 pub mod context;

--- a/cognitod/src/main.rs
+++ b/cognitod/src/main.rs
@@ -946,7 +946,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
             incident_store.clone(),
             config.psi.sustained_pressure_seconds,
             sink,
-        );
+        )
+        .with_episode_capture(config.episode_capture.clone());
         tokio::spawn(async move {
             psi_monitor.run().await;
         });

--- a/datasets/episodes/golden/fork_storm_v0.1.json
+++ b/datasets/episodes/golden/fork_storm_v0.1.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.2",
+  "version": "0.3",
   "episode_id": "ep-fork-storm-000001",
   "captured_at": "2026-09-03T00:00:00Z",
   "source": "synthetic",
@@ -13,6 +13,7 @@
     "pod": "payment-api"
   },
   "victim_stall_us": 1000000,
+  "cell": null,
   "candidates": [
     {
       "pod": {

--- a/datasets/schema/episode.schema.json
+++ b/datasets/schema/episode.schema.json
@@ -1,9 +1,9 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://linnix.dev/schema/episode.v0.2.json",
+  "$id": "https://linnix.dev/schema/episode.v0.3.json",
   "title": "Episode",
   "description": "Regenerated from cognitod::episode::Episode (cognitod/src/episode.rs). One captured or replayed incident: the invariant this format holds is that an episode captured on a real k3s VM must replay in-process on a laptop, byte-identically, with no kernel involvement. Versioned independently of the Insight schema (datasets/schema/insight.schema.json) embedded in `diagnosis`.",
-  "version": "0.2",
+  "version": "0.3",
   "type": "object",
   "additionalProperties": false,
   "required": [
@@ -15,6 +15,7 @@
     "trigger",
     "victim",
     "victim_stall_us",
+    "cell",
     "candidates",
     "pod_graph",
     "diagnosis",
@@ -23,7 +24,7 @@
     "outcome"
   ],
   "properties": {
-    "version": { "type": "string", "const": "0.2" },
+    "version": { "type": "string", "const": "0.3" },
     "episode_id": { "type": "string", "minLength": 1 },
     "captured_at": { "type": "string", "format": "date-time" },
     "source": {
@@ -45,6 +46,24 @@
       "description": "StallEvent::stall_delta_us at capture time -- the magnitude replay weights blame against.",
       "type": "integer",
       "minimum": 0
+    },
+    "cell": {
+      "description": "The kernel/topology cell a vm_capture episode ran on. Null for synthetic/design_partner episodes. Added on the v0.3 format bump for Phase 3's kernel/topology matrix.",
+      "oneOf": [
+        { "type": "null" },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["kernel_release", "arch", "btf_present", "cgroup_driver", "k3s_version"],
+          "properties": {
+            "kernel_release": { "type": "string" },
+            "arch": { "type": "string" },
+            "btf_present": { "type": "boolean" },
+            "cgroup_driver": { "type": "string" },
+            "k3s_version": { "type": ["string", "null"] }
+          }
+        }
+      ]
     },
     "candidates": {
       "type": "array",

--- a/terraform/kernel-matrix/main.tf
+++ b/terraform/kernel-matrix/main.tf
@@ -1,0 +1,176 @@
+# Incident Lab kernel/topology matrix -- disposable instances that boot,
+# run cognitod with episode_capture on, and self-terminate after ttl_hours.
+#
+# Why this isn't ../ec2 with a for_each bolted on: that module resolves its
+# AMI via `most_recent = true` and is built to survive indefinitely (EIP,
+# Route53, CloudWatch alarms, `ignore_changes = [ami]` to avoid replacing a
+# running server). A `most_recent` filter re-resolved on every `apply`
+# breaks the one thing a kernel matrix needs -- a reproducible cell
+# identity, since the AMI (and its actual kernel) can change out from under
+# you between runs. Callers must resolve and pin a literal `ami_id` per
+# cell (e.g. via `aws ec2 describe-images`) instead.
+#
+# Why this doesn't build per-cell AMIs with Packer either: Packer bakes
+# cognitod into the image at build time, which is the right shape for a
+# product release, not for iterating on what gets captured -- rebuilding
+# an AMI per code change to the capture path would dominate the loop this
+# lab exists to shorten. Cells vary the base image (kernel/arch); cognitod
+# itself is installed fresh by user-data on every boot from `main`.
+
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+}
+
+locals {
+  common_tags = merge(
+    var.tags,
+    {
+      Project   = var.project_name
+      Ephemeral = "true"
+      ManagedBy = "terraform-kernel-matrix"
+      TtlHours  = tostring(var.ttl_hours)
+    }
+  )
+
+  cells_by_name = { for c in var.cells : c.name => c }
+}
+
+# SSH only -- no dashboard/API/Prometheus ports. A matrix instance's only
+# job is to capture episodes to disk; nothing needs to reach cognitod's API
+# from outside, and this stays true even after the eventual k3s injection
+# harness lands (that harness will drive it over SSH/SSM, not the API).
+resource "aws_security_group" "matrix" {
+  name_prefix = "${var.project_name}-"
+  description = "SSH-only access for Incident Lab kernel/topology matrix instances"
+  vpc_id      = var.vpc_id
+
+  ingress {
+    description = "SSH from admin"
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = var.admin_cidr_blocks
+  }
+
+  egress {
+    description = "All outbound traffic"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = merge(local.common_tags, { Name = "${var.project_name}-sg" })
+}
+
+resource "aws_iam_role" "matrix" {
+  name_prefix = "${var.project_name}-"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action    = "sts:AssumeRole"
+        Effect    = "Allow"
+        Principal = { Service = "ec2.amazonaws.com" }
+      }
+    ]
+  })
+
+  tags = local.common_tags
+}
+
+# Lets each instance terminate itself once its ttl_hours elapses, scoped so
+# it can only ever terminate instances tagged as part of this module's own
+# run -- not a blanket ec2:TerminateInstances grant.
+resource "aws_iam_role_policy" "self_terminate" {
+  name_prefix = "self-terminate-"
+  role        = aws_iam_role.matrix.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = "ec2:TerminateInstances"
+        Resource = "*"
+        Condition = {
+          StringEquals = {
+            "ec2:ResourceTag/Project" = var.project_name
+          }
+        }
+      }
+    ]
+  })
+}
+
+# SSM as a fallback debugging path if SSH access needs revoking mid-run.
+resource "aws_iam_role_policy_attachment" "ssm" {
+  role       = aws_iam_role.matrix.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}
+
+resource "aws_iam_instance_profile" "matrix" {
+  name_prefix = "${var.project_name}-"
+  role        = aws_iam_role.matrix.name
+
+  tags = local.common_tags
+}
+
+resource "aws_instance" "cell" {
+  for_each = local.cells_by_name
+
+  ami           = each.value.ami_id
+  instance_type = each.value.instance_type
+  key_name      = var.key_name
+
+  subnet_id                   = var.subnet_id
+  vpc_security_group_ids      = [aws_security_group.matrix.id]
+  iam_instance_profile        = aws_iam_instance_profile.matrix.name
+  associate_public_ip_address = var.associate_public_ip
+
+  root_block_device {
+    volume_type           = "gp3"
+    volume_size           = 20
+    delete_on_termination = true
+    encrypted             = true
+
+    tags = merge(local.common_tags, { Name = "${var.project_name}-${each.key}-root" })
+  }
+
+  metadata_options {
+    http_endpoint               = "enabled"
+    http_tokens                 = "required" # IMDSv2
+    http_put_response_hop_limit = 1
+  }
+
+  user_data = templatefile("${path.module}/user-data.sh.tftpl", {
+    github_repo = var.github_repo
+    ttl_hours   = var.ttl_hours
+    cell_name   = each.key
+  })
+
+  tags = merge(
+    local.common_tags,
+    {
+      Name = "${var.project_name}-${each.key}"
+      Cell = each.key
+      Arch = each.value.arch
+    }
+  )
+
+  # Deliberately no `ignore_changes = [ami]` (unlike ../ec2): a cell whose
+  # ami_id changes is a different cell and should replace the instance, not
+  # keep running the old image under a new name.
+}

--- a/terraform/kernel-matrix/main.tf
+++ b/terraform/kernel-matrix/main.tf
@@ -91,31 +91,11 @@ resource "aws_iam_role" "matrix" {
   tags = local.common_tags
 }
 
-# Lets each instance terminate itself once its ttl_hours elapses, scoped so
-# it can only ever terminate instances tagged as part of this module's own
-# run -- not a blanket ec2:TerminateInstances grant.
-resource "aws_iam_role_policy" "self_terminate" {
-  name_prefix = "self-terminate-"
-  role        = aws_iam_role.matrix.id
-
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Effect   = "Allow"
-        Action   = "ec2:TerminateInstances"
-        Resource = "*"
-        Condition = {
-          StringEquals = {
-            "ec2:ResourceTag/Project" = var.project_name
-          }
-        }
-      }
-    ]
-  })
-}
-
 # SSM as a fallback debugging path if SSH access needs revoking mid-run.
+# No ec2:TerminateInstances grant: the TTL self-terminate shuts the guest
+# down from the inside (`systemctl poweroff` + instance_initiated_shutdown_
+# behavior = "terminate" below), so the instance role never needs the AWS
+# API permission to terminate itself.
 resource "aws_iam_role_policy_attachment" "ssm" {
   role       = aws_iam_role.matrix.name
   policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
@@ -139,6 +119,12 @@ resource "aws_instance" "cell" {
   vpc_security_group_ids      = [aws_security_group.matrix.id]
   iam_instance_profile        = aws_iam_instance_profile.matrix.name
   associate_public_ip_address = var.associate_public_ip
+
+  # The TTL self-terminate in user-data.sh.tftpl shuts the guest down from
+  # the inside (`systemctl poweroff`) using only stock-AMI tools -- no
+  # awscli/IMDS credentials needed. That only tears the instance down
+  # rather than just stopping it because of this setting.
+  instance_initiated_shutdown_behavior = "terminate"
 
   root_block_device {
     volume_type           = "gp3"

--- a/terraform/kernel-matrix/outputs.tf
+++ b/terraform/kernel-matrix/outputs.tf
@@ -1,0 +1,17 @@
+output "cell_instance_ids" {
+  description = "Map of cell name to instance id"
+  value       = { for name, inst in aws_instance.cell : name => inst.id }
+}
+
+output "cell_public_ips" {
+  description = "Map of cell name to public IP (null if associate_public_ip is false)"
+  value       = { for name, inst in aws_instance.cell : name => inst.public_ip }
+}
+
+output "ssh_commands" {
+  description = "Convenience ssh command per cell (assumes associate_public_ip = true)"
+  value = {
+    for name, inst in aws_instance.cell :
+    name => "ssh -i <path-to-${var.key_name}.pem> ubuntu@${inst.public_ip}"
+  }
+}

--- a/terraform/kernel-matrix/user-data.sh.tftpl
+++ b/terraform/kernel-matrix/user-data.sh.tftpl
@@ -1,0 +1,60 @@
+#!/bin/bash
+#
+# Boots one Incident Lab kernel/topology matrix cell: arms a self-terminate
+# timer first (so it survives regardless of what happens below), then
+# installs cognitod and turns on episode capture.
+
+set -e
+
+exec > >(tee /var/log/user-data.log)
+exec 2>&1
+
+echo "========================================="
+echo "Incident Lab matrix cell: ${cell_name}"
+echo "Kernel: $(uname -r)  Arch: $(uname -m)"
+echo "Time: $(date -u)"
+echo "========================================="
+
+# Arm the TTL self-terminate before anything that can fail. It's a detached
+# background process, so once launched it survives any later step in this
+# script aborting under `set -e` -- the whole point of a safety net.
+sudo DEBIAN_FRONTEND=noninteractive apt-get update
+sudo DEBIAN_FRONTEND=noninteractive apt-get install -y awscli
+
+TOKEN=$(curl -sX PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")
+INSTANCE_ID=$(curl -sH "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/instance-id)
+REGION=$(curl -sH "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/placement/region)
+TTL_SECONDS=$((${ttl_hours} * 3600))
+
+nohup bash -c "
+    sleep $TTL_SECONDS
+    echo 'ttl_hours elapsed, self-terminating ${cell_name} ($INSTANCE_ID)' | systemd-cat -t linnix-matrix-ttl
+    aws ec2 terminate-instances --instance-ids $INSTANCE_ID --region $REGION
+" >/var/log/linnix-matrix-ttl.log 2>&1 &
+disown
+
+echo "Self-terminate armed for $TTL_SECONDS seconds from now ($(date -u -d "+$TTL_SECONDS seconds")Z)."
+
+cloud-init status --wait || true
+
+sudo DEBIAN_FRONTEND=noninteractive apt-get install -y \
+    linux-headers-$(uname -r) || sudo apt-get install -y linux-headers-generic
+
+curl -fsSL "https://raw.githubusercontent.com/${github_repo}/main/docs/examples/install-ec2.sh" -o /tmp/install-ec2.sh
+chmod +x /tmp/install-ec2.sh
+sudo /tmp/install-ec2.sh --dev
+
+sudo tee -a /etc/linnix/linnix.toml > /dev/null <<'EOF'
+
+[episode_capture]
+enabled = true
+output_dir = "/var/lib/linnix/episodes"
+EOF
+
+sudo mkdir -p /var/lib/linnix/episodes
+sudo systemctl enable linnix-cognitod
+sudo systemctl restart linnix-cognitod
+
+echo "========================================="
+echo "cognitod installed with episode_capture enabled"
+echo "========================================="

--- a/terraform/kernel-matrix/user-data.sh.tftpl
+++ b/terraform/kernel-matrix/user-data.sh.tftpl
@@ -15,28 +15,28 @@ echo "Kernel: $(uname -r)  Arch: $(uname -m)"
 echo "Time: $(date -u)"
 echo "========================================="
 
-# Arm the TTL self-terminate before anything that can fail. It's a detached
-# background process, so once launched it survives any later step in this
-# script aborting under `set -e` -- the whole point of a safety net.
-sudo DEBIAN_FRONTEND=noninteractive apt-get update
-sudo DEBIAN_FRONTEND=noninteractive apt-get install -y awscli
-
-TOKEN=$(curl -sX PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")
-INSTANCE_ID=$(curl -sH "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/instance-id)
-REGION=$(curl -sH "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/placement/region)
+# Arm the TTL self-terminate before anything that can fail, using only
+# tools already on the stock AMI -- no apt/network dependency, so a
+# provisioning failure (even a totally offline instance) can't prevent it
+# from firing. `systemctl poweroff` relies on the instance's
+# instance_initiated_shutdown_behavior being set to "terminate" (main.tf),
+# so a shutdown from inside the guest actually tears the instance down
+# instead of just stopping it.
 TTL_SECONDS=$((${ttl_hours} * 3600))
-
 nohup bash -c "
     sleep $TTL_SECONDS
-    echo 'ttl_hours elapsed, self-terminating ${cell_name} ($INSTANCE_ID)' | systemd-cat -t linnix-matrix-ttl
-    aws ec2 terminate-instances --instance-ids $INSTANCE_ID --region $REGION
+    echo 'ttl_hours elapsed, self-terminating ${cell_name}' | systemd-cat -t linnix-matrix-ttl
+    systemctl poweroff
 " >/var/log/linnix-matrix-ttl.log 2>&1 &
 disown
 
 echo "Self-terminate armed for $TTL_SECONDS seconds from now ($(date -u -d "+$TTL_SECONDS seconds")Z)."
 
-cloud-init status --wait || true
+# No `cloud-init status --wait` here: this script *is* cloud-init's own
+# user-data stage, so waiting on cloud-init to finish from inside it would
+# deadlock -- cloud-init can't finish until this script returns.
 
+sudo DEBIAN_FRONTEND=noninteractive apt-get update
 sudo DEBIAN_FRONTEND=noninteractive apt-get install -y \
     linux-headers-$(uname -r) || sudo apt-get install -y linux-headers-generic
 

--- a/terraform/kernel-matrix/variables.tf
+++ b/terraform/kernel-matrix/variables.tf
@@ -1,0 +1,97 @@
+# Terraform variables for the Incident Lab kernel/topology matrix.
+#
+# This module is deliberately separate from ../ec2 (a single-instance,
+# long-lived product deployment with Route53/CloudWatch alarms/EIP). The
+# matrix is N disposable, short-lived instances whose only job is to run
+# cognitod with episode_capture enabled and self-terminate.
+
+variable "aws_region" {
+  description = "AWS region to deploy the matrix into"
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "project_name" {
+  description = "Prefix used for resource names and the Project tag"
+  type        = string
+  default     = "linnix-kernel-matrix"
+}
+
+variable "vpc_id" {
+  description = "VPC ID to launch matrix instances into"
+  type        = string
+}
+
+variable "subnet_id" {
+  description = "Subnet ID to launch matrix instances into"
+  type        = string
+}
+
+variable "admin_cidr_blocks" {
+  description = "CIDR blocks allowed SSH access to matrix instances"
+  type        = list(string)
+}
+
+variable "key_name" {
+  description = "SSH key pair name for matrix instance access"
+  type        = string
+}
+
+variable "associate_public_ip" {
+  description = "Associate a public IP with each matrix instance (needed for SSH without a bastion/SSM)"
+  type        = bool
+  default     = true
+}
+
+variable "github_repo" {
+  description = "GitHub repo to pull install-ec2.sh and the built binaries from"
+  type        = string
+  default     = "linnix-os/linnix"
+}
+
+variable "ttl_hours" {
+  description = "Hours after boot before each instance self-terminates, regardless of whether a capture run finished. A safety net, not the primary teardown path -- prefer `terraform destroy` when the run is done."
+  type        = number
+  default     = 4
+}
+
+# Each cell is one disposable instance. `ami_id` must be a pinned, literal
+# AMI id (not resolved via a `most_recent` data source) -- see the design
+# note in main.tf for why. The actual kernel_release/btf_present/arch a
+# cell produces is discovered at runtime by cognitod's own
+# `cell::detect_cell()` and stamped onto the captured episode; this module
+# only needs to boot genuinely different images, not predict what they'll
+# report.
+#
+# No explicit BTF dimension yet: every stock Ubuntu kernel new enough to
+# clear this project's own eBPF floor (5.12+ x86 / 5.18+ arm64, see
+# ebpf-kernel-floor memory) ships CONFIG_DEBUG_INFO_BTF=y, so ordinary
+# `ami_id` choices can't produce a BTF-absent cell -- that needs a kernel
+# deliberately built without it, which nothing here provides. Add a
+# `btf_present`-forcing cell (custom AMI/kernel) as a follow-up if the
+# missing-BTF fallback path in cognitod ever needs real-VM coverage.
+variable "cells" {
+  description = "Kernel/topology cells to provision, one instance each"
+  type = list(object({
+    name          = string
+    ami_id        = string
+    instance_type = string
+    arch          = string # "amd64" or "arm64" -- must match ami_id's arch
+  }))
+
+  validation {
+    condition     = alltrue([for c in var.cells : contains(["amd64", "arm64"], c.arch)])
+    error_message = "Each cell's arch must be \"amd64\" or \"arm64\"."
+  }
+
+  validation {
+    condition     = length(distinct([for c in var.cells : c.name])) == length(var.cells)
+    error_message = "Cell names must be unique."
+  }
+}
+
+variable "tags" {
+  description = "Extra tags applied to every resource, merged over the module's own tags"
+  type        = map(string)
+  default     = {}
+}

--- a/xtask-lab/src/main.rs
+++ b/xtask-lab/src/main.rs
@@ -28,7 +28,7 @@ use std::path::{Path, PathBuf};
 use anyhow::{Context, Result, bail};
 use cognitod::attribution::{AttributionSink, BlameMetrics};
 use cognitod::collectors::psi::calculate_blame_attributions;
-use cognitod::episode::Episode;
+use cognitod::episode::{Episode, EpisodeSource};
 use cognitod::schema::InsightReason;
 use serde::Serialize;
 
@@ -107,8 +107,23 @@ pub enum Verdict {
 pub struct EpisodeScore {
     pub episode_id: String,
     pub scenario: Option<String>,
+    pub source: EpisodeSource,
     pub verdict: Verdict,
     pub predicted: Option<Prediction>,
+}
+
+/// Accuracy over one `EpisodeSource`'s slice of a score run. Kept separate
+/// per source because they mean different things: `Synthetic` accuracy is a
+/// regression gate (the six hand-authored scenarios must keep scoring
+/// 100%), while `VmCapture`/`DesignPartner` accuracy is a number to watch,
+/// not a bar to clear -- a real capture can be a genuinely hard case no
+/// scenario author anticipated.
+#[derive(Debug, Serialize)]
+pub struct SourceBreakdown {
+    pub source: EpisodeSource,
+    pub scored: usize,
+    pub correct: usize,
+    pub accuracy: f64,
 }
 
 #[derive(Debug, Serialize)]
@@ -116,7 +131,18 @@ pub struct ScoreReport {
     pub scored: usize,
     pub correct: usize,
     pub accuracy: f64,
+    pub by_source: Vec<SourceBreakdown>,
     pub episodes: Vec<EpisodeScore>,
+}
+
+impl ScoreReport {
+    /// The `Synthetic` breakdown, if any episode of that source was scored.
+    /// This is the one `run_score` gates the build on -- see its doc comment.
+    pub fn synthetic(&self) -> Option<&SourceBreakdown> {
+        self.by_source
+            .iter()
+            .find(|b| b.source == EpisodeSource::Synthetic)
+    }
 }
 
 fn score_one(episode: &Episode) -> EpisodeScore {
@@ -139,9 +165,38 @@ fn score_one(episode: &Episode) -> EpisodeScore {
     EpisodeScore {
         episode_id: episode.episode_id.clone(),
         scenario: episode.scenario.clone(),
+        source: episode.source,
         verdict,
         predicted,
     }
+}
+
+fn breakdown_for(scores: &[EpisodeScore], source: EpisodeSource) -> Option<SourceBreakdown> {
+    let mut scored = 0;
+    let mut correct = 0;
+    for s in scores.iter().filter(|s| s.source == source) {
+        if s.verdict == Verdict::NoGroundTruth {
+            continue;
+        }
+        scored += 1;
+        if s.verdict == Verdict::Correct {
+            correct += 1;
+        }
+    }
+    if scored == 0 && !scores.iter().any(|s| s.source == source) {
+        return None;
+    }
+    let accuracy = if scored > 0 {
+        correct as f64 / scored as f64
+    } else {
+        1.0
+    };
+    Some(SourceBreakdown {
+        source,
+        scored,
+        correct,
+        accuracy,
+    })
 }
 
 pub fn score(episodes: &[Episode]) -> ScoreReport {
@@ -161,10 +216,20 @@ pub fn score(episodes: &[Episode]) -> ScoreReport {
         1.0
     };
 
+    let by_source = [
+        EpisodeSource::Synthetic,
+        EpisodeSource::VmCapture,
+        EpisodeSource::DesignPartner,
+    ]
+    .into_iter()
+    .filter_map(|source| breakdown_for(&scores, source))
+    .collect();
+
     ScoreReport {
         scored,
         correct,
         accuracy,
+        by_source,
         episodes: scores,
     }
 }
@@ -258,12 +323,18 @@ fn run_score(path: &Path) -> Result<()> {
     let report = score(&episodes);
     println!("{}", serde_json::to_string_pretty(&report)?);
 
-    if report.accuracy < 1.0 {
+    // Only `Synthetic` accuracy gates the build. `VmCapture`/`DesignPartner`
+    // episodes are real-world data, not a hand-authored regression suite --
+    // a genuinely hard real capture must not fail CI the way a regression in
+    // the six scenario manifests should. See `SourceBreakdown`'s doc comment.
+    if let Some(synthetic) = report.synthetic()
+        && synthetic.accuracy < 1.0
+    {
         bail!(
-            "accuracy {:.1}% ({}/{} correct) is below 100%",
-            report.accuracy * 100.0,
-            report.correct,
-            report.scored
+            "synthetic accuracy {:.1}% ({}/{} correct) is below 100%",
+            synthetic.accuracy * 100.0,
+            synthetic.correct,
+            synthetic.scored
         );
     }
     Ok(())
@@ -343,5 +414,52 @@ mod tests {
 
         let report = score(&[episode]);
         assert_eq!(report.episodes[0].verdict, Verdict::WrongReason);
+    }
+
+    #[test]
+    fn a_wrong_vm_capture_does_not_drag_down_the_synthetic_breakdown() {
+        let synthetic = golden();
+        let mut vm_capture = golden();
+        vm_capture.source = EpisodeSource::VmCapture;
+        vm_capture.episode_id = "ep-vm-wrong".to_string();
+        vm_capture.ground_truth.as_mut().unwrap().reason_code = InsightReason::NoisyNeighbor;
+
+        let report = score(&[synthetic, vm_capture]);
+
+        let synthetic_breakdown = report.synthetic().expect("a synthetic episode was scored");
+        assert_eq!(synthetic_breakdown.accuracy, 1.0);
+
+        let vm_breakdown = report
+            .by_source
+            .iter()
+            .find(|b| b.source == EpisodeSource::VmCapture)
+            .expect("a vm_capture episode was scored");
+        assert!(vm_breakdown.accuracy < 1.0);
+
+        // Overall accuracy still reflects the mix -- only the per-source
+        // breakdown, which `run_score` gates on, separates them.
+        assert!(report.accuracy < 1.0);
+    }
+
+    #[test]
+    fn synthetic_accuracy_below_100_percent_fails_the_gate_even_with_a_perfect_vm_capture() {
+        let mut synthetic = golden();
+        synthetic.ground_truth.as_mut().unwrap().reason_code = InsightReason::NoisyNeighbor;
+        let mut vm_capture = golden();
+        vm_capture.source = EpisodeSource::VmCapture;
+        vm_capture.episode_id = "ep-vm-right".to_string();
+
+        let report = score(&[synthetic, vm_capture]);
+
+        assert!(report.synthetic().unwrap().accuracy < 1.0);
+        assert_eq!(
+            report
+                .by_source
+                .iter()
+                .find(|b| b.source == EpisodeSource::VmCapture)
+                .unwrap()
+                .accuracy,
+            1.0
+        );
     }
 }

--- a/xtask-lab/src/scenario.rs
+++ b/xtask-lab/src/scenario.rs
@@ -147,6 +147,7 @@ impl ScenarioManifest {
             },
             victim: self.victim.clone(),
             victim_stall_us: self.victim_stall_us,
+            cell: None,
             candidates,
             pod_graph: Vec::new(),
             diagnosis: None,


### PR DESCRIPTION
## Summary
- Capture path: `Episode::Cell` (kernel_release/arch/btf_present/cgroup_driver/k3s_version), `cognitod::cell::detect_cell()`, and `[episode_capture]` config wiring so `PsiMonitor` can write every `StallEvent` to disk as a `VmCapture` episode (off by default, zero effect on any real fleet).
- `xtask lab score` is now source-aware: `Synthetic` accuracy still gates CI at 100%, `VmCapture`/`DesignPartner` accuracy is tracked separately and never fails the build.
- Fixed a blocking correctness bug found before any real infra work started: captured episodes replayed with zero attribution because offender candidates never carried their `cpu_percent`/`fork_count`/`short_job_count` signals, and the offender set itself only counted CPU consumers, silently dropping fork/short-job-only offenders (the flagship fork-storm scenario's own shape). Added a regression test asserting a captured episode replays to the same attribution as the live `StallEvent`.
- `Episode::from_capture` now accepts an optional `ground_truth` to stamp, instead of hardcoding `None` — plumbing for a future k3s injection harness that knows the expected culprit; both current call sites still pass `None` since neither has one yet.
- New Terraform module, `terraform/kernel-matrix/`: disposable, tag-scoped, self-terminating EC2 instances for the kernel/topology matrix, deliberately separate from `terraform/ec2/` (a long-lived single-instance product deployment). Cells take a pinned literal AMI id rather than a `most_recent` lookup, for reproducible cell identity; `cognitod::cell::detect_cell()` discovers the real kernel/arch/BTF facts at boot rather than the module predicting them. Along the way, found (and fixed only in this new module) a stale install-script URL also present in `packer/linnix-ami.pkr.hcl` and `terraform/ec2/user-data.sh` — those two are unfixed here, out of scope, but currently broken.

## Test plan
- [x] `cargo fmt --check` / `cargo clippy --all-targets -- -D warnings` clean (Docker, arm64 native)
- [x] `cargo nextest run --workspace` at reduced link parallelism — full pass aside from the pre-existing, environment-only `an_executed_action_is_measured` timing flake (confirmed unrelated, untouched file)
- [x] New regression test: captured-episode replay matches live-event attribution
- [x] `terraform validate` / `terraform fmt -check` clean for the new module (official `hashicorp/terraform` Docker image, no local binary)
- [ ] No real `terraform apply` has been run — this PR does not provision any AWS infrastructure; cost/scope disclosure and an explicit go-ahead are still owed before that happens

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017B8bHXCsmYRZZ6tZKmkJdh