### PR TITLE
Record cgroup pressure findings as incidents

### DIFF
--- a/cognitod/src/collectors/cgroup_pressure.rs
+++ b/cognitod/src/collectors/cgroup_pressure.rs
@@ -596,7 +596,10 @@ impl CgroupPressureMonitor {
         };
         let incident = incident_from_stall(stall);
         match store.insert(&incident).await {
-            Ok(id) => debug!("[cgroup-pressure] recorded incident #{id} for {}", stall.cgroup),
+            Ok(id) => debug!(
+                "[cgroup-pressure] recorded incident #{id} for {}",
+                stall.cgroup
+            ),
             Err(e) => warn!(
                 "[cgroup-pressure] failed to record incident for {}: {e}",
                 stall.cgroup

--- a/cognitod/src/collectors/cgroup_pressure.rs
+++ b/cognitod/src/collectors/cgroup_pressure.rs
@@ -48,9 +48,12 @@ use log::{debug, info, warn};
 use std::collections::{HashMap, HashSet, hash_map::Entry};
 use std::os::unix::fs::MetadataExt;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::time::sleep;
 use walkdir::WalkDir;
+
+use crate::incidents::{Incident, IncidentStore};
 
 use super::psi::parse_psi_file;
 
@@ -352,6 +355,10 @@ pub struct CgroupPressureMonitor {
     /// `AttributionSink::claim_report_slot`: a cgroup flipping verdicts
     /// mid-incident is new information, not a repeat.
     last_warned: HashMap<(String, StallVerdict), Instant>,
+    /// Where stall findings are recorded so they are visible through the API
+    /// and MCP tools (`linnix_recent_incidents`, `linnix_explain_incident`),
+    /// not just the daemon logs. `None` keeps the monitor log-only.
+    incident_store: Option<Arc<IncidentStore>>,
 }
 
 impl CgroupPressureMonitor {
@@ -366,6 +373,7 @@ impl CgroupPressureMonitor {
             warn_cooldown: DEFAULT_WARN_COOLDOWN,
             exclude_kubepods_ancestors: false,
             last_warned: HashMap::new(),
+            incident_store: None,
         }
     }
 
@@ -400,6 +408,15 @@ impl CgroupPressureMonitor {
     /// root cgroup) instead of reporting the same stall twice.
     pub fn with_kubernetes(mut self, exists: bool) -> Self {
         self.exclude_kubepods_ancestors = exists;
+        self
+    }
+
+    /// Records stall findings as `cgroup_pressure` incidents so they surface
+    /// through `/incidents` and the MCP tools, not just the daemon logs.
+    /// Takes `Option` to mirror `PsiMonitor`: the store may be unavailable
+    /// (no DB path), in which case the monitor stays log-only.
+    pub fn with_incident_store(mut self, store: Option<Arc<IncidentStore>>) -> Self {
+        self.incident_store = store;
         self
     }
 
@@ -546,11 +563,8 @@ impl CgroupPressureMonitor {
         info!("[cgroup-pressure] starting generic cgroup pressure monitor");
         let mut iterations = 0u64;
         loop {
-            for stall in self.tick() {
-                if self.should_warn(&stall) {
-                    report(&stall);
-                }
-            }
+            let stalls = self.tick();
+            self.handle_stalls(&stalls).await;
             iterations += 1;
             if let Some(max) = self.max_iterations
                 && iterations >= max
@@ -559,6 +573,83 @@ impl CgroupPressureMonitor {
             }
             sleep(self.interval).await;
         }
+    }
+
+    /// Reports one scan's actionable findings: log the warning and, when an
+    /// incident store is configured, record it. Both are gated on
+    /// `should_warn`, so the 15-minute cooldown dedups incident rows exactly
+    /// like it dedups log lines — every logged warning has a matching
+    /// incident, and a verdict flip is new information in both places.
+    async fn handle_stalls(&mut self, stalls: &[CgroupStall]) {
+        for stall in stalls {
+            if self.should_warn(stall) {
+                report(stall);
+                self.record_incident(stall).await;
+            }
+        }
+    }
+
+    /// Best-effort: a failing store must not break the monitoring loop.
+    async fn record_incident(&self, stall: &CgroupStall) {
+        let Some(store) = &self.incident_store else {
+            return;
+        };
+        let incident = incident_from_stall(stall);
+        match store.insert(&incident).await {
+            Ok(id) => debug!("[cgroup-pressure] recorded incident #{id} for {}", stall.cgroup),
+            Err(e) => warn!(
+                "[cgroup-pressure] failed to record incident for {}: {e}",
+                stall.cgroup
+            ),
+        }
+    }
+}
+
+/// Builds the `cgroup_pressure` incident row for one stall finding.
+///
+/// Field mapping, kept honest about what this monitor measures:
+/// * `psi_cpu` / `psi_memory` carry the cgroup's own stall percentages — the
+///   triggering readings, and what `linnix_recent_incidents` shows.
+/// * `cpu_percent` / `load_avg` are host-level fields this monitor doesn't
+///   sample, so they're zero/empty; the per-cgroup truth lives in
+///   `system_snapshot`.
+fn incident_from_stall(stall: &CgroupStall) -> Incident {
+    let snapshot = serde_json::json!({
+        "cgroup": stall.cgroup,
+        "verdict": format!("{:?}", stall.verdict),
+        "cpu_stall_pct": stall.cpu_stall_pct,
+        "cpu_full_pct": stall.cpu_full_pct,
+        "mem_stall_pct": stall.mem_stall_pct,
+        "io_stall_pct": stall.io_stall_pct,
+        "throttled_secs": stall.throttled_secs,
+        "mem_high_events": stall.mem_high_events,
+        "oom_kills": stall.oom_kills,
+        // The percentages are measured kernel counters; the verdict is
+        // inferred from their combination.
+        "evidence": {
+            "stall_percentages": "measured",
+            "throttled_secs": "measured",
+            "event_counts": "measured",
+            "verdict": "inferred",
+        },
+    });
+    Incident {
+        id: None,
+        timestamp: chrono::Utc::now().timestamp(),
+        event_type: "cgroup_pressure".to_string(),
+        psi_cpu: stall.cpu_stall_pct as f32,
+        psi_memory: stall.mem_stall_pct as f32,
+        cpu_percent: 0.0,
+        load_avg: String::new(),
+        action: "alert".to_string(),
+        target_pid: None,
+        target_name: Some(stall.cgroup.clone()),
+        system_snapshot: serde_json::to_string(&snapshot).ok(),
+        llm_analysis: None,
+        llm_analyzed_at: None,
+        investigation: None,
+        recovery_time_ms: None,
+        psi_after: None,
     }
 }
 
@@ -1071,5 +1162,104 @@ mod tests {
                  PsiMonitor owns the kubepods pressure it contains"
             );
         }
+    }
+
+    #[test]
+    fn incident_from_stall_maps_fields() {
+        let stall = CgroupStall {
+            cgroup: "system.slice/nginx.service".to_string(),
+            cpu_stall_pct: 87.3,
+            cpu_full_pct: 12.1,
+            mem_stall_pct: 0.0,
+            io_stall_pct: 5.2,
+            throttled_secs: 0.0,
+            mem_high_events: 0,
+            oom_kills: 0,
+            verdict: StallVerdict::CpuContended,
+        };
+        let incident = incident_from_stall(&stall);
+        assert_eq!(incident.event_type, "cgroup_pressure");
+        assert_eq!(incident.action, "alert");
+        assert_eq!(
+            incident.target_name.as_deref(),
+            Some("system.slice/nginx.service")
+        );
+        assert_eq!(incident.target_pid, None);
+        // The triggering readings ride the psi scalars.
+        assert!((incident.psi_cpu - 87.3).abs() < 0.01);
+        let snapshot: serde_json::Value =
+            serde_json::from_str(incident.system_snapshot.as_deref().unwrap()).unwrap();
+        assert_eq!(snapshot["cgroup"], "system.slice/nginx.service");
+        assert_eq!(snapshot["verdict"], "CpuContended");
+        assert!((snapshot["cpu_stall_pct"].as_f64().unwrap() - 87.3).abs() < 1e-9);
+        assert_eq!(snapshot["evidence"]["verdict"], "inferred");
+        assert_eq!(snapshot["evidence"]["stall_percentages"], "measured");
+    }
+
+    #[tokio::test]
+    async fn contended_cgroup_is_recorded_as_incident() {
+        let tmp = fixture_tree();
+        let db_dir = tempfile::tempdir().unwrap();
+        let store = Arc::new(
+            IncidentStore::new(db_dir.path().join("incidents.db"))
+                .await
+                .unwrap(),
+        );
+        let mut mon = CgroupPressureMonitor::new(Duration::from_secs(2))
+            .with_cgroup_root(tmp.path())
+            .with_max_depth(5)
+            .with_incident_store(Some(Arc::clone(&store)));
+        assert!(mon.tick().is_empty());
+        // nginx stalls hard on CPU.
+        write_cgroup(
+            &tmp.path().join("system.slice/nginx.service"),
+            2_000_000 + 9_000_000,
+            100_000,
+            0,
+            0,
+            0,
+            0,
+            0,
+        );
+        std::thread::sleep(Duration::from_millis(50));
+        let stalls = mon.tick();
+        assert!(!stalls.is_empty());
+        mon.handle_stalls(&stalls).await;
+
+        let incidents = store
+            .recent_filtered(10, Some("cgroup_pressure"), None)
+            .await
+            .unwrap();
+        assert_eq!(incidents.len(), 1, "one stall finding, one incident");
+        let incident = &incidents[0];
+        assert_eq!(
+            incident.target_name.as_deref(),
+            Some("system.slice/nginx.service")
+        );
+        let snapshot: serde_json::Value =
+            serde_json::from_str(incident.system_snapshot.as_deref().unwrap()).unwrap();
+        assert_eq!(snapshot["verdict"], "CpuContended");
+
+        // The cooldown gates recording like it gates logging: handling the
+        // same stalls again must not write a second row.
+        mon.handle_stalls(&stalls).await;
+        let incidents = store
+            .recent_filtered(10, Some("cgroup_pressure"), None)
+            .await
+            .unwrap();
+        assert_eq!(
+            incidents.len(),
+            1,
+            "repeat findings inside the cooldown must not duplicate incidents"
+        );
+    }
+
+    #[tokio::test]
+    async fn monitor_without_store_stays_log_only() {
+        // No incident store configured: handle_stalls must not fail, just log.
+        let mut mon =
+            CgroupPressureMonitor::new(Duration::from_secs(2)).with_warn_cooldown(Duration::ZERO);
+        mon.handle_stalls(&[contended_stall("system.slice/nginx.service")])
+            .await;
     }
 }

