### PR TITLE
Phase 3: fix arm64 OOM in kernel-matrix boot script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -122,3 +122,12 @@ videos/
 
 # Local analysis scratch
 ARCHITECTURE-AUDIT.md
+
+# Terraform local state/plan artifacts (never commit real state or plans)
+**/.terraform/
+*.tfstate
+*.tfstate.*
+*.tfplan
+terraform.tfvars
+*.auto.tfvars
+!terraform/*/terraform.tfvars.example

--- a/terraform/kernel-matrix/.terraform.lock.hcl
+++ b/terraform/kernel-matrix/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:Ijt7pOlB7Tr7maGQIqtsLFbl7pSMIj06TVdkoSBcYOw=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}

--- a/terraform/kernel-matrix/main.tf
+++ b/terraform/kernel-matrix/main.tf
@@ -146,6 +146,10 @@ resource "aws_instance" "cell" {
     ttl_hours   = var.ttl_hours
     cell_name   = each.key
   })
+  # Without this, a change to user-data.sh.tftpl only updates Terraform's
+  # state -- the running instance keeps whatever boot script it started
+  # with, since cloud-init doesn't re-run user-data on its own.
+  user_data_replace_on_change = true
 
   tags = merge(
     local.common_tags,

--- a/terraform/kernel-matrix/user-data.sh.tftpl
+++ b/terraform/kernel-matrix/user-data.sh.tftpl
@@ -40,6 +40,20 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get update
 sudo DEBIAN_FRONTEND=noninteractive apt-get install -y \
     linux-headers-$(uname -r) || sudo apt-get install -y linux-headers-generic
 
+# install-ec2.sh builds cognitod from source with LTO, which OOM-kills rustc
+# on small instances with no swap (confirmed: a t4g.small, 1.8GB RAM, no
+# swap, killed rustc twice linking cognitod's full dependency tree even
+# though the same build succeeded on an equally-sized amd64 instance). A
+# swapfile is the general fix -- cheap, and doesn't require sizing every
+# cell's instance_type to whatever the current dependency tree happens to
+# need.
+if [ "$(swapon --show | wc -l)" -eq 0 ]; then
+    sudo fallocate -l 4G /swapfile
+    sudo chmod 600 /swapfile
+    sudo mkswap /swapfile
+    sudo swapon /swapfile
+fi
+
 curl -fsSL "https://raw.githubusercontent.com/${github_repo}/main/docs/examples/install-ec2.sh" -o /tmp/install-ec2.sh
 chmod +x /tmp/install-ec2.sh
 sudo /tmp/install-ec2.sh --dev


### PR DESCRIPTION
## Summary
- Ran a real `terraform apply` of the Phase 3 kernel/topology matrix module (3 disposable cells: amd64-jammy, amd64-noble, arm64-noble) against a live AWS account and found a real bug: `rustc` was OOM-killed (confirmed via `dmesg`) building `cognitod` from source on `t4g.small` (1.8GB RAM, no swap) — the same LTO release build succeeded on an equally-sized amd64 instance only because amd64 had more usable headroom.
- Fix: add a 4G swapfile step to `user-data.sh.tftpl` before it calls `install-ec2.sh`.
- Also set `user_data_replace_on_change = true` on `aws_instance.cell` — without it, editing the boot script only updates Terraform's state and never reaches a running instance (confirmed: the first `apply` after the fix showed "0 to add, 3 to change" with no actual instance replacement until this was added).
- Added missing `.gitignore` entries (`.terraform/`, `*.tfstate*`, `*.tfplan`, `terraform.tfvars`) across all three `terraform/` trees in this repo, and committed the kernel-matrix provider lock file per normal Terraform practice.

## Test plan
- [x] `terraform validate` / `terraform fmt -check` clean
- [x] Re-applied all 3 cells with the fix; all reached `linnix-cognitod` active with `episode_capture` enabled, correct per-cell identity (kernel/arch/BTF) confirmed via SSM
- [x] Confirmed swap present and in use (`swapon --show`) on all 3 during the build, no further OOM kills in `dmesg`
- [x] Confirmed arm64 clears the project's 5.18 eBPF floor on real AWS AMIs (kernel `7.0.0-1012-aws`, BTF present)

🤖 Generated with [Claude Code](https://claude.com/claude-code)