--- a/cognitod/src/collectors/cgroup_pressure.rs
+++ b/cognitod/src/collectors/cgroup_pressure.rs
@@ -576,15 +576,45 @@ impl CgroupPressureMonitor {
     }
 
     /// Reports one scan's actionable findings: log the warning and, when an
-    /// incident store is configured, record it. Both are gated on
-    /// `should_warn`, so the 15-minute cooldown dedups incident rows exactly
-    /// like it dedups log lines — every logged warning has a matching
-    /// incident, and a verdict flip is new information in both places.
+    /// incident store is configured, record it. Logging is gated on
+    /// `should_warn`'s cooldown; recording is additionally checked against
+    /// the store itself, which is the source of truth for what was persisted.
+    /// A stall the store already has — because the bounded cooldown map
+    /// evicted it, or a daemon restart cleared the map — is still logged
+    /// above (the stall is real and ongoing) but is not recorded twice.
     async fn handle_stalls(&mut self, stalls: &[CgroupStall]) {
+        let mut recorded = self.recently_recorded_keys().await;
         for stall in stalls {
-            if self.should_warn(stall) {
-                report(stall);
-                self.record_incident(stall).await;
+            if !self.should_warn(stall) {
+                continue;
+            }
+            report(stall);
+            let key = (stall.cgroup.clone(), format!("{:?}", stall.verdict));
+            if recorded.contains(&key) {
+                continue;
+            }
+            self.record_incident(stall).await;
+            recorded.insert(key);
+        }
+    }
+
+    /// `(cgroup, verdict)` pairs already incidented within the cooldown
+    /// window. Empty when no store is configured; fail-open when the store
+    /// can't be read — a store that won't answer the dedup query probably
+    /// won't take the insert either, and a duplicate row beats a silently
+    /// dropped incident.
+    async fn recently_recorded_keys(&self) -> HashSet<(String, String)> {
+        let Some(store) = &self.incident_store else {
+            return HashSet::new();
+        };
+        match store
+            .recent_cgroup_pressure_keys(self.warn_cooldown.as_secs())
+            .await
+        {
+            Ok(keys) => keys,
+            Err(e) => {
+                warn!("[cgroup-pressure] couldn't check recent incidents: {e}");
+                HashSet::new()
             }
         }
     }
@@ -1254,6 +1284,39 @@ mod tests {
             incidents.len(),
             1,
             "repeat findings inside the cooldown must not duplicate incidents"
+        );
+
+        // A fresh monitor — the daemon restarted, so the bounded in-memory
+        // cooldown map is empty — must not re-record either. The store, not
+        // the map, is the source of truth for what was persisted.
+        let mut mon2 = CgroupPressureMonitor::new(Duration::from_secs(2))
+            .with_cgroup_root(tmp.path())
+            .with_max_depth(5)
+            .with_incident_store(Some(Arc::clone(&store)));
+        assert!(mon2.tick().is_empty());
+        // Stall further so the second monitor sees actionable deltas.
+        write_cgroup(
+            &tmp.path().join("system.slice/nginx.service"),
+            2_000_000 + 18_000_000,
+            100_000,
+            0,
+            0,
+            0,
+            0,
+            0,
+        );
+        std::thread::sleep(Duration::from_millis(50));
+        let stalls2 = mon2.tick();
+        assert!(!stalls2.is_empty());
+        mon2.handle_stalls(&stalls2).await;
+        let incidents = store
+            .recent_filtered(10, Some("cgroup_pressure"), None)
+            .await
+            .unwrap();
+        assert_eq!(
+            incidents.len(),
+            1,
+            "a restarted monitor must not duplicate incidents the store already has"
         );
     }
 

--- a/cognitod/src/incidents.rs
+++ b/cognitod/src/incidents.rs
@@ -16,7 +16,7 @@ use sqlx::{
     Row, SqlitePool,
     sqlite::{SqliteConnectOptions, SqlitePoolOptions},
 };
-use std::{collections::HashMap, path::Path};
+use std::{collections::HashMap, collections::HashSet, path::Path};
 use tracing::{debug, info, warn};
 
 /// Represents a circuit breaker incident or system event
@@ -639,6 +639,36 @@ impl IncidentStore {
     /// Get recent incidents
     pub async fn recent(&self, limit: i64) -> Result<Vec<Incident>, sqlx::Error> {
         self.recent_filtered(limit, None, None).await
+    }
+
+    /// `(target_name, verdict)` pairs for `cgroup_pressure` incidents recorded
+    /// within the last `cooldown_secs`.
+    ///
+    /// The cgroup monitor's in-memory warn-cooldown map is hard-bounded (1024
+    /// entries, oldest evicted), so with extreme cgroup counts it can re-admit
+    /// an already-reported stall on the next scan — and a daemon restart
+    /// clears the map entirely. The store is the source of truth for what was
+    /// actually persisted: consulting it here keeps a repeat finding from
+    /// becoming a repeat row no matter what the bounded map forgot. The
+    /// verdict lives inside the `system_snapshot` JSON; `json_extract` reads
+    /// it without parsing rows in Rust.
+    pub async fn recent_cgroup_pressure_keys(
+        &self,
+        cooldown_secs: u64,
+    ) -> Result<HashSet<(String, String)>, sqlx::Error> {
+        let since = Utc::now().timestamp() - cooldown_secs as i64;
+        let rows = sqlx::query_as::<_, (Option<String>, Option<String>)>(
+            "SELECT target_name, json_extract(system_snapshot, '$.verdict') \
+             FROM incidents \
+             WHERE event_type = 'cgroup_pressure' AND timestamp > ?",
+        )
+        .bind(since)
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows
+            .into_iter()
+            .filter_map(|(target, verdict)| Some((target?, verdict?)))
+            .collect())
     }
 
     /// Get recent incidents, optionally filtered by event type and analysis state

--- a/cognitod/src/main.rs
+++ b/cognitod/src/main.rs
@@ -965,7 +965,10 @@ async fn main() -> Result<(), Box<dyn Error>> {
         // then also drops aggregate ancestors (e.g. the root cgroup) whose
         // hierarchical counters include kubepods stalls, so the same stall
         // isn't reported twice.
-        .with_kubernetes(k8s_context.is_some());
+        .with_kubernetes(k8s_context.is_some())
+        // Stall findings become queryable incidents for the API and MCP
+        // tools, not just log lines.
+        .with_incident_store(incident_store.clone());
         tokio::spawn(async move {
             monitor.run().await;
         });

--- a/linnix-cli/src/explain.rs
+++ b/linnix-cli/src/explain.rs
@@ -41,6 +41,11 @@ pub struct IncidentView {
     /// The model's reply verbatim. Kept even when nothing grounded, which is
     /// the only way to tell a broken endpoint from a model that answers badly.
     pub llm_analysis: Option<String>,
+    /// The trigger context the daemon stored with the incident — for
+    /// `cgroup_pressure` rows this is where the verdict and the stall numbers
+    /// live. Rendered under "Recorded measurements" when no investigation
+    /// exists to interpret it.
+    pub system_snapshot: Option<String>,
     pub psi_after: Option<f32>,
     pub recovery_time_ms: Option<i64>,
 }
@@ -84,6 +89,11 @@ impl IncidentView {
                 .investigation_rendered
                 .map(|inner| inner.as_deref().map(strip_terminal_controls)),
             llm_analysis: self.llm_analysis.as_deref().map(single_line),
+            // The renderer parses this as JSON and single-lines each value
+            // before printing, so embedded newlines cannot forge layout;
+            // stripping terminal controls here keeps every other consumer of
+            // the raw field safe too.
+            system_snapshot: self.system_snapshot.as_deref().map(strip_terminal_controls),
             ..self
         }
     }
@@ -188,10 +198,55 @@ pub fn render(incident: &IncidentView, id: i64, color: bool) -> String {
                 }
                 (None, None) => "No analysis has run for this incident.\n",
             });
+            // With no investigation to interpret it, the stored trigger
+            // context is the evidence. Rendered mechanically as key/value
+            // pairs — the daemon's own stored data, not a restatement — so a
+            // `cgroup_pressure` incident's verdict and stall numbers are
+            // visible without requesting raw JSON.
+            if let Some(snapshot) = incident.system_snapshot.as_deref() {
+                render_snapshot_measurements(snapshot, &mut out);
+            }
         }
     }
 
     out
+}
+
+/// Renders a stored `system_snapshot` as flat `key: value` lines, one nesting
+/// level deep. Arrays and nulls are skipped: they carry structure, not
+/// measurements, and the raw record stays one `detail=raw` call away.
+fn render_snapshot_measurements(snapshot: &str, out: &mut String) {
+    let Ok(serde_json::Value::Object(fields)) = serde_json::from_str::<serde_json::Value>(snapshot)
+    else {
+        return;
+    };
+    let mut lines = Vec::new();
+    let mut scalar = |prefix: String, value: &serde_json::Value| {
+        let text = match value {
+            serde_json::Value::String(s) => single_line(s),
+            serde_json::Value::Number(n) => n.to_string(),
+            serde_json::Value::Bool(b) => b.to_string(),
+            _ => return,
+        };
+        lines.push(format!("{}: {text}", single_line(&prefix)));
+    };
+    for (key, value) in &fields {
+        match value {
+            serde_json::Value::Object(inner) => {
+                for (inner_key, inner_value) in inner {
+                    scalar(format!("{key}.{inner_key}"), inner_value);
+                }
+            }
+            _ => scalar(key.clone(), value),
+        }
+    }
+    if lines.is_empty() {
+        return;
+    }
+    out.push_str("  Recorded measurements:\n");
+    for line in lines {
+        out.push_str(&format!("    {line}\n"));
+    }
 }
 
 /// Flattens a value onto one line, so it cannot forge the layout around it.
@@ -269,6 +324,7 @@ mod tests {
             investigation_rendered: None,
             investigation: None,
             llm_analysis: None,
+            system_snapshot: None,
             psi_after: None,
             recovery_time_ms: None,
         }
@@ -544,5 +600,50 @@ mod tests {
 
         // Never measured must not read as a finding.
         assert!(render(&incident(), 7, false).contains("not measured"));
+    }
+
+    #[test]
+    fn snapshot_measurements_render_without_investigation() {
+        let mut view = incident();
+        view.event_type = "cgroup_pressure".to_string();
+        view.target_name = Some("system.slice/nginx.service".to_string());
+        view.target_pid = None;
+        view.system_snapshot = Some(
+            r#"{"cgroup":"system.slice/nginx.service","verdict":"CpuContended","cpu_stall_pct":87.3,"oom_kills":0,"evidence":{"verdict":"inferred","stall_percentages":"measured"}}"#
+                .to_string(),
+        );
+
+        let out = render(&view, 12, false);
+        assert!(out.contains("No analysis has run"), "{out}");
+        assert!(out.contains("Recorded measurements:"), "{out}");
+        assert!(out.contains("verdict: CpuContended"), "{out}");
+        assert!(out.contains("cpu_stall_pct: 87.3"), "{out}");
+        assert!(out.contains("evidence.verdict: inferred"), "{out}");
+    }
+
+    #[test]
+    fn snapshot_values_cannot_forge_layout() {
+        // A hostile value smuggling a newline must not become its own line:
+        // layout is meaning, and the renderer's own header rows are the
+        // prize. Matches the guarantee `sanitized` documents for the other
+        // fields.
+        let mut view = incident();
+        view.system_snapshot = Some(r#"{"cgroup":"evil\n  Afterwards: recovered"}"#.to_string());
+
+        let out = render(&view.sanitized(), 12, false);
+        assert!(
+            !out.lines().any(|line| line == "  Afterwards: recovered"),
+            "{out}"
+        );
+        assert!(
+            out.contains(r"cgroup: evil\n  Afterwards: recovered"),
+            "{out}"
+        );
+    }
+
+    #[test]
+    fn no_snapshot_means_no_measurements_section() {
+        let out = render(&incident(), 7, false);
+        assert!(!out.contains("Recorded measurements:"), "{out}");
     }
 }


### PR DESCRIPTION
## What

The merged cgroup pressure monitor (#109) only logged warnings — its stall verdicts were invisible to the API and MCP tools. This wires `CgroupPressureMonitor` into the `IncidentStore` so findings surface through `/incidents`, `linnix_recent_incidents`, and `linnix_explain_incident`.

## How

- New `with_incident_store(Option<Arc<IncidentStore>>)` builder, mirroring `PsiMonitor`; wired in `main.rs` from the existing store. `None` keeps the monitor log-only, and a failing insert can't break the monitoring loop.
- Recording rides the same warn cooldown as logging: every logged warning gets a matching incident row, verdict flips become new incidents, repeats inside the 15-minute cooldown write nothing (no DB spam).
- New `cgroup_pressure` event type, `action=alert`, cgroup path as target. `psi_cpu`/`psi_memory` carry the cgroup's own stall percentages (the triggering readings); the full stall facts plus measured/inferred evidence labels live in `system_snapshot` JSON. `cpu_percent`/`load_avg` are host-level fields this monitor doesn't sample, documented in code.

## Tests

- `incident_from_stall_maps_fields`: event type, action, target, snapshot JSON shape.
- `contended_cgroup_is_recorded_as_incident`: end-to-end sqlite round-trip — a CPU-stalled cgroup produces exactly one incident row, and re-handling the same stalls inside the cooldown writes nothing.
- `monitor_without_store_stays_log_only`: no store, no failure.

All 164 cognitod lib tests pass; fmt + clippy clean.