### PR TITLE
collectors: add userspace runqueue-starvation and blkio-stall monitors

### DIFF
--- a/cognitod/src/collectors/blkio_stall.rs
+++ b/cognitod/src/collectors/blkio_stall.rs
@@ -8,25 +8,34 @@
 //!
 //! Design:
 //!
-//! * **Signal (inferred):** every 2s, each process's `wchan` is classified.
-//!   The finding is the fraction of samples in a 60s sliding window whose
-//!   `wchan` named a block-layer wait point (`io_schedule`,
-//!   `wait_on_page_bit` family, `blkdev_issue_*`, `get_request*`), i.e.
-//!   "process P was observed waiting on block IO in X% of samples".
-//!   Warn at >= 50%, critical at >= 80% — sustained, not a passing read.
-//! * **Cross-check (measured):** `/proc/<pid>/io` `read_bytes`/`write_bytes`
-//!   deltas ride along in the snapshot. Bytes moving while wchan says
-//!   "waiting" is the normal shape of an IO-heavy victim; bytes *not*
-//!   moving across the whole window is worse — possibly hung storage —
-//!   and the report line says so. The cross-check never gates the finding:
-//!   a stuck task is still a stall.
+//! * **Signal (inferred):** every 2s, each thread's `wchan` is classified
+//!   and aggregated to the process — a poll counts as a block-wait sample
+//!   when *any* thread is observed in a block-layer wait (`io_schedule`,
+//!   `wait_on_page_bit` family, `blkdev_issue_*`, `get_request*`), since
+//!   `/proc/<pid>/wchan` alone only reflects the thread-group leader.
+//!   The finding is the fraction of samples in a 60s sliding window in
+//!   which the process was observed waiting on block IO. Warn at >= 50%,
+//!   critical at >= 80% — sustained, not a passing read.
+//! * **Cross-check (measured when readable):** `/proc/<pid>/io`
+//!   `read_bytes`/`write_bytes` deltas ride along in the snapshot,
+//!   computed newest-minus-oldest *inside* the window from timestamped
+//!   samples. Bytes moving while wchan says "waiting" is the normal shape
+//!   of an IO-heavy victim; bytes *not* moving across the whole window is
+//!   worse — possibly hung storage — and the report line says so, but only
+//!   when the counters were actually read: unreadable counters are labeled
+//!   `unavailable`, never fabricated as zero. The cross-check never gates
+//!   the finding: a stuck task is still a stall.
 //! * **Warm-up honesty:** the percentage is normalized against the full
 //!   window's expected sample count (30), not the samples observed so far,
 //!   so a short-lived burst can't inflate into a verdict — same lesson as
 //!   the fork monitor's review fix. New processes accumulate samples from
 //!   zero and converge to their true fraction.
-//! * **Cost:** one `wchan` read per process per 2s poll (tiny files,
-//!   negligible); `io` is read only for processes with at least one
+//! * **Cost:** one `task`-dir listing plus one `wchan` read per thread per
+//!   2s poll (tiny files, microseconds each; the scan stops at the first
+//!   block-wait found, so stalled processes cost a partial scan).
+//!   Per-process thread scans are capped at 1024 lowest tids — the cap
+//!   only engages on pathological thread counts, and the scan repeats
+//!   every poll. `io` is read only for processes with at least one
 //!   block-wait sample in the window (suspects), so idle hosts pay almost
 //!   nothing. Per-pid state is pruned by window age, so exited processes
 //!   are forgotten within 60s.
@@ -63,6 +72,12 @@ const DEFAULT_WARN_COOLDOWN: Duration = Duration::from_secs(15 * 60);
 const MAX_COOLDOWN_ENTRIES: usize = 1024;
 /// How many distinct block-wait kinds ride along in the incident snapshot.
 const TOP_WCHAN_KINDS: usize = 4;
+/// Cap on threads scanned per process per poll for the wchan sample.
+/// One wchan read is microseconds, but a pathological 100k-thread process
+/// must not stall the 2s loop: lowest tids first (deterministic; thread
+/// IDs are allocated densely from the leader, so the cap only engages on
+/// absurd thread counts), and the scan repeats every poll anyway.
+const MAX_WCHAN_THREADS_PER_POLL: usize = 1024;
 
 /// What a process's sampled block-IO wait fraction means.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -98,19 +113,28 @@ pub struct BlkioStall {
     /// Samples a full window holds (denominator of `wait_pct`).
     pub expected_samples: u32,
     /// `/proc/<pid>/io` deltas across the suspect window, for the
-    /// cross-check: bytes moving vs. not.
-    pub io_read_bytes_delta: u64,
-    pub io_write_bytes_delta: u64,
+    /// cross-check: bytes moving vs. not. `None` when the counters were
+    /// never successfully read inside the window (unreadable or raced
+    /// with process exit) — absence is not zero, and the snapshot labels
+    /// it `unavailable` instead of fabricating a zero delta.
+    pub io_bytes_delta: Option<(u64, u64)>,
     /// Observed block-wait kinds and their sample counts, most common first.
     pub wchan_kinds: Vec<(String, u32)>,
     pub verdict: BlkioVerdict,
 }
 
 impl BlkioStall {
-    /// Stable identity for cooldown and incident-dedup keys. PIDs recycle;
-    /// the command name is the identity that survives.
+    /// Stable identity for cooldown and incident-dedup keys: the process
+    /// plus its command name. PIDs are unique per process system-wide, so
+    /// this distinguishes two `postgres` backends where a comm-only key
+    /// suppressed every same-named process for the whole cooldown. A
+    /// recycled PID's counters regress, which re-baselines the
+    /// measurement — and the store keys the verdict to this identity, so
+    /// the new process dedups against its own history, not another
+    /// victim's.
     fn victim_label(&self) -> String {
-        self.comm.clone().unwrap_or_else(|| "unknown".to_string())
+        let comm = self.comm.clone().unwrap_or_else(|| "unknown".to_string());
+        format!("{comm} (pid={})", self.pid)
     }
 }
 
@@ -154,8 +178,38 @@ fn blkio_wait_kind(wchan: &str) -> Option<&'static str> {
     }
 }
 
-fn read_wchan(proc_root: &Path, pid: u32) -> Option<String> {
-    std::fs::read_to_string(proc_root.join(pid.to_string()).join("wchan")).ok()
+/// Thread IDs for a process. Falls back to the leader alone when the
+/// `task` directory can't be listed (a thread exiting mid-scan, or a
+/// fixture tree without per-thread files).
+fn list_tids(proc_root: &Path, pid: u32) -> Vec<u32> {
+    let task_dir = proc_root.join(pid.to_string()).join("task");
+    let Ok(entries) = std::fs::read_dir(&task_dir) else {
+        return vec![pid];
+    };
+    let mut tids: Vec<u32> = entries
+        .flatten()
+        .filter_map(|e| e.file_name().to_str()?.parse::<u32>().ok())
+        .collect();
+    if tids.is_empty() {
+        tids.push(pid);
+    }
+    tids.sort_unstable();
+    tids
+}
+
+/// One thread's `wchan`. The leader's file is also visible at the plain
+/// pid path; worker threads live under `task/<tid>/`.
+fn read_thread_wchan(proc_root: &Path, pid: u32, tid: u32) -> Option<String> {
+    let path = if tid == pid {
+        proc_root.join(pid.to_string()).join("wchan")
+    } else {
+        proc_root
+            .join(pid.to_string())
+            .join("task")
+            .join(tid.to_string())
+            .join("wchan")
+    };
+    std::fs::read_to_string(path).ok()
 }
 
 fn read_comm(proc_root: &Path, pid: u32) -> Option<String> {
@@ -199,14 +253,15 @@ fn list_pids(proc_root: &Path) -> Vec<u32> {
     out
 }
 
-/// IO-byte baseline for a suspect process: first and latest counters inside
-/// the window, so the snapshot can cross-check "waiting" against "moving".
-#[derive(Debug, Clone, Copy)]
+/// IO-byte baseline for a suspect process: timestamped
+/// `(sampled_at, read_bytes, write_bytes)` counter samples inside the
+/// sliding window. The reported delta is newest-minus-oldest *in the
+/// window*, so a stall that started hours ago doesn't smear ancient
+/// progress into the current window — and earlier progress can't conceal
+/// that no bytes moved during the last 60s.
+#[derive(Debug, Clone, Default)]
 struct IoBaseline {
-    first_read: u64,
-    first_write: u64,
-    last_read: u64,
-    last_write: u64,
+    samples: VecDeque<(Instant, u64, u64)>,
 }
 
 /// Stateful block-IO stall monitor.
@@ -320,6 +375,28 @@ impl BlkioStallMonitor {
         true
     }
 
+    /// One poll's block-wait sample for a process: `Some(kind)` when any
+    /// scanned thread is observed in a block-layer wait, `None`
+    /// otherwise. `/proc/<pid>/wchan` reflects only the thread-group
+    /// leader, so worker-thread stalls (databases, app servers whose
+    /// leader idles in a futex/event loop) are invisible without the
+    /// per-thread enumeration — the poll counts as a block-wait sample
+    /// for the process when *any* thread is waiting. Threads are scanned
+    /// lowest-tid-first up to `MAX_WCHAN_THREADS_PER_POLL`; a thread that
+    /// exits mid-scan is skipped (unreadable wchan is not a wait).
+    fn sample_process_wchan(&self, pid: u32) -> Option<&'static str> {
+        for tid in list_tids(&self.proc_root, pid)
+            .into_iter()
+            .take(MAX_WCHAN_THREADS_PER_POLL)
+        {
+            let wchan = read_thread_wchan(&self.proc_root, pid, tid).unwrap_or_default();
+            if let Some(kind) = blkio_wait_kind(&wchan) {
+                return Some(kind);
+            }
+        }
+        None
+    }
+
     /// One poll: sample every process's `wchan`, maintain the suspect
     /// windows, and return a finding for the worst block-IO waiter when it
     /// is actionable.
@@ -328,10 +405,10 @@ impl BlkioStallMonitor {
     }
 
     fn tick_at(&mut self, now: Instant) -> Option<BlkioStall> {
-        // 1. Sample wchan for every process; record block-wait sightings.
+        // 1. Sample wchan for every thread of every process; record a
+        // block-wait sighting for the process when any thread waits.
         for pid in list_pids(&self.proc_root) {
-            let wchan = read_wchan(&self.proc_root, pid).unwrap_or_default();
-            if let Some(kind) = blkio_wait_kind(&wchan) {
+            if let Some(kind) = self.sample_process_wchan(pid) {
                 self.wait_samples
                     .entry(pid)
                     .or_default()
@@ -340,40 +417,25 @@ impl BlkioStallMonitor {
         }
 
         // 2. IO cross-check, suspects only: fold this poll's counters into
-        // the baseline. A regressing counter means the PID was recycled:
-        // re-baseline instead of fabricating a negative delta.
+        // the timestamped baseline. A regressing counter means the PID was
+        // recycled: re-baseline instead of fabricating a negative delta.
+        // Unreadable counters simply add no sample — availability is
+        // tracked explicitly (see fix below), never fabricated as zero.
         let suspects: Vec<u32> = self.wait_samples.keys().copied().collect();
         for pid in suspects {
             let Some((r, w)) = read_io_bytes(&self.proc_root, pid) else {
                 continue;
             };
-            match self.io_baselines.get_mut(&pid) {
-                Some(baseline) => {
-                    if r < baseline.last_read || w < baseline.last_write {
-                        debug!("[blkio] io counters regressed for pid={pid}; re-baselining");
-                        *baseline = IoBaseline {
-                            first_read: r,
-                            first_write: w,
-                            last_read: r,
-                            last_write: w,
-                        };
-                    } else {
-                        baseline.last_read = r;
-                        baseline.last_write = w;
-                    }
-                }
-                None => {
-                    self.io_baselines.insert(
-                        pid,
-                        IoBaseline {
-                            first_read: r,
-                            first_write: w,
-                            last_read: r,
-                            last_write: w,
-                        },
-                    );
-                }
+            let baseline = self.io_baselines.entry(pid).or_default();
+            if baseline
+                .samples
+                .back()
+                .is_some_and(|&(_, last_r, last_w)| r < last_r || w < last_w)
+            {
+                debug!("[blkio] io counters regressed for pid={pid}; re-baselining");
+                baseline.samples.clear();
             }
+            baseline.samples.push_back((now, r, w));
         }
 
         // 3. Age out samples older than the window; forget processes with
@@ -390,6 +452,26 @@ impl BlkioStallMonitor {
         }
         for pid in empty_pids {
             self.wait_samples.remove(&pid);
+            self.io_baselines.remove(&pid);
+        }
+        // Age the IO samples with the same window: the delta below must
+        // cover the window, not the process's lifetime. Drop baselines
+        // whose samples all aged out — their counters are unobservable
+        // now, which the finding reports as unavailable.
+        let mut stale_io = Vec::new();
+        for (pid, baseline) in self.io_baselines.iter_mut() {
+            while baseline
+                .samples
+                .front()
+                .is_some_and(|&(t, _, _)| t < cutoff)
+            {
+                baseline.samples.pop_front();
+            }
+            if baseline.samples.is_empty() {
+                stale_io.push(*pid);
+            }
+        }
+        for pid in stale_io {
             self.io_baselines.remove(&pid);
         }
 
@@ -420,16 +502,16 @@ impl BlkioStallMonitor {
             .collect();
         wchan_kinds.sort_by_key(|a| std::cmp::Reverse(a.1));
         wchan_kinds.truncate(TOP_WCHAN_KINDS);
-        let (io_read_bytes_delta, io_write_bytes_delta) = self
-            .io_baselines
-            .get(&pid)
-            .map(|b| {
-                (
-                    b.last_read.saturating_sub(b.first_read),
-                    b.last_write.saturating_sub(b.first_write),
-                )
-            })
-            .unwrap_or((0, 0));
+        // Newest-minus-oldest *inside the window*; `None` when no counter
+        // sample survived the window — never a fabricated zero.
+        let io_bytes_delta: Option<(u64, u64)> = self.io_baselines.get(&pid).and_then(|b| {
+            let &(_, first_r, first_w) = b.samples.front()?;
+            let &(_, last_r, last_w) = b.samples.back()?;
+            Some((
+                last_r.saturating_sub(first_r),
+                last_w.saturating_sub(first_w),
+            ))
+        });
         Some(BlkioStall {
             pid,
             comm: read_comm(&self.proc_root, pid),
@@ -437,8 +519,7 @@ impl BlkioStallMonitor {
             window_secs: WINDOW.as_secs_f64(),
             wait_samples,
             expected_samples: self.expected_samples,
-            io_read_bytes_delta,
-            io_write_bytes_delta,
+            io_bytes_delta,
             wchan_kinds,
             verdict,
         })
@@ -545,9 +626,12 @@ impl BlkioStallMonitor {
 ///   fields this monitor doesn't sample, so they're zero/empty; the
 ///   triggering reading is the sampled block-wait fraction, carried in
 ///   `system_snapshot`.
-/// * `target_pid` / `target_name` name the victim process.
+/// * `target_pid` / `target_name` name the victim process; the name
+///   carries the PID so same-comm victims are distinct identities.
 /// * The wait fraction is `inferred` (sampled wchan peeks, not delay
-///   accounting); the IO byte deltas are `measured` kernel counters.
+///   accounting); the IO byte deltas are `measured` kernel counters when
+///   they were readable inside the window, `unavailable` otherwise —
+///   never a fabricated zero.
 fn incident_from_finding(finding: &BlkioStall) -> Incident {
     let wchan_kinds: Vec<serde_json::Value> = finding
         .wchan_kinds
@@ -561,17 +645,18 @@ fn incident_from_finding(finding: &BlkioStall) -> Incident {
         "window_secs": finding.window_secs,
         "wait_samples": finding.wait_samples,
         "expected_samples": finding.expected_samples,
-        "io_read_bytes_delta": finding.io_read_bytes_delta,
-        "io_write_bytes_delta": finding.io_write_bytes_delta,
+        "io_read_bytes_delta": finding.io_bytes_delta.map(|(r, _)| r),
+        "io_write_bytes_delta": finding.io_bytes_delta.map(|(_, w)| w),
         "wchan_kinds": wchan_kinds,
         "source_tier": "polling",
         "verdict": format!("{:?}", finding.verdict),
         // wchan sampling is an inferred fraction; the io counters are
-        // measured. No bytes moving across the whole window while wchan
-        // says "waiting" is the hung-storage shape.
+        // measured when readable, unavailable when not. No bytes moving
+        // across the whole window while wchan says "waiting" is the
+        // hung-storage shape.
         "evidence": {
             "blkio_wait": "inferred",
-            "io_counters": "measured",
+            "io_counters": if finding.io_bytes_delta.is_some() { "measured" } else { "unavailable" },
         },
     });
     Incident {
@@ -595,25 +680,29 @@ fn incident_from_finding(finding: &BlkioStall) -> Incident {
 }
 
 /// One human- and agent-readable line per actionable finding. The wait
-/// fraction is `inferred`; the IO deltas are `measured` — the tags say
-/// which is which.
+/// fraction is `inferred`; the IO deltas are `measured` when readable and
+/// `unavailable` when not — the tags say which is which, and the
+/// hung-storage note only appears for counters that were actually read.
 fn report(finding: &BlkioStall) {
     let victim = match finding.comm.as_deref() {
         Some(comm) => format!("{comm} (pid={})", finding.pid),
         None => format!("pid={}", finding.pid),
     };
-    let io_note = if finding.io_read_bytes_delta == 0 && finding.io_write_bytes_delta == 0 {
-        "; no IO progress across the window — possible hung storage"
-    } else {
-        ""
+    let (io_note, io_tag) = match finding.io_bytes_delta {
+        Some((0, 0)) => (
+            "; no IO progress across the window — possible hung storage",
+            "io counters measured",
+        ),
+        Some(_) => ("", "io counters measured"),
+        None => ("", "io counters unavailable"),
     };
     match finding.verdict {
         BlkioVerdict::BlkioWarning => warn!(
-            "[blkio] WARNING: process {victim} spent {:.0}% of the last {:.0}s in block-IO wait ({}/{} samples) [wait inferred, io counters measured]{io_note}",
+            "[blkio] WARNING: process {victim} spent {:.0}% of the last {:.0}s in block-IO wait ({}/{} samples) [wait inferred, {io_tag}]{io_note}",
             finding.wait_pct, finding.window_secs, finding.wait_samples, finding.expected_samples,
         ),
         BlkioVerdict::BlkioCritical => warn!(
-            "[blkio] CRITICAL: process {victim} spent {:.0}% of the last {:.0}s in block-IO wait ({}/{} samples) — effectively stalled on storage [wait inferred, io counters measured]{io_note}",
+            "[blkio] CRITICAL: process {victim} spent {:.0}% of the last {:.0}s in block-IO wait ({}/{} samples) — effectively stalled on storage [wait inferred, {io_tag}]{io_note}",
             finding.wait_pct, finding.window_secs, finding.wait_samples, finding.expected_samples,
         ),
         BlkioVerdict::Healthy => {}
@@ -659,6 +748,26 @@ mod tests {
             fs::write(d.join("comm"), format!("{comm}\n")).unwrap();
         }
 
+        /// (Re)places one thread's wchan. The leader's wchan is also
+        /// mirrored at `<pid>/wchan`, like the kernel's alias.
+        fn set_thread_wchan(&self, pid: u32, tid: u32, wchan: &str) {
+            let task = self
+                .dir
+                .path()
+                .join(pid.to_string())
+                .join("task")
+                .join(tid.to_string());
+            fs::create_dir_all(&task).unwrap();
+            fs::write(task.join("wchan"), format!("{wchan}\n")).unwrap();
+            if tid == pid {
+                fs::write(
+                    self.dir.path().join(pid.to_string()).join("wchan"),
+                    format!("{wchan}\n"),
+                )
+                .unwrap();
+            }
+        }
+
         fn remove_pid(&self, pid: u32) {
             fs::remove_dir_all(self.dir.path().join(pid.to_string())).unwrap();
         }
@@ -676,8 +785,7 @@ mod tests {
             window_secs: 60.0,
             wait_samples: 18,
             expected_samples: 30,
-            io_read_bytes_delta: 1_000_000,
-            io_write_bytes_delta: 0,
+            io_bytes_delta: Some((1_000_000, 0)),
             wchan_kinds: vec![("io_schedule".to_string(), 18)],
             verdict: BlkioVerdict::BlkioWarning,
         }
@@ -731,6 +839,58 @@ mod tests {
     }
 
     #[test]
+    fn worker_thread_block_wait_fires() {
+        // The leader idles in a futex (event loop) while a worker is stuck
+        // in io_schedule: /proc/<pid>/wchan alone would miss this
+        // entirely, so the monitor enumerates task/<tid>/wchan and a poll
+        // counts when *any* thread waits.
+        let fake = FakeProc::new();
+        // 6s poll => 10 expected samples per 60s window.
+        let mut mon = fake.monitor_with_interval(Duration::from_secs(6));
+        let t0 = Instant::now();
+        let mut finding = None;
+        for i in 0..10 {
+            fake.set_proc(100, "db", "futex_wait_queue_me", 1000 * i, 0);
+            fake.set_thread_wchan(100, 101, "io_schedule");
+            finding = mon.tick_at(t0 + Duration::from_secs(6 * i));
+        }
+        let finding = finding.expect("worker-thread block-IO wait must fire");
+        assert_eq!(finding.pid, 100);
+        assert_eq!(finding.verdict, BlkioVerdict::BlkioCritical);
+        assert_eq!(
+            finding.wchan_kinds,
+            vec![("io_schedule".to_string(), 10)],
+            "the worker thread's wait kind must be reported"
+        );
+        // The IO cross-check still rode along for the process.
+        assert_eq!(finding.io_bytes_delta, Some((9000, 0)));
+    }
+
+    #[test]
+    fn thread_scan_cap_bounds_cost() {
+        // 1030 threads, lowest tids first, cap at 1024: the stalled
+        // thread beyond the cap is not sampled on this poll. This pins
+        // the documented tradeoff — pathological thread counts can't
+        // stall the 2s loop, at the cost of missing waits past the cap.
+        let fake = FakeProc::new();
+        let mon = fake.monitor_with_interval(Duration::from_secs(2));
+        fake.set_proc(100, "db", "futex_wait_queue_me", 0, 0);
+        for tid in 101..=1129u32 {
+            let wchan = if tid == 1129 {
+                "io_schedule"
+            } else {
+                "futex_wait_queue_me"
+            };
+            fake.set_thread_wchan(100, tid, wchan);
+        }
+        assert_eq!(
+            mon.sample_process_wchan(100),
+            None,
+            "threads past the per-process scan cap are not sampled"
+        );
+    }
+
+    #[test]
     fn warmup_under_reports_and_converges() {
         // 6s poll => 10 expected samples per 60s window. Four wait samples
         // are 40% — a short burst must not inflate into a verdict just
@@ -775,7 +935,10 @@ mod tests {
         assert_eq!(finding.pid, 100);
         assert_eq!(finding.comm.as_deref(), Some("backfill"));
         // The IO cross-check rode along: bytes moved while waiting.
-        assert!(finding.io_read_bytes_delta > 0);
+        assert!(
+            matches!(finding.io_bytes_delta, Some((r, _)) if r > 0),
+            "read-byte delta must be measured and positive"
+        );
         assert_eq!(
             finding.wchan_kinds,
             vec![("wait_on_page".to_string(), 30)],
@@ -797,8 +960,11 @@ mod tests {
             finding = mon.tick_at(t0 + Duration::from_secs(2 * i));
         }
         let finding = finding.expect("must fire");
-        assert_eq!(finding.io_read_bytes_delta, 0);
-        assert_eq!(finding.io_write_bytes_delta, 0);
+        assert_eq!(
+            finding.io_bytes_delta,
+            Some((0, 0)),
+            "counters were read and did not move: a measured zero"
+        );
     }
 
     #[test]
@@ -828,8 +994,64 @@ mod tests {
             .tick_at(t0 + Duration::from_secs(60))
             .expect("must fire");
         assert_eq!(
-            finding.io_read_bytes_delta, 3900,
+            finding.io_bytes_delta,
+            Some((3900, 0)),
             "delta must be measured from the re-baselined counters"
+        );
+    }
+
+    #[test]
+    fn io_delta_covers_only_the_window() {
+        // 2s poll, 60s window, 36 ticks (t=0..70s). Bytes move early, then
+        // stop at t=40s. The reported delta must be newest-minus-oldest
+        // *inside the window* — [t=10s, t=70s]: 20000-5000 — not since
+        // first sighting, so ancient progress can't smear into (or
+        // conceal a stall within) the current window.
+        let fake = FakeProc::new();
+        let mut mon = fake.monitor_with_interval(Duration::from_secs(2));
+        let t0 = Instant::now();
+        let mut finding = None;
+        for i in 0..=35u64 {
+            fake.set_proc(100, "backfill", "io_schedule", 1000 * i.min(20), 0);
+            finding = mon.tick_at(t0 + Duration::from_secs(2 * i));
+        }
+        let finding = finding.expect("must fire");
+        assert_eq!(
+            finding.io_bytes_delta,
+            Some((15_000, 0)),
+            "delta must cover only the 60s window"
+        );
+    }
+
+    #[test]
+    fn unavailable_io_counters_are_not_fabricated() {
+        // wchan says "waiting" but /proc/<pid>/io is unreadable (raced
+        // with process exit): the finding still fires — the cross-check
+        // never gates — but the counters are labeled unavailable, not
+        // zero, and no hung-storage claim is made.
+        let fake = FakeProc::new();
+        let mut mon = fake.monitor_with_interval(Duration::from_secs(2));
+        let t0 = Instant::now();
+        let mut finding = None;
+        for i in 0..30 {
+            // wchan + comm present, io file absent.
+            let d = fake.pid_dir(100);
+            fs::write(d.join("wchan"), "io_schedule\n").unwrap();
+            fs::write(d.join("comm"), "backfill\n").unwrap();
+            finding = mon.tick_at(t0 + Duration::from_secs(2 * i));
+        }
+        let finding = finding.expect("must fire");
+        assert_eq!(
+            finding.io_bytes_delta, None,
+            "unreadable counters must be unavailable, not zero"
+        );
+        let incident = incident_from_finding(&finding);
+        let snapshot: serde_json::Value =
+            serde_json::from_str(incident.system_snapshot.as_deref().unwrap()).unwrap();
+        assert_eq!(snapshot["evidence"]["io_counters"], "unavailable");
+        assert!(
+            snapshot["io_read_bytes_delta"].is_null() && snapshot["io_write_bytes_delta"].is_null(),
+            "the snapshot must not carry fabricated zero deltas"
         );
     }
 
@@ -888,7 +1110,7 @@ mod tests {
             if i == 9 {
                 let finding = finding.expect("10/10 must fire");
                 assert_eq!(finding.comm, None);
-                assert_eq!(finding.victim_label(), "unknown");
+                assert_eq!(finding.victim_label(), "unknown (pid=200)");
             }
         }
     }
@@ -910,6 +1132,26 @@ mod tests {
         assert!(mon.should_warn(&escalated));
         // A different victim is unaffected.
         assert!(mon.should_warn(&warning_finding("other")));
+    }
+
+    #[test]
+    fn same_comm_processes_do_not_suppress_each_other() {
+        // Two processes sharing a comm (think `postgres` backends): the
+        // dedup identity includes the PID, so each victim warns on its own.
+        let mut mon = BlkioStallMonitor::new(Duration::from_secs(2));
+        let a = BlkioStall {
+            pid: 100,
+            ..warning_finding("postgres")
+        };
+        let b = BlkioStall {
+            pid: 200,
+            ..warning_finding("postgres")
+        };
+        assert!(mon.should_warn(&a), "first victim must warn");
+        assert!(
+            mon.should_warn(&b),
+            "a different PID with the same comm must warn too"
+        );
     }
 
     #[test]
@@ -956,8 +1198,7 @@ mod tests {
             window_secs: 60.0,
             wait_samples: 26,
             expected_samples: 30,
-            io_read_bytes_delta: 5_000_000,
-            io_write_bytes_delta: 1000,
+            io_bytes_delta: Some((5_000_000, 1000)),
             wchan_kinds: vec![("io_schedule".to_string(), 26)],
             verdict: BlkioVerdict::BlkioCritical,
         };
@@ -965,7 +1206,11 @@ mod tests {
         assert_eq!(incident.event_type, "blkio_stall");
         assert_eq!(incident.action, "alert");
         assert_eq!(incident.target_pid, Some(4242));
-        assert_eq!(incident.target_name.as_deref(), Some("backfill"));
+        assert_eq!(
+            incident.target_name.as_deref(),
+            Some("backfill (pid=4242)"),
+            "the incident identity names the victim process, not just the comm"
+        );
         // Host-level fields this monitor doesn't sample stay zero/empty;
         // the triggering reading lives in the snapshot.
         assert_eq!(incident.psi_cpu, 0.0);
@@ -1010,7 +1255,10 @@ mod tests {
             .unwrap();
         assert_eq!(incidents.len(), 1, "one finding, one incident");
         assert_eq!(incidents[0].event_type, "blkio_stall");
-        assert_eq!(incidents[0].target_name.as_deref(), Some("backfill"));
+        assert_eq!(
+            incidents[0].target_name.as_deref(),
+            Some("backfill (pid=100)")
+        );
 
         // The store already has this finding: handling it again must not
         // write a second row. Recording is decided against the store, not
@@ -1046,6 +1294,41 @@ mod tests {
             incidents.len(),
             1,
             "a restarted monitor must not duplicate incidents the store already has"
+        );
+    }
+
+    #[tokio::test]
+    async fn same_comm_victims_record_independently() {
+        // The store dedup key is (target_name, verdict) and the target
+        // name carries the PID: two same-comm victims are two identities,
+        // so both record — one `postgres` backend no longer suppresses
+        // the others for the whole cooldown.
+        let db_dir = tempfile::tempdir().unwrap();
+        let store = Arc::new(
+            IncidentStore::new(db_dir.path().join("incidents.db"))
+                .await
+                .unwrap(),
+        );
+        let mut mon = BlkioStallMonitor::new(Duration::from_secs(2))
+            .with_incident_store(Some(Arc::clone(&store)));
+        let a = BlkioStall {
+            pid: 100,
+            ..warning_finding("postgres")
+        };
+        let b = BlkioStall {
+            pid: 200,
+            ..warning_finding("postgres")
+        };
+        mon.handle_finding(&a).await;
+        mon.handle_finding(&b).await;
+        let incidents = store
+            .recent_filtered(10, Some("blkio_stall"), None)
+            .await
+            .unwrap();
+        assert_eq!(
+            incidents.len(),
+            2,
+            "same-comm processes are distinct incident identities"
         );
     }
 

--- a/cognitod/src/collectors/blkio_stall.rs
+++ b/cognitod/src/collectors/blkio_stall.rs
@@ -1,0 +1,1098 @@
+//! Userspace block-IO stall-victim detector: no eBPF, no privileges beyond /proc.
+//!
+//! A process stuck waiting on storage shows up in two places a normal user
+//! can read: its `wchan` names the kernel wait point, and
+//! `/proc/<pid>/io` accounts the bytes it actually moved. Neither is exact
+//! — `wchan` is a sampled point-in-time peek, not a delay account — so this
+//! monitor runs at the spec's tier B and labels everything accordingly.
+//!
+//! Design:
+//!
+//! * **Signal (inferred):** every 2s, each process's `wchan` is classified.
+//!   The finding is the fraction of samples in a 60s sliding window whose
+//!   `wchan` named a block-layer wait point (`io_schedule`,
+//!   `wait_on_page_bit` family, `blkdev_issue_*`, `get_request*`), i.e.
+//!   "process P was observed waiting on block IO in X% of samples".
+//!   Warn at >= 50%, critical at >= 80% — sustained, not a passing read.
+//! * **Cross-check (measured):** `/proc/<pid>/io` `read_bytes`/`write_bytes`
+//!   deltas ride along in the snapshot. Bytes moving while wchan says
+//!   "waiting" is the normal shape of an IO-heavy victim; bytes *not*
+//!   moving across the whole window is worse — possibly hung storage —
+//!   and the report line says so. The cross-check never gates the finding:
+//!   a stuck task is still a stall.
+//! * **Warm-up honesty:** the percentage is normalized against the full
+//!   window's expected sample count (30), not the samples observed so far,
+//!   so a short-lived burst can't inflate into a verdict — same lesson as
+//!   the fork monitor's review fix. New processes accumulate samples from
+//!   zero and converge to their true fraction.
+//! * **Cost:** one `wchan` read per process per 2s poll (tiny files,
+//!   negligible); `io` is read only for processes with at least one
+//!   block-wait sample in the window (suspects), so idle hosts pay almost
+//!   nothing. Per-pid state is pruned by window age, so exited processes
+//!   are forgotten within 60s.
+//! * **Tier A upgrade path:** taskstats netlink gives exact per-task delay
+//!   accounting (`blkio_delay_total`) and would make the wait `measured`.
+//!   It needs a dedicated netlink thread; the sampled fraction here is the
+//!   honest tier-B version.
+//!
+//! Findings become `blkio_stall` incidents via the same store-backed dedup
+//! discipline as the other monitors: the incident store — not the bounded
+//! in-memory warn map — is the source of truth for what was already
+//! persisted, so map eviction and daemon restarts cannot duplicate rows.
+
+use log::{debug, info, warn};
+use std::collections::{HashMap, HashSet, VecDeque};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+use tokio::time::sleep;
+
+use crate::incidents::{Incident, IncidentStore};
+
+/// Sliding window over which block-wait samples are counted.
+const WINDOW: Duration = Duration::from_secs(60);
+/// Fraction of window samples in block-layer wait at or above which a
+/// warning fires: half the window observed waiting on storage.
+const WARN_WAIT_PCT: f64 = 50.0;
+/// Fraction at or above which a critical fires.
+const CRIT_WAIT_PCT: f64 = 80.0;
+/// Default quiet period between repeat warnings for the same victim+verdict,
+/// mirroring the other monitors.
+const DEFAULT_WARN_COOLDOWN: Duration = Duration::from_secs(15 * 60);
+/// Cap on the warn-cooldown map; oldest entries are evicted past this.
+const MAX_COOLDOWN_ENTRIES: usize = 1024;
+/// How many distinct block-wait kinds ride along in the incident snapshot.
+const TOP_WCHAN_KINDS: usize = 4;
+
+/// What a process's sampled block-IO wait fraction means.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum BlkioVerdict {
+    Healthy,
+    /// Process observed waiting on block IO in >= 50% of window samples.
+    /// Storage is its bottleneck (or its workload is purely IO-bound —
+    /// correlate with the workload before paging).
+    BlkioWarning,
+    /// 80% or more of samples waiting: the process is effectively stalled
+    /// on storage.
+    BlkioCritical,
+}
+
+impl BlkioVerdict {
+    /// `false` for `Healthy`; used to filter log/report noise.
+    pub fn actionable(self) -> bool {
+        !matches!(self, BlkioVerdict::Healthy)
+    }
+}
+
+/// One actionable block-IO stall finding for a scan window.
+#[derive(Debug, Clone)]
+pub struct BlkioStall {
+    pub pid: u32,
+    pub comm: Option<String>,
+    /// % of the window's expected samples observed in block-layer wait.
+    pub wait_pct: f64,
+    /// Seconds the window covers.
+    pub window_secs: f64,
+    /// Block-wait samples actually observed (numerator of `wait_pct`).
+    pub wait_samples: u32,
+    /// Samples a full window holds (denominator of `wait_pct`).
+    pub expected_samples: u32,
+    /// `/proc/<pid>/io` deltas across the suspect window, for the
+    /// cross-check: bytes moving vs. not.
+    pub io_read_bytes_delta: u64,
+    pub io_write_bytes_delta: u64,
+    /// Observed block-wait kinds and their sample counts, most common first.
+    pub wchan_kinds: Vec<(String, u32)>,
+    pub verdict: BlkioVerdict,
+}
+
+impl BlkioStall {
+    /// Stable identity for cooldown and incident-dedup keys. PIDs recycle;
+    /// the command name is the identity that survives.
+    fn victim_label(&self) -> String {
+        self.comm.clone().unwrap_or_else(|| "unknown".to_string())
+    }
+}
+
+fn classify(wait_pct: f64) -> BlkioVerdict {
+    if wait_pct >= CRIT_WAIT_PCT {
+        BlkioVerdict::BlkioCritical
+    } else if wait_pct >= WARN_WAIT_PCT {
+        BlkioVerdict::BlkioWarning
+    } else {
+        BlkioVerdict::Healthy
+    }
+}
+
+/// Classifies a `wchan` value: `Some` canonical kind when the task was
+/// observed waiting in the block layer, `None` otherwise. Best-effort by
+/// construction — `wchan` is a sampled peek, and filesystem-specific waits
+/// usually funnel through `io_schedule`/`wait_on_page_bit` anyway.
+///
+/// Recognized families:
+/// * `io_schedule[_timeout]` — the generic block-layer sleep.
+/// * `wait_on_page*` — `wait_on_page_bit[_killable]` (file *and* swap cache
+///   page waits — this is the swapin signal too), `wait_on_page_writeback`.
+/// * `blkdev_issue*` — flush/zeroout/discard submission waits.
+/// * `get_request*` — request-queue waits (older kernels).
+fn blkio_wait_kind(wchan: &str) -> Option<&'static str> {
+    let w = wchan.trim();
+    if w.is_empty() || w == "0" {
+        // "0" means running (or wchan disabled) — not waiting.
+        return None;
+    }
+    if w.contains("io_schedule") {
+        Some("io_schedule")
+    } else if w.starts_with("wait_on_page") {
+        Some("wait_on_page")
+    } else if w.starts_with("blkdev_issue") {
+        Some("blkio_issue")
+    } else if w.starts_with("get_request") {
+        Some("get_request")
+    } else {
+        None
+    }
+}
+
+fn read_wchan(proc_root: &Path, pid: u32) -> Option<String> {
+    std::fs::read_to_string(proc_root.join(pid.to_string()).join("wchan")).ok()
+}
+
+fn read_comm(proc_root: &Path, pid: u32) -> Option<String> {
+    std::fs::read_to_string(proc_root.join(pid.to_string()).join("comm"))
+        .ok()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+}
+
+/// `(read_bytes, write_bytes)` from `/proc/<pid>/io`. `None` when the file
+/// is missing or unparseable — absence is not zero.
+fn read_io_bytes(proc_root: &Path, pid: u32) -> Option<(u64, u64)> {
+    let content = std::fs::read_to_string(proc_root.join(pid.to_string()).join("io")).ok()?;
+    let mut read_bytes = None;
+    let mut write_bytes = None;
+    for line in content.lines() {
+        if let Some(rest) = line.strip_prefix("read_bytes:") {
+            read_bytes = rest.trim().parse::<u64>().ok();
+        } else if let Some(rest) = line.strip_prefix("write_bytes:") {
+            write_bytes = rest.trim().parse::<u64>().ok();
+        }
+    }
+    Some((read_bytes?, write_bytes?))
+}
+
+/// Numeric `/proc` entries: the live PID set.
+fn list_pids(proc_root: &Path) -> Vec<u32> {
+    let mut out = Vec::new();
+    let Ok(entries) = std::fs::read_dir(proc_root) else {
+        return out;
+    };
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let Some(name_str) = name.to_str() else {
+            continue;
+        };
+        if let Ok(pid) = name_str.parse::<u32>() {
+            out.push(pid);
+        }
+    }
+    out
+}
+
+/// IO-byte baseline for a suspect process: first and latest counters inside
+/// the window, so the snapshot can cross-check "waiting" against "moving".
+#[derive(Debug, Clone, Copy)]
+struct IoBaseline {
+    first_read: u64,
+    first_write: u64,
+    last_read: u64,
+    last_write: u64,
+}
+
+/// Stateful block-IO stall monitor.
+pub struct BlkioStallMonitor {
+    proc_root: PathBuf,
+    interval: Duration,
+    /// Samples a full window holds; the denominator every percentage is
+    /// normalized against, so warm-up under-reports instead of inflating.
+    expected_samples: u32,
+    /// Per-PID `(sampled_at, block-wait kind)` inside the sliding window.
+    wait_samples: HashMap<u32, VecDeque<(Instant, &'static str)>>,
+    /// Per-suspect-PID IO baselines for the cross-check.
+    io_baselines: HashMap<u32, IoBaseline>,
+    warn_cooldown: Duration,
+    max_iterations: Option<u64>,
+    /// When each victim+verdict was last warned about.
+    last_warned: HashMap<(String, BlkioVerdict), Instant>,
+    /// Whether the last incident-record attempt failed (warn-once, then
+    /// debug until a record succeeds — `handle_finding` retries every scan).
+    record_unhealthy: bool,
+    /// Where findings are recorded so they are visible through the API
+    /// and MCP tools, not just the daemon logs. `None` keeps the monitor
+    /// log-only.
+    incident_store: Option<Arc<IncidentStore>>,
+}
+
+impl BlkioStallMonitor {
+    pub fn new(interval: Duration) -> Self {
+        let expected_samples =
+            (WINDOW.as_secs_f64() / interval.as_secs_f64().max(0.001)).round() as u32;
+        Self {
+            proc_root: PathBuf::from("/proc"),
+            interval,
+            expected_samples: expected_samples.max(1),
+            wait_samples: HashMap::new(),
+            io_baselines: HashMap::new(),
+            warn_cooldown: DEFAULT_WARN_COOLDOWN,
+            max_iterations: None,
+            last_warned: HashMap::new(),
+            record_unhealthy: false,
+            incident_store: None,
+        }
+    }
+
+    /// Points the monitor at a fixture tree instead of the live `/proc`.
+    /// Test-only in practice; mirrors the other monitors.
+    pub fn with_proc_root(mut self, root: impl Into<PathBuf>) -> Self {
+        self.proc_root = root.into();
+        self
+    }
+
+    /// Bounds the scan loop so it terminates. Only useful for tests.
+    pub fn with_max_iterations(mut self, iterations: u64) -> Self {
+        self.max_iterations = Some(iterations);
+        self
+    }
+
+    /// Quiet period between repeat warnings for the same victim+verdict.
+    /// `Duration::ZERO` warns on every occurrence (useful for tests).
+    pub fn with_warn_cooldown(mut self, cooldown: Duration) -> Self {
+        self.warn_cooldown = cooldown;
+        self
+    }
+
+    /// Records findings as `blkio_stall` incidents so they surface through
+    /// `/incidents` and the MCP tools, not just the daemon logs. Takes
+    /// `Option` to mirror the other monitors: the store may be unavailable
+    /// (no DB path), in which case the monitor stays log-only.
+    pub fn with_incident_store(mut self, store: Option<Arc<IncidentStore>>) -> Self {
+        self.incident_store = store;
+        self
+    }
+
+    /// Log-reporting gate: true the first time a victim reports a given
+    /// verdict, and again once the cooldown has elapsed. A verdict *change*
+    /// for the same victim always reports. This gates the log line only —
+    /// incident recording is decided separately against the store (see
+    /// `handle_finding`), so a failed insert is retried on the next scan
+    /// instead of being swallowed by this cooldown.
+    fn should_warn(&mut self, finding: &BlkioStall) -> bool {
+        if self.warn_cooldown.is_zero() {
+            return true;
+        }
+        let key = (finding.victim_label(), finding.verdict);
+        let now = Instant::now();
+        if let Some(last) = self.last_warned.get(&key)
+            && now.duration_since(*last) < self.warn_cooldown
+        {
+            return false;
+        }
+        if self.last_warned.len() >= MAX_COOLDOWN_ENTRIES {
+            let cooldown = self.warn_cooldown;
+            self.last_warned
+                .retain(|_, last| now.duration_since(*last) < cooldown);
+            // Expiry frees nothing when every entry is still inside its
+            // cooldown; evict the oldest instead so the map stays bounded.
+            // Mirrors the other monitors' cap discipline.
+            while self.last_warned.len() >= MAX_COOLDOWN_ENTRIES {
+                let Some(oldest) = self
+                    .last_warned
+                    .iter()
+                    .min_by_key(|(_, last)| **last)
+                    .map(|(k, _)| k.clone())
+                else {
+                    break;
+                };
+                self.last_warned.remove(&oldest);
+            }
+        }
+        self.last_warned.insert(key, now);
+        true
+    }
+
+    /// One poll: sample every process's `wchan`, maintain the suspect
+    /// windows, and return a finding for the worst block-IO waiter when it
+    /// is actionable.
+    pub fn tick(&mut self) -> Option<BlkioStall> {
+        self.tick_at(Instant::now())
+    }
+
+    fn tick_at(&mut self, now: Instant) -> Option<BlkioStall> {
+        // 1. Sample wchan for every process; record block-wait sightings.
+        for pid in list_pids(&self.proc_root) {
+            let wchan = read_wchan(&self.proc_root, pid).unwrap_or_default();
+            if let Some(kind) = blkio_wait_kind(&wchan) {
+                self.wait_samples
+                    .entry(pid)
+                    .or_default()
+                    .push_back((now, kind));
+            }
+        }
+
+        // 2. IO cross-check, suspects only: fold this poll's counters into
+        // the baseline. A regressing counter means the PID was recycled:
+        // re-baseline instead of fabricating a negative delta.
+        let suspects: Vec<u32> = self.wait_samples.keys().copied().collect();
+        for pid in suspects {
+            let Some((r, w)) = read_io_bytes(&self.proc_root, pid) else {
+                continue;
+            };
+            match self.io_baselines.get_mut(&pid) {
+                Some(baseline) => {
+                    if r < baseline.last_read || w < baseline.last_write {
+                        debug!("[blkio] io counters regressed for pid={pid}; re-baselining");
+                        *baseline = IoBaseline {
+                            first_read: r,
+                            first_write: w,
+                            last_read: r,
+                            last_write: w,
+                        };
+                    } else {
+                        baseline.last_read = r;
+                        baseline.last_write = w;
+                    }
+                }
+                None => {
+                    self.io_baselines.insert(
+                        pid,
+                        IoBaseline {
+                            first_read: r,
+                            first_write: w,
+                            last_read: r,
+                            last_write: w,
+                        },
+                    );
+                }
+            }
+        }
+
+        // 3. Age out samples older than the window; forget processes with
+        // nothing left (exited, or quiet again) so state stays bounded.
+        let cutoff = now.checked_sub(WINDOW).unwrap_or(now);
+        let mut empty_pids = Vec::new();
+        for (pid, samples) in self.wait_samples.iter_mut() {
+            while samples.front().is_some_and(|&(t, _)| t < cutoff) {
+                samples.pop_front();
+            }
+            if samples.is_empty() {
+                empty_pids.push(*pid);
+            }
+        }
+        for pid in empty_pids {
+            self.wait_samples.remove(&pid);
+            self.io_baselines.remove(&pid);
+        }
+
+        // 4. Rank suspects by wait fraction, normalized against the full
+        // window's expected samples — a process seen for only part of the
+        // window under-reports, never inflates.
+        let mut best: Option<(u32, f64)> = None;
+        for (&pid, samples) in &self.wait_samples {
+            let pct = samples.len() as f64 / f64::from(self.expected_samples) * 100.0;
+            if pct >= WARN_WAIT_PCT && best.is_none_or(|(_, b)| pct > b) {
+                best = Some((pid, pct));
+            }
+        }
+        let (pid, wait_pct) = best?;
+        let verdict = classify(wait_pct);
+        if !verdict.actionable() {
+            return None;
+        }
+        let samples = &self.wait_samples[&pid];
+        let wait_samples = samples.len() as u32;
+        let mut kind_counts: HashMap<&'static str, u32> = HashMap::new();
+        for &(_, kind) in samples.iter() {
+            *kind_counts.entry(kind).or_default() += 1;
+        }
+        let mut wchan_kinds: Vec<(String, u32)> = kind_counts
+            .into_iter()
+            .map(|(kind, n)| (kind.to_string(), n))
+            .collect();
+        wchan_kinds.sort_by_key(|a| std::cmp::Reverse(a.1));
+        wchan_kinds.truncate(TOP_WCHAN_KINDS);
+        let (io_read_bytes_delta, io_write_bytes_delta) = self
+            .io_baselines
+            .get(&pid)
+            .map(|b| {
+                (
+                    b.last_read.saturating_sub(b.first_read),
+                    b.last_write.saturating_sub(b.first_write),
+                )
+            })
+            .unwrap_or((0, 0));
+        Some(BlkioStall {
+            pid,
+            comm: read_comm(&self.proc_root, pid),
+            wait_pct,
+            window_secs: WINDOW.as_secs_f64(),
+            wait_samples,
+            expected_samples: self.expected_samples,
+            io_read_bytes_delta,
+            io_write_bytes_delta,
+            wchan_kinds,
+            verdict,
+        })
+    }
+
+    pub async fn run(mut self) {
+        info!("[blkio] starting block-IO stall monitor");
+        let mut iterations = 0u64;
+        loop {
+            if let Some(finding) = self.tick() {
+                self.handle_finding(&finding).await;
+            }
+            iterations += 1;
+            if let Some(max) = self.max_iterations
+                && iterations >= max
+            {
+                break;
+            }
+            sleep(self.interval).await;
+        }
+    }
+
+    /// Reports one actionable finding: log the warning and, when an incident
+    /// store is configured, record it.
+    ///
+    /// Logging rides `should_warn`'s cooldown — a stalled process is one log
+    /// line, not one per poll. Recording is gated only on the store itself,
+    /// which is the source of truth for what was persisted: the log
+    /// cooldown never suppresses a record attempt, so a transient insert
+    /// failure is retried on the next scan instead of vanishing for the
+    /// whole cooldown.
+    async fn handle_finding(&mut self, finding: &BlkioStall) {
+        if self.should_warn(finding) {
+            report(finding);
+        }
+        let recorded = self.recently_recorded_keys().await;
+        let key = (finding.victim_label(), format!("{:?}", finding.verdict));
+        if recorded.contains(&key) {
+            return;
+        }
+        self.record_incident(finding).await;
+    }
+
+    /// `(victim, verdict)` pairs already incidented within the cooldown
+    /// window. Empty when no store is configured; fail-open when the store
+    /// can't be read — a store that won't answer the dedup query probably
+    /// won't take the insert either, and a duplicate row beats a silently
+    /// dropped incident.
+    async fn recently_recorded_keys(&self) -> HashSet<(String, String)> {
+        let Some(store) = &self.incident_store else {
+            return HashSet::new();
+        };
+        match store
+            .recent_incident_keys("blkio_stall", self.warn_cooldown.as_secs())
+            .await
+        {
+            Ok(keys) => keys,
+            Err(e) => {
+                warn!("[blkio] couldn't check recent incidents: {e}");
+                HashSet::new()
+            }
+        }
+    }
+
+    /// Best-effort: a failing store must not break the monitoring loop.
+    /// The first failure logs at warn level; repeats stay at debug until a
+    /// record succeeds, since `handle_finding` retries the insert on every
+    /// scan while the stall continues.
+    async fn record_incident(&mut self, finding: &BlkioStall) {
+        let Some(store) = &self.incident_store else {
+            return;
+        };
+        let incident = incident_from_finding(finding);
+        match store.insert(&incident).await {
+            Ok(id) => {
+                debug!(
+                    "[blkio] recorded incident #{id} for {}",
+                    finding.victim_label()
+                );
+                self.record_unhealthy = false;
+            }
+            Err(e) => {
+                if self.record_unhealthy {
+                    debug!(
+                        "[blkio] still failing to record incident for {}: {e}",
+                        finding.victim_label()
+                    );
+                } else {
+                    warn!(
+                        "[blkio] failed to record incident for {}: {e}",
+                        finding.victim_label()
+                    );
+                    self.record_unhealthy = true;
+                }
+            }
+        }
+    }
+}
+
+/// Builds the `blkio_stall` incident row for one finding.
+///
+/// Field mapping, kept honest about what this monitor measures:
+/// * `psi_cpu` / `psi_memory` / `cpu_percent` / `load_avg` are host-level
+///   fields this monitor doesn't sample, so they're zero/empty; the
+///   triggering reading is the sampled block-wait fraction, carried in
+///   `system_snapshot`.
+/// * `target_pid` / `target_name` name the victim process.
+/// * The wait fraction is `inferred` (sampled wchan peeks, not delay
+///   accounting); the IO byte deltas are `measured` kernel counters.
+fn incident_from_finding(finding: &BlkioStall) -> Incident {
+    let wchan_kinds: Vec<serde_json::Value> = finding
+        .wchan_kinds
+        .iter()
+        .map(|(kind, n)| serde_json::json!({ "kind": kind, "samples": n }))
+        .collect();
+    let snapshot = serde_json::json!({
+        "pid": finding.pid,
+        "comm": finding.comm,
+        "blkio_wait_pct": finding.wait_pct,
+        "window_secs": finding.window_secs,
+        "wait_samples": finding.wait_samples,
+        "expected_samples": finding.expected_samples,
+        "io_read_bytes_delta": finding.io_read_bytes_delta,
+        "io_write_bytes_delta": finding.io_write_bytes_delta,
+        "wchan_kinds": wchan_kinds,
+        "source_tier": "polling",
+        "verdict": format!("{:?}", finding.verdict),
+        // wchan sampling is an inferred fraction; the io counters are
+        // measured. No bytes moving across the whole window while wchan
+        // says "waiting" is the hung-storage shape.
+        "evidence": {
+            "blkio_wait": "inferred",
+            "io_counters": "measured",
+        },
+    });
+    Incident {
+        id: None,
+        timestamp: chrono::Utc::now().timestamp(),
+        event_type: "blkio_stall".to_string(),
+        psi_cpu: 0.0,
+        psi_memory: 0.0,
+        cpu_percent: 0.0,
+        load_avg: String::new(),
+        action: "alert".to_string(),
+        target_pid: Some(finding.pid as i32),
+        target_name: Some(finding.victim_label()),
+        system_snapshot: serde_json::to_string(&snapshot).ok(),
+        llm_analysis: None,
+        llm_analyzed_at: None,
+        investigation: None,
+        recovery_time_ms: None,
+        psi_after: None,
+    }
+}
+
+/// One human- and agent-readable line per actionable finding. The wait
+/// fraction is `inferred`; the IO deltas are `measured` — the tags say
+/// which is which.
+fn report(finding: &BlkioStall) {
+    let victim = match finding.comm.as_deref() {
+        Some(comm) => format!("{comm} (pid={})", finding.pid),
+        None => format!("pid={}", finding.pid),
+    };
+    let io_note = if finding.io_read_bytes_delta == 0 && finding.io_write_bytes_delta == 0 {
+        "; no IO progress across the window — possible hung storage"
+    } else {
+        ""
+    };
+    match finding.verdict {
+        BlkioVerdict::BlkioWarning => warn!(
+            "[blkio] WARNING: process {victim} spent {:.0}% of the last {:.0}s in block-IO wait ({}/{} samples) [wait inferred, io counters measured]{io_note}",
+            finding.wait_pct, finding.window_secs, finding.wait_samples, finding.expected_samples,
+        ),
+        BlkioVerdict::BlkioCritical => warn!(
+            "[blkio] CRITICAL: process {victim} spent {:.0}% of the last {:.0}s in block-IO wait ({}/{} samples) — effectively stalled on storage [wait inferred, io counters measured]{io_note}",
+            finding.wait_pct, finding.window_secs, finding.wait_samples, finding.expected_samples,
+        ),
+        BlkioVerdict::Healthy => {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    /// A fake `/proc` tree: `<dir>/<pid>/{wchan,io,comm}`.
+    struct FakeProc {
+        dir: TempDir,
+    }
+
+    impl FakeProc {
+        fn new() -> Self {
+            Self {
+                dir: TempDir::new().unwrap(),
+            }
+        }
+
+        fn pid_dir(&self, pid: u32) -> PathBuf {
+            let d = self.dir.path().join(pid.to_string());
+            fs::create_dir_all(&d).unwrap();
+            d
+        }
+
+        /// (Re)places a process's wchan, io counters, and comm.
+        fn set_proc(&self, pid: u32, comm: &str, wchan: &str, read_bytes: u64, write_bytes: u64) {
+            let d = self.pid_dir(pid);
+            fs::write(d.join("wchan"), format!("{wchan}\n")).unwrap();
+            fs::write(
+                d.join("io"),
+                format!(
+                    "rchar: 0\nwchar: 0\nsyscr: 0\nsyscw: 0\nread_bytes: {read_bytes}\n\
+                     write_bytes: {write_bytes}\ncancelled_write_bytes: 0\n"
+                ),
+            )
+            .unwrap();
+            fs::write(d.join("comm"), format!("{comm}\n")).unwrap();
+        }
+
+        fn remove_pid(&self, pid: u32) {
+            fs::remove_dir_all(self.dir.path().join(pid.to_string())).unwrap();
+        }
+
+        fn monitor_with_interval(&self, interval: Duration) -> BlkioStallMonitor {
+            BlkioStallMonitor::new(interval).with_proc_root(self.dir.path())
+        }
+    }
+
+    fn warning_finding(comm: &str) -> BlkioStall {
+        BlkioStall {
+            pid: 4242,
+            comm: Some(comm.to_string()),
+            wait_pct: 60.0,
+            window_secs: 60.0,
+            wait_samples: 18,
+            expected_samples: 30,
+            io_read_bytes_delta: 1_000_000,
+            io_write_bytes_delta: 0,
+            wchan_kinds: vec![("io_schedule".to_string(), 18)],
+            verdict: BlkioVerdict::BlkioWarning,
+        }
+    }
+
+    #[test]
+    fn classify_matrix() {
+        assert_eq!(classify(0.0), BlkioVerdict::Healthy);
+        assert_eq!(classify(49.9), BlkioVerdict::Healthy);
+        assert_eq!(classify(50.0), BlkioVerdict::BlkioWarning);
+        assert_eq!(classify(79.9), BlkioVerdict::BlkioWarning);
+        assert_eq!(classify(80.0), BlkioVerdict::BlkioCritical);
+        assert_eq!(classify(100.0), BlkioVerdict::BlkioCritical);
+    }
+
+    #[test]
+    fn wchan_classification() {
+        // Block-layer waits.
+        for wchan in [
+            "io_schedule",
+            "io_schedule_timeout",
+            "wait_on_page_bit",
+            "wait_on_page_bit_killable",
+            "wait_on_page_writeback",
+            "blkdev_issue_flush",
+            "blkdev_issue_zeroout",
+            "get_request",
+            "get_request_wait",
+        ] {
+            assert!(
+                blkio_wait_kind(wchan).is_some(),
+                "{wchan} must classify as block-IO wait"
+            );
+        }
+        // Everything else is not block-IO wait.
+        for wchan in [
+            "0",
+            "",
+            "do_nanosleep",
+            "futex_wait_queue_me",
+            "poll_schedule_timeout",
+            "do_sys_poll",
+            "pipe_wait",
+            "ep_poll",
+        ] {
+            assert!(
+                blkio_wait_kind(wchan).is_none(),
+                "{wchan} must not classify as block-IO wait"
+            );
+        }
+    }
+
+    #[test]
+    fn warmup_under_reports_and_converges() {
+        // 6s poll => 10 expected samples per 60s window. Four wait samples
+        // are 40% — a short burst must not inflate into a verdict just
+        // because few samples exist yet.
+        let fake = FakeProc::new();
+        let mut mon = fake.monitor_with_interval(Duration::from_secs(6));
+        let t0 = Instant::now();
+        fake.set_proc(100, "backfill", "io_schedule", 1000, 0);
+        for i in 0..4 {
+            assert!(
+                mon.tick_at(t0 + Duration::from_secs(6 * i)).is_none(),
+                "4/10 samples (40%) must not fire during warm-up"
+            );
+            fake.set_proc(100, "backfill", "io_schedule", 1000 + 100 * i, 0);
+        }
+        // The fraction converges as the window fills: 5/10 = 50% warns.
+        fake.set_proc(100, "backfill", "io_schedule", 2000, 0);
+        let finding = mon
+            .tick_at(t0 + Duration::from_secs(24))
+            .expect("5/10 samples (50%) must warn");
+        assert_eq!(finding.verdict, BlkioVerdict::BlkioWarning);
+        assert!((finding.wait_pct - 50.0).abs() < 1e-9);
+        assert_eq!(finding.wait_samples, 5);
+        assert_eq!(finding.expected_samples, 10);
+    }
+
+    #[test]
+    fn sustained_wait_fires_critical() {
+        // 2s poll => 30 expected samples. A full window of block-IO wait
+        // is 100% — critical.
+        let fake = FakeProc::new();
+        let mut mon = fake.monitor_with_interval(Duration::from_secs(2));
+        let t0 = Instant::now();
+        let mut finding = None;
+        for i in 0..30 {
+            fake.set_proc(100, "backfill", "wait_on_page_bit", 1000 * i, 0);
+            finding = mon.tick_at(t0 + Duration::from_secs(2 * i));
+        }
+        let finding = finding.expect("30/30 samples must be critical");
+        assert_eq!(finding.verdict, BlkioVerdict::BlkioCritical);
+        assert!((finding.wait_pct - 100.0).abs() < 1e-9);
+        assert_eq!(finding.pid, 100);
+        assert_eq!(finding.comm.as_deref(), Some("backfill"));
+        // The IO cross-check rode along: bytes moved while waiting.
+        assert!(finding.io_read_bytes_delta > 0);
+        assert_eq!(
+            finding.wchan_kinds,
+            vec![("wait_on_page".to_string(), 30)],
+            "the observed wchan kind must be reported"
+        );
+    }
+
+    #[test]
+    fn io_counters_not_moving_is_visible() {
+        // wchan says "waiting" but no bytes move across the whole window:
+        // the hung-storage shape. The finding still fires; the snapshot
+        // carries the zero deltas so consumers can tell.
+        let fake = FakeProc::new();
+        let mut mon = fake.monitor_with_interval(Duration::from_secs(2));
+        let t0 = Instant::now();
+        let mut finding = None;
+        for i in 0..30 {
+            fake.set_proc(100, "stuck", "io_schedule", 0, 0);
+            finding = mon.tick_at(t0 + Duration::from_secs(2 * i));
+        }
+        let finding = finding.expect("must fire");
+        assert_eq!(finding.io_read_bytes_delta, 0);
+        assert_eq!(finding.io_write_bytes_delta, 0);
+    }
+
+    #[test]
+    fn io_counter_regression_rebaselines() {
+        let fake = FakeProc::new();
+        let mut mon = fake.monitor_with_interval(Duration::from_secs(2));
+        let t0 = Instant::now();
+        fake.set_proc(100, "backfill", "io_schedule", 10_000, 0);
+        mon.tick_at(t0);
+        // PID recycled: counters start over. Must not fabricate a negative
+        // delta or panic.
+        fake.set_proc(100, "backfill", "io_schedule", 500, 0);
+        mon.tick_at(t0 + Duration::from_secs(2));
+        fake.set_proc(100, "backfill", "io_schedule", 1500, 0);
+        let finding = mon.tick_at(t0 + Duration::from_secs(4));
+        // Only 3 samples so far: 10% — no finding, but also no panic and
+        // the baseline recovered. Drive to a full window and check the
+        // delta is measured from the re-baselined counters.
+        assert!(finding.is_none());
+        for i in 3..30 {
+            fake.set_proc(100, "backfill", "io_schedule", 1500 + 100 * i, 0);
+            mon.tick_at(t0 + Duration::from_secs(2 * i));
+        }
+        // One more tick to get the finding with the final counters.
+        fake.set_proc(100, "backfill", "io_schedule", 1500 + 100 * 29, 0);
+        let finding = mon
+            .tick_at(t0 + Duration::from_secs(60))
+            .expect("must fire");
+        assert_eq!(
+            finding.io_read_bytes_delta, 3900,
+            "delta must be measured from the re-baselined counters"
+        );
+    }
+
+    #[test]
+    fn stale_samples_age_out_and_processes_are_forgotten() {
+        let fake = FakeProc::new();
+        let mut mon = fake.monitor_with_interval(Duration::from_secs(6));
+        let t0 = Instant::now();
+        // 5 wait samples => 50% => warning.
+        for i in 0..5 {
+            fake.set_proc(100, "backfill", "io_schedule", 1000, 0);
+            mon.tick_at(t0 + Duration::from_secs(6 * i));
+        }
+        assert!(!mon.wait_samples.is_empty());
+        // The process goes quiet (running, not waiting). Its windowed
+        // samples keep it actionable for a while — it really did spend
+        // half the window in block-IO wait — but once every sample ages
+        // past the 60s window the finding must stop, and the process must
+        // be forgotten. Samples land at t=0..24, so t>=84 is fully aged.
+        for i in 5..20 {
+            fake.set_proc(100, "backfill", "0", 1000, 0);
+            let finding = mon.tick_at(t0 + Duration::from_secs(6 * i));
+            if i >= 14 {
+                assert!(
+                    finding.is_none(),
+                    "aged-out samples must not fire (t={}s)",
+                    6 * i
+                );
+            }
+        }
+        assert!(
+            mon.wait_samples.is_empty() && mon.io_baselines.is_empty(),
+            "quiet processes must be forgotten, keeping state bounded"
+        );
+        // The process exits entirely: same outcome, no panic.
+        fake.remove_pid(100);
+        assert!(mon.tick_at(t0 + Duration::from_secs(200)).is_none());
+    }
+
+    #[test]
+    fn unknown_comm_when_comm_unreadable() {
+        let fake = FakeProc::new();
+        let mut mon = fake.monitor_with_interval(Duration::from_secs(6));
+        let t0 = Instant::now();
+        // wchan + io present, comm missing: the rate still fires, the
+        // victim is honestly unknown.
+        for i in 0..10 {
+            let d = fake.pid_dir(200);
+            fs::write(d.join("wchan"), "io_schedule\n").unwrap();
+            fs::write(
+                d.join("io"),
+                "rchar: 0\nwchar: 0\nsyscr: 0\nsyscw: 0\nread_bytes: 100\nwrite_bytes: 0\ncancelled_write_bytes: 0\n",
+            )
+            .unwrap();
+            let finding = mon.tick_at(t0 + Duration::from_secs(6 * i));
+            if i == 9 {
+                let finding = finding.expect("10/10 must fire");
+                assert_eq!(finding.comm, None);
+                assert_eq!(finding.victim_label(), "unknown");
+            }
+        }
+    }
+
+    #[test]
+    fn warn_cooldown_dedups_repeat_verdicts() {
+        let mut mon = BlkioStallMonitor::new(Duration::from_secs(2));
+        let finding = warning_finding("backfill");
+        assert!(mon.should_warn(&finding), "first occurrence must warn");
+        assert!(
+            !mon.should_warn(&finding),
+            "immediate repeat must be cooled down"
+        );
+        // A verdict change for the same victim is new information.
+        let escalated = BlkioStall {
+            verdict: BlkioVerdict::BlkioCritical,
+            ..warning_finding("backfill")
+        };
+        assert!(mon.should_warn(&escalated));
+        // A different victim is unaffected.
+        assert!(mon.should_warn(&warning_finding("other")));
+    }
+
+    #[test]
+    fn warn_cooldown_expires() {
+        let mut mon = BlkioStallMonitor::new(Duration::from_secs(2))
+            .with_warn_cooldown(Duration::from_millis(30));
+        let finding = warning_finding("backfill");
+        assert!(mon.should_warn(&finding));
+        assert!(!mon.should_warn(&finding));
+        std::thread::sleep(Duration::from_millis(60));
+        assert!(mon.should_warn(&finding), "cooldown must expire");
+    }
+
+    #[test]
+    fn zero_warn_cooldown_warns_every_time() {
+        let mut mon =
+            BlkioStallMonitor::new(Duration::from_secs(2)).with_warn_cooldown(Duration::ZERO);
+        let finding = warning_finding("backfill");
+        assert!(mon.should_warn(&finding));
+        assert!(mon.should_warn(&finding));
+    }
+
+    #[test]
+    fn warn_cooldown_map_is_bounded() {
+        let mut mon = BlkioStallMonitor::new(Duration::from_secs(2))
+            .with_warn_cooldown(Duration::from_secs(3600));
+        for i in 0..(MAX_COOLDOWN_ENTRIES + 50) {
+            let finding = warning_finding(&format!("backfill-{i}"));
+            assert!(mon.should_warn(&finding), "new victim must warn");
+        }
+        assert!(
+            mon.last_warned.len() <= MAX_COOLDOWN_ENTRIES,
+            "cooldown map grew past its cap: {}",
+            mon.last_warned.len()
+        );
+    }
+
+    #[test]
+    fn incident_from_finding_maps_fields() {
+        let finding = BlkioStall {
+            pid: 4242,
+            comm: Some("backfill".to_string()),
+            wait_pct: 85.0,
+            window_secs: 60.0,
+            wait_samples: 26,
+            expected_samples: 30,
+            io_read_bytes_delta: 5_000_000,
+            io_write_bytes_delta: 1000,
+            wchan_kinds: vec![("io_schedule".to_string(), 26)],
+            verdict: BlkioVerdict::BlkioCritical,
+        };
+        let incident = incident_from_finding(&finding);
+        assert_eq!(incident.event_type, "blkio_stall");
+        assert_eq!(incident.action, "alert");
+        assert_eq!(incident.target_pid, Some(4242));
+        assert_eq!(incident.target_name.as_deref(), Some("backfill"));
+        // Host-level fields this monitor doesn't sample stay zero/empty;
+        // the triggering reading lives in the snapshot.
+        assert_eq!(incident.psi_cpu, 0.0);
+        assert_eq!(incident.cpu_percent, 0.0);
+        let snapshot: serde_json::Value =
+            serde_json::from_str(incident.system_snapshot.as_deref().unwrap()).unwrap();
+        assert_eq!(snapshot["verdict"], "BlkioCritical");
+        assert_eq!(snapshot["source_tier"], "polling");
+        assert!((snapshot["blkio_wait_pct"].as_f64().unwrap() - 85.0).abs() < 1e-9);
+        assert_eq!(snapshot["io_read_bytes_delta"], 5_000_000);
+        assert_eq!(snapshot["wchan_kinds"][0]["kind"], "io_schedule");
+        // The wait fraction is inferred (sampled peeks); the IO deltas are
+        // measured kernel counters.
+        assert_eq!(snapshot["evidence"]["blkio_wait"], "inferred");
+        assert_eq!(snapshot["evidence"]["io_counters"], "measured");
+    }
+
+    #[tokio::test]
+    async fn finding_is_recorded_as_incident() {
+        let fake = FakeProc::new();
+        let db_dir = tempfile::tempdir().unwrap();
+        let store = Arc::new(
+            IncidentStore::new(db_dir.path().join("incidents.db"))
+                .await
+                .unwrap(),
+        );
+        let mut mon = fake
+            .monitor_with_interval(Duration::from_secs(2))
+            .with_incident_store(Some(Arc::clone(&store)));
+        let t0 = Instant::now();
+        let mut finding = None;
+        for i in 0..30 {
+            fake.set_proc(100, "backfill", "io_schedule", 1000 * i, 0);
+            finding = mon.tick_at(t0 + Duration::from_secs(2 * i));
+        }
+        let finding = finding.expect("must fire");
+        mon.handle_finding(&finding).await;
+
+        let incidents = store
+            .recent_filtered(10, Some("blkio_stall"), None)
+            .await
+            .unwrap();
+        assert_eq!(incidents.len(), 1, "one finding, one incident");
+        assert_eq!(incidents[0].event_type, "blkio_stall");
+        assert_eq!(incidents[0].target_name.as_deref(), Some("backfill"));
+
+        // The store already has this finding: handling it again must not
+        // write a second row. Recording is decided against the store, not
+        // the log cooldown.
+        mon.handle_finding(&finding).await;
+        let incidents = store
+            .recent_filtered(10, Some("blkio_stall"), None)
+            .await
+            .unwrap();
+        assert_eq!(
+            incidents.len(),
+            1,
+            "repeat findings must not duplicate incidents"
+        );
+
+        // A fresh monitor — the daemon restarted, so the bounded in-memory
+        // cooldown map is empty — must not re-record either.
+        let mut mon2 = fake
+            .monitor_with_interval(Duration::from_secs(2))
+            .with_incident_store(Some(Arc::clone(&store)));
+        let mut finding2 = None;
+        for i in 0..30 {
+            fake.set_proc(100, "backfill", "io_schedule", 1000 * i, 0);
+            finding2 = mon2.tick_at(t0 + Duration::from_secs(2 * i));
+        }
+        let finding2 = finding2.expect("must fire");
+        mon2.handle_finding(&finding2).await;
+        let incidents = store
+            .recent_filtered(10, Some("blkio_stall"), None)
+            .await
+            .unwrap();
+        assert_eq!(
+            incidents.len(),
+            1,
+            "a restarted monitor must not duplicate incidents the store already has"
+        );
+    }
+
+    #[tokio::test]
+    async fn failed_insert_is_retried_on_the_next_scan() {
+        let db_dir = tempfile::tempdir().unwrap();
+        let db_path = db_dir.path().join("incidents.db");
+        let finding = warning_finding("backfill");
+
+        // The store is down: the finding is logged, but the failed insert
+        // must not poison future record attempts — recording has no
+        // in-memory cooldown, only the store's own contents.
+        let down_store = Arc::new(IncidentStore::new(&db_path).await.unwrap());
+        down_store.close_pool_for_test().await;
+        let mut mon = BlkioStallMonitor::new(Duration::from_secs(2))
+            .with_incident_store(Some(Arc::clone(&down_store)));
+        mon.handle_finding(&finding).await;
+
+        // The store recovers (fresh pool on the same file). The next scan
+        // must retry the insert instead of sitting out a cooldown.
+        let up_store = Arc::new(IncidentStore::new(&db_path).await.unwrap());
+        mon.incident_store = Some(Arc::clone(&up_store));
+        mon.handle_finding(&finding).await;
+        let incidents = up_store
+            .recent_filtered(10, Some("blkio_stall"), None)
+            .await
+            .unwrap();
+        assert_eq!(
+            incidents.len(),
+            1,
+            "a failed insert must be retried once the store recovers"
+        );
+
+        // And the now-recorded finding dedups against the store: no second row.
+        mon.handle_finding(&finding).await;
+        let incidents = up_store
+            .recent_filtered(10, Some("blkio_stall"), None)
+            .await
+            .unwrap();
+        assert_eq!(incidents.len(), 1, "a recorded finding must not duplicate");
+    }
+
+    #[tokio::test]
+    async fn monitor_without_store_stays_log_only() {
+        // No incident store configured: handle_finding must not fail, just log.
+        let mut mon =
+            BlkioStallMonitor::new(Duration::from_secs(2)).with_warn_cooldown(Duration::ZERO);
+        mon.handle_finding(&warning_finding("backfill")).await;
+    }
+}

--- a/cognitod/src/collectors/mod.rs
+++ b/cognitod/src/collectors/mod.rs
@@ -1,3 +1,5 @@
+pub mod blkio_stall;
 pub mod cgroup_pressure;
 pub mod fork_storm;
 pub mod psi;
+pub mod runqueue_starvation;

--- a/cognitod/src/collectors/runqueue_starvation.rs
+++ b/cognitod/src/collectors/runqueue_starvation.rs
@@ -1,0 +1,1192 @@
+//! Userspace runqueue-starvation detector: no eBPF, no privileges beyond /proc.
+//!
+//! A thread that is runnable but not running is waiting on a runqueue —
+//! somebody else's threads are eating its CPU. The kernel accounts exactly
+//! this in `/proc/<pid>/task/<tid>/schedstat` (`runqueue_wait_ns`), so the
+//! victim side of CPU starvation is a *measured* number from userspace.
+//!
+//! Design:
+//!
+//! * **Signal (measured):** per-thread `schedstat` Δ over a 10s sliding
+//!   window ⇒ ms each thread spent waiting for a CPU. Polled every 5s.
+//!   Warn at >= 2000 ms waited per 10s window (20% of a CPU's time spent
+//!   waiting), critical at >= 5000 ms (50%). Thresholds are grounded in a
+//!   quick experiment on a 2-CPU sandbox: an uncontended spinner waited
+//!   ~31 ms / 5s, while the same spinner against 4 hogs waited ~6514 ms /
+//!   10s — the thresholds sit cleanly between idle noise and real
+//!   saturation.
+//! * **Cost bound:** `schedstat` is read only for the threads of the top-50
+//!   processes by recent CPU time (`utime+stime` Δ from `/proc/<pid>/stat`,
+//!   per the spec). One cheap `stat` read per process ranks the field;
+//!   only the top-50's threads pay the `schedstat` read. In-memory baselines
+//!   still scale with thread count but are pruned after 60s idle.
+//! * **Coverage tradeoff, stated plainly:** a thread whose process falls
+//!   outside the top-50 isn't measured on that poll. In practice the
+//!   population most likely to starve *is* the CPU-hungry one — starving
+//!   threads are runnable threads competing for CPUs — and ranking is at
+//!   process granularity, so a fully-starved thread is still measured while
+//!   any sibling thread burns CPU. Threads of genuinely idle processes
+//!   can't meaningfully starve: they weren't trying to run.
+//! * **Warm-up honesty:** the window wait is the raw Δ in ms — it is never
+//!   divided by a short warm-up span, so a partial window can only
+//!   *under*-report, never inflate into a verdict.
+//! * **Offender honesty:** offender identity ("whose threads preempted the
+//!   victim") needs `sched_switch` and is eBPF-only (spec §4). The incident
+//!   labels the offender `unavailable` and says so; correlate manually with
+//!   `cgroup_pressure` incidents for the `inferred` version.
+//! * **Degradation:** kernels without `CONFIG_SCHEDSTATS` have no readable
+//!   schedstat files. The monitor then disables itself (warns once, never
+//!   fabricates) and resumes if the files appear.
+//!
+//! Findings become `cpu_starvation` incidents via the same store-backed
+//! dedup discipline as the other monitors: the incident store — not the
+//! bounded in-memory warn map — is the source of truth for what was already
+//! persisted, so map eviction and daemon restarts cannot duplicate rows.
+
+use log::{debug, info, warn};
+use std::cmp::Ordering;
+use std::collections::{HashMap, HashSet, VecDeque};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+use tokio::time::sleep;
+
+use crate::incidents::{Incident, IncidentStore};
+
+/// Sliding window over which per-thread runqueue wait is accumulated.
+const WINDOW: Duration = Duration::from_secs(10);
+/// Wait at or above which a warning fires: 20% of a CPU's time in the
+/// window spent waiting on a runqueue (experiment-grounded, see above).
+const WARN_WAIT_MS: f64 = 2000.0;
+/// Wait at or above which a critical fires: 50% of the window waiting.
+const CRIT_WAIT_MS: f64 = 5000.0;
+/// Default quiet period between repeat warnings for the same victim+verdict,
+/// mirroring the other monitors.
+const DEFAULT_WARN_COOLDOWN: Duration = Duration::from_secs(15 * 60);
+/// Cap on the warn-cooldown map; oldest entries are evicted past this.
+const MAX_COOLDOWN_ENTRIES: usize = 1024;
+/// Baselines idle longer than this are dropped — the thread exited or the
+/// host went quiet; either way the memory shouldn't linger.
+const STALE_BASELINE: Duration = Duration::from_secs(60);
+/// How many of the worst waiters ride along in the incident snapshot for
+/// context. The finding itself names only the worst.
+const TOP_WAITERS_IN_SNAPSHOT: usize = 5;
+/// `schedstat` is read only for the threads of this many top processes by
+/// recent CPU time — the spec's cost bound for the 5s poll.
+const TOP_PROCESSES_BY_CPU: usize = 50;
+
+/// What a thread's measured runqueue wait means.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum StarvationVerdict {
+    Healthy,
+    /// Thread spent >= 20% of the window waiting for a CPU: something is
+    /// eating its share.
+    StarvationWarning,
+    /// Thread spent >= 50% of the window waiting: effectively starved.
+    StarvationCritical,
+}
+
+impl StarvationVerdict {
+    /// `false` for `Healthy`; used to filter log/report noise.
+    pub fn actionable(self) -> bool {
+        !matches!(self, StarvationVerdict::Healthy)
+    }
+}
+
+/// One actionable starvation finding for a scan window: the worst waiter.
+#[derive(Debug, Clone)]
+pub struct CpuStarvation {
+    /// The starving thread.
+    pub tid: u32,
+    /// Its thread-group leader (process).
+    pub tgid: u32,
+    pub comm: Option<String>,
+    /// Measured ms spent waiting on a runqueue inside the window.
+    pub wait_ms: f64,
+    /// Seconds the window covers.
+    pub window_secs: f64,
+    /// Worst waiters for snapshot context: `(tid, tgid, comm, wait_ms)`,
+    /// worst first, including this finding's victim at index 0.
+    pub top_waiters: Vec<(u32, u32, Option<String>, f64)>,
+    pub verdict: StarvationVerdict,
+}
+
+impl CpuStarvation {
+    /// Stable identity for cooldown and incident-dedup keys. TIDs recycle;
+    /// the command name is the identity that survives.
+    fn victim_label(&self) -> String {
+        self.comm.clone().unwrap_or_else(|| "unknown".to_string())
+    }
+}
+
+fn classify(wait_ms: f64) -> StarvationVerdict {
+    if wait_ms >= CRIT_WAIT_MS {
+        StarvationVerdict::StarvationCritical
+    } else if wait_ms >= WARN_WAIT_MS {
+        StarvationVerdict::StarvationWarning
+    } else {
+        StarvationVerdict::Healthy
+    }
+}
+
+/// `(cpu_time_ns, runqueue_wait_ns)` from a `schedstat` file. Field order is
+/// `cpu_time_ns runqueue_wait_ns timeslices` (spec §6). `None` when the file
+/// is missing or unparseable — absence is not zero.
+fn read_schedstat(path: &Path) -> Option<(u64, u64)> {
+    let content = std::fs::read_to_string(path).ok()?;
+    let mut fields = content.split_whitespace();
+    let cpu_ns = fields.next()?.parse::<u64>().ok()?;
+    let wait_ns = fields.next()?.parse::<u64>().ok()?;
+    Some((cpu_ns, wait_ns))
+}
+
+/// `utime + stime` in clock ticks from `/proc/<pid>/stat` (fields 14, 15).
+/// `None` when the file is missing or unparseable — absence is not zero.
+/// The comm field may itself contain spaces and parentheses, so fields are
+/// split after the *last* `)`.
+fn read_stat_cputime(proc_root: &Path, pid: u32) -> Option<u64> {
+    let content = std::fs::read_to_string(proc_root.join(pid.to_string()).join("stat")).ok()?;
+    let after_comm = content.rfind(')')?;
+    let mut fields = content[after_comm + 1..].split_whitespace();
+    // fields[0] is field 3 (state); utime is field 14, stime field 15.
+    let utime = fields.nth(11)?.parse::<u64>().ok()?;
+    let stime = fields.next()?.parse::<u64>().ok()?;
+    Some(utime.saturating_add(stime))
+}
+
+/// Numeric `/proc` entries: the live PID set.
+fn list_pids(proc_root: &Path) -> Vec<u32> {
+    let mut out = Vec::new();
+    let Ok(entries) = std::fs::read_dir(proc_root) else {
+        return out;
+    };
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let Some(name_str) = name.to_str() else {
+            continue;
+        };
+        if let Ok(pid) = name_str.parse::<u32>() {
+            out.push(pid);
+        }
+    }
+    out
+}
+
+/// Top-N pids by CPU-time delta, highest first (ties: lowest pid first, so
+/// the choice is deterministic). Pure for testability.
+fn top_pids_by_cpu(deltas: &mut [(u32, u64)]) -> Vec<u32> {
+    deltas.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
+    deltas
+        .iter()
+        .take(TOP_PROCESSES_BY_CPU)
+        .map(|&(pid, _)| pid)
+        .collect()
+}
+/// Path to a per-thread proc file. The leader's files are also visible at
+/// the plain pid path (`/proc/<tgid>/schedstat` is the same file as
+/// `/proc/<tgid>/task/<tgid>/schedstat`), which doubles as the fallback
+/// when a `task` directory can't be listed.
+fn thread_file(proc_root: &Path, tgid: u32, tid: u32, name: &str) -> PathBuf {
+    if tid == tgid {
+        proc_root.join(tgid.to_string()).join(name)
+    } else {
+        proc_root
+            .join(tgid.to_string())
+            .join("task")
+            .join(tid.to_string())
+            .join(name)
+    }
+}
+
+fn read_task_comm(proc_root: &Path, tgid: u32, tid: u32) -> Option<String> {
+    std::fs::read_to_string(thread_file(proc_root, tgid, tid, "comm"))
+        .ok()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+}
+
+/// `(tgid, tid)` for every thread under `proc_root`. Falls back to the
+/// leader alone when a `task` directory can't be listed.
+fn list_threads(proc_root: &Path) -> Vec<(u32, u32)> {
+    let mut out = Vec::new();
+    let Ok(entries) = std::fs::read_dir(proc_root) else {
+        return out;
+    };
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let Some(name_str) = name.to_str() else {
+            continue;
+        };
+        let Ok(tgid) = name_str.parse::<u32>() else {
+            continue;
+        };
+        let task_dir = proc_root.join(name_str).join("task");
+        let Ok(task_entries) = std::fs::read_dir(&task_dir) else {
+            out.push((tgid, tgid));
+            continue;
+        };
+        let mut any = false;
+        for task_entry in task_entries.flatten() {
+            let task_name = task_entry.file_name();
+            let Some(task_str) = task_name.to_str() else {
+                continue;
+            };
+            let Ok(tid) = task_str.parse::<u32>() else {
+                continue;
+            };
+            out.push((tgid, tid));
+            any = true;
+        }
+        if !any {
+            out.push((tgid, tgid));
+        }
+    }
+    out
+}
+
+/// Per-thread wait baseline: enough history to Δ over the window.
+struct ThreadBaseline {
+    /// `(sampled_at, runqueue_wait_ns)` within the sliding window.
+    samples: VecDeque<(Instant, u64)>,
+    last_seen: Instant,
+}
+
+/// Stateful runqueue-starvation monitor.
+pub struct RunqueueStarvationMonitor {
+    proc_root: PathBuf,
+    interval: Duration,
+    wait_baselines: HashMap<u32, ThreadBaseline>,
+    /// Per-pid last `utime+stime` (ticks): ranks the next poll's top-50.
+    /// Rebuilt every poll; a pid absent one poll re-baselines at zero Δ.
+    cpu_baselines: HashMap<u32, u64>,
+    /// `None` until the first poll; `Some(false)` while schedstat is
+    /// unreadable (degraded, warns once).
+    schedstat_available: Option<bool>,
+    warn_cooldown: Duration,
+    max_iterations: Option<u64>,
+    /// When each victim+verdict was last warned about.
+    last_warned: HashMap<(String, StarvationVerdict), Instant>,
+    /// Whether the last incident-record attempt failed (warn-once, then
+    /// debug until a record succeeds — `handle_burst` retries every scan).
+    record_unhealthy: bool,
+    /// Where findings are recorded so they are visible through the API
+    /// and MCP tools, not just the daemon logs. `None` keeps the monitor
+    /// log-only.
+    incident_store: Option<Arc<IncidentStore>>,
+}
+
+impl RunqueueStarvationMonitor {
+    pub fn new(interval: Duration) -> Self {
+        Self {
+            proc_root: PathBuf::from("/proc"),
+            interval,
+            wait_baselines: HashMap::new(),
+            cpu_baselines: HashMap::new(),
+            schedstat_available: None,
+            warn_cooldown: DEFAULT_WARN_COOLDOWN,
+            max_iterations: None,
+            last_warned: HashMap::new(),
+            record_unhealthy: false,
+            incident_store: None,
+        }
+    }
+
+    /// Points the monitor at a fixture tree instead of the live `/proc`.
+    /// Test-only in practice; mirrors the other monitors.
+    pub fn with_proc_root(mut self, root: impl Into<PathBuf>) -> Self {
+        self.proc_root = root.into();
+        self
+    }
+
+    /// Bounds the scan loop so it terminates. Only useful for tests.
+    pub fn with_max_iterations(mut self, iterations: u64) -> Self {
+        self.max_iterations = Some(iterations);
+        self
+    }
+
+    /// Quiet period between repeat warnings for the same victim+verdict.
+    /// `Duration::ZERO` warns on every occurrence (useful for tests).
+    pub fn with_warn_cooldown(mut self, cooldown: Duration) -> Self {
+        self.warn_cooldown = cooldown;
+        self
+    }
+
+    /// Records findings as `cpu_starvation` incidents so they surface
+    /// through `/incidents` and the MCP tools, not just the daemon logs.
+    /// Takes `Option` to mirror the other monitors: the store may be
+    /// unavailable (no DB path), in which case the monitor stays log-only.
+    pub fn with_incident_store(mut self, store: Option<Arc<IncidentStore>>) -> Self {
+        self.incident_store = store;
+        self
+    }
+
+    /// Log-reporting gate: true the first time a victim reports a given
+    /// verdict, and again once the cooldown has elapsed. A verdict *change*
+    /// for the same victim always reports. This gates the log line only —
+    /// incident recording is decided separately against the store (see
+    /// `handle_finding`), so a failed insert is retried on the next scan
+    /// instead of being swallowed by this cooldown.
+    fn should_warn(&mut self, finding: &CpuStarvation) -> bool {
+        if self.warn_cooldown.is_zero() {
+            return true;
+        }
+        let key = (finding.victim_label(), finding.verdict);
+        let now = Instant::now();
+        if let Some(last) = self.last_warned.get(&key)
+            && now.duration_since(*last) < self.warn_cooldown
+        {
+            return false;
+        }
+        if self.last_warned.len() >= MAX_COOLDOWN_ENTRIES {
+            let cooldown = self.warn_cooldown;
+            self.last_warned
+                .retain(|_, last| now.duration_since(*last) < cooldown);
+            // Expiry frees nothing when every entry is still inside its
+            // cooldown; evict the oldest instead so the map stays bounded.
+            // Mirrors the other monitors' cap discipline.
+            while self.last_warned.len() >= MAX_COOLDOWN_ENTRIES {
+                let Some(oldest) = self
+                    .last_warned
+                    .iter()
+                    .min_by_key(|(_, last)| **last)
+                    .map(|(k, _)| k.clone())
+                else {
+                    break;
+                };
+                self.last_warned.remove(&oldest);
+            }
+        }
+        self.last_warned.insert(key, now);
+        true
+    }
+
+    /// Folds one poll's `runqueue_wait_ns` reading into the thread's
+    /// baseline and returns the measured wait (ms) accumulated inside the
+    /// window, or `None` until two samples exist. The wait is the raw Δ —
+    /// never divided by a short warm-up span, so a partial window can only
+    /// under-report, never inflate.
+    fn update_baseline(&mut self, tid: u32, now: Instant, wait_ns: u64) -> Option<f64> {
+        let baseline = self
+            .wait_baselines
+            .entry(tid)
+            .or_insert_with(|| ThreadBaseline {
+                samples: VecDeque::new(),
+                last_seen: now,
+            });
+        baseline.last_seen = now;
+        // A regressing cumulative counter means the TID was recycled (or
+        // the counter wrapped): drop the history and start over rather
+        // than fabricating a negative — or wildly positive — Δ.
+        if baseline
+            .samples
+            .back()
+            .is_some_and(|&(_, last)| wait_ns < last)
+        {
+            debug!("[runqueue] runqueue_wait_ns regressed for tid={tid}; re-baselining");
+            baseline.samples.clear();
+        }
+        baseline.samples.push_back((now, wait_ns));
+        let cutoff = now.checked_sub(WINDOW).unwrap_or(now);
+        while baseline.samples.front().is_some_and(|&(t, _)| t < cutoff) {
+            baseline.samples.pop_front();
+        }
+        let &(first_t, first_w) = baseline.samples.front()?;
+        let &(last_t, last_w) = baseline.samples.back()?;
+        // Distinct samples: `tick` always pushes a fresh `now`, but tests
+        // drive `tick_at` directly and may reuse a timestamp.
+        if baseline.samples.len() < 2 || last_t <= first_t {
+            return None;
+        }
+        Some(last_w.saturating_sub(first_w) as f64 / 1e6)
+    }
+
+    /// One poll: rank processes by recent CPU time, refresh the top-50's
+    /// threads' wait baselines, rank by window wait, and return a finding
+    /// for the worst waiter when it is actionable. The first sighting of a
+    /// thread only establishes its baseline.
+    pub fn tick(&mut self) -> Option<CpuStarvation> {
+        self.tick_at(Instant::now())
+    }
+
+    fn tick_at(&mut self, now: Instant) -> Option<CpuStarvation> {
+        // Phase 1: rank processes by CPU time consumed since the last poll
+        // (`utime+stime` Δ). A first sighting has no Δ yet and ranks zero —
+        // ranking converges from the second poll. Absence is not zero, so
+        // unreadable stat files simply don't rank.
+        let mut deltas: Vec<(u32, u64)> = Vec::new();
+        let mut cpu_now: HashMap<u32, u64> = HashMap::new();
+        for pid in list_pids(&self.proc_root) {
+            let Some(cputime) = read_stat_cputime(&self.proc_root, pid) else {
+                continue;
+            };
+            let last = self.cpu_baselines.get(&pid).copied().unwrap_or(cputime);
+            deltas.push((pid, cputime.saturating_sub(last)));
+            cpu_now.insert(pid, cputime);
+        }
+        self.cpu_baselines = cpu_now;
+        let top: HashSet<u32> = top_pids_by_cpu(&mut deltas).into_iter().collect();
+
+        // Phase 2: read schedstat only for the top-50's threads — the cost
+        // bound. Threads outside the top-50 aren't measured this poll;
+        // their baselines keep aging and are pruned after 60s idle.
+        let mut any_schedstat = false;
+        // `(tid, tgid, wait_ms)` for every measured thread with a
+        // measurable window.
+        let mut waiters: Vec<(u32, u32, f64)> = Vec::new();
+        for (tgid, tid) in list_threads(&self.proc_root) {
+            if !top.contains(&tgid) {
+                continue;
+            }
+            let sched_path = thread_file(&self.proc_root, tgid, tid, "schedstat");
+            let Some((_, wait_ns)) = read_schedstat(&sched_path) else {
+                continue;
+            };
+            any_schedstat = true;
+            if let Some(wait_ms) = self.update_baseline(tid, now, wait_ns) {
+                waiters.push((tid, tgid, wait_ms));
+            }
+        }
+
+        // Drop baselines for threads long gone so the map stays bounded.
+        // (Before the degradation early-return: an empty scan must still
+        // prune.)
+        self.wait_baselines
+            .retain(|_, b| now.duration_since(b.last_seen) < STALE_BASELINE);
+
+        // Degradation: no schedstat anywhere means CONFIG_SCHEDSTATS is
+        // off (or /proc is otherwise unusable). Disable findings — warn
+        // once, never fabricate — and resume if the files appear.
+        if !any_schedstat {
+            if self.schedstat_available != Some(false) {
+                warn!(
+                    "[runqueue] no readable schedstat files; CONFIG_SCHEDSTATS is likely off — \
+                     starvation detection disabled until they appear"
+                );
+            }
+            self.schedstat_available = Some(false);
+            return None;
+        }
+        if self.schedstat_available == Some(false) {
+            info!("[runqueue] schedstat readable again; starvation detection resumed");
+        }
+        self.schedstat_available = Some(true);
+
+        waiters.sort_by(|a, b| b.2.partial_cmp(&a.2).unwrap_or(Ordering::Equal));
+        let &(tid, tgid, wait_ms) = waiters.first()?;
+        let verdict = classify(wait_ms);
+        if !verdict.actionable() {
+            return None;
+        }
+        let top_waiters: Vec<(u32, u32, Option<String>, f64)> = waiters
+            .iter()
+            .take(TOP_WAITERS_IN_SNAPSHOT)
+            .map(|&(tid, tgid, wait_ms)| {
+                (
+                    tid,
+                    tgid,
+                    read_task_comm(&self.proc_root, tgid, tid),
+                    wait_ms,
+                )
+            })
+            .collect();
+        let comm = top_waiters.first().and_then(|(_, _, comm, _)| comm.clone());
+        Some(CpuStarvation {
+            tid,
+            tgid,
+            comm,
+            wait_ms,
+            window_secs: WINDOW.as_secs_f64(),
+            top_waiters,
+            verdict,
+        })
+    }
+
+    pub async fn run(mut self) {
+        info!("[runqueue] starting runqueue starvation monitor");
+        let mut iterations = 0u64;
+        loop {
+            if let Some(finding) = self.tick() {
+                self.handle_finding(&finding).await;
+            }
+            iterations += 1;
+            if let Some(max) = self.max_iterations
+                && iterations >= max
+            {
+                break;
+            }
+            sleep(self.interval).await;
+        }
+    }
+
+    /// Reports one actionable finding: log the warning and, when an incident
+    /// store is configured, record it.
+    ///
+    /// Logging rides `should_warn`'s cooldown — a starving thread is one log
+    /// line, not one per poll. Recording is gated only on the store itself,
+    /// which is the source of truth for what was persisted: the log
+    /// cooldown never suppresses a record attempt, so a transient insert
+    /// failure is retried on the next scan instead of vanishing for the
+    /// whole cooldown.
+    async fn handle_finding(&mut self, finding: &CpuStarvation) {
+        if self.should_warn(finding) {
+            report(finding);
+        }
+        let recorded = self.recently_recorded_keys().await;
+        let key = (finding.victim_label(), format!("{:?}", finding.verdict));
+        if recorded.contains(&key) {
+            return;
+        }
+        self.record_incident(finding).await;
+    }
+
+    /// `(victim, verdict)` pairs already incidented within the cooldown
+    /// window. Empty when no store is configured; fail-open when the store
+    /// can't be read — a store that won't answer the dedup query probably
+    /// won't take the insert either, and a duplicate row beats a silently
+    /// dropped incident.
+    async fn recently_recorded_keys(&self) -> HashSet<(String, String)> {
+        let Some(store) = &self.incident_store else {
+            return HashSet::new();
+        };
+        match store
+            .recent_incident_keys("cpu_starvation", self.warn_cooldown.as_secs())
+            .await
+        {
+            Ok(keys) => keys,
+            Err(e) => {
+                warn!("[runqueue] couldn't check recent incidents: {e}");
+                HashSet::new()
+            }
+        }
+    }
+
+    /// Best-effort: a failing store must not break the monitoring loop.
+    /// The first failure logs at warn level; repeats stay at debug until a
+    /// record succeeds, since `handle_finding` retries the insert on every
+    /// scan while the starvation continues.
+    async fn record_incident(&mut self, finding: &CpuStarvation) {
+        let Some(store) = &self.incident_store else {
+            return;
+        };
+        let incident = incident_from_finding(finding);
+        match store.insert(&incident).await {
+            Ok(id) => {
+                debug!(
+                    "[runqueue] recorded incident #{id} for {}",
+                    finding.victim_label()
+                );
+                self.record_unhealthy = false;
+            }
+            Err(e) => {
+                if self.record_unhealthy {
+                    debug!(
+                        "[runqueue] still failing to record incident for {}: {e}",
+                        finding.victim_label()
+                    );
+                } else {
+                    warn!(
+                        "[runqueue] failed to record incident for {}: {e}",
+                        finding.victim_label()
+                    );
+                    self.record_unhealthy = true;
+                }
+            }
+        }
+    }
+}
+
+/// Builds the `cpu_starvation` incident row for one finding.
+///
+/// Field mapping, kept honest about what this monitor measures:
+/// * `psi_cpu` / `psi_memory` / `cpu_percent` / `load_avg` are host-level
+///   fields this monitor doesn't sample, so they're zero/empty; the
+///   triggering reading is the runqueue wait, carried in `system_snapshot`.
+/// * `target_pid` / `target_name` name the *measured* victim thread.
+/// * The offender is `unavailable`: naming which threads preempted the
+///   victim needs eBPF `sched_switch` (spec §4). Correlate with
+///   `cgroup_pressure` incidents for the `inferred` version.
+fn incident_from_finding(finding: &CpuStarvation) -> Incident {
+    let top_waiters: Vec<serde_json::Value> = finding
+        .top_waiters
+        .iter()
+        .map(|(tid, tgid, comm, wait_ms)| {
+            serde_json::json!({
+                "tid": tid,
+                "tgid": tgid,
+                "comm": comm,
+                "wait_ms": wait_ms,
+            })
+        })
+        .collect();
+    let snapshot = serde_json::json!({
+        "tid": finding.tid,
+        "tgid": finding.tgid,
+        "comm": finding.comm,
+        "wait_ms": finding.wait_ms,
+        "window_secs": finding.window_secs,
+        "top_waiters": top_waiters,
+        "source_tier": "polling",
+        "verdict": format!("{:?}", finding.verdict),
+        // The victim's wait is a measured kernel counter; the offender is
+        // not identified — that needs eBPF.
+        "evidence": {
+            "runqueue_wait": "measured",
+            "offender": "unavailable",
+        },
+    });
+    Incident {
+        id: None,
+        timestamp: chrono::Utc::now().timestamp(),
+        event_type: "cpu_starvation".to_string(),
+        psi_cpu: 0.0,
+        psi_memory: 0.0,
+        cpu_percent: 0.0,
+        load_avg: String::new(),
+        action: "alert".to_string(),
+        target_pid: Some(finding.tid as i32),
+        target_name: Some(finding.victim_label()),
+        system_snapshot: serde_json::to_string(&snapshot).ok(),
+        llm_analysis: None,
+        llm_analyzed_at: None,
+        investigation: None,
+        recovery_time_ms: None,
+        psi_after: None,
+    }
+}
+
+/// One human- and agent-readable line per actionable finding. The wait is
+/// `measured`; no offender is named — the tag says which is which.
+fn report(finding: &CpuStarvation) {
+    let victim = match finding.comm.as_deref() {
+        Some(comm) => format!("{comm} (tid={})", finding.tid),
+        None => format!("tid={}", finding.tid),
+    };
+    let pct = finding.wait_ms / 1000.0 / finding.window_secs * 100.0;
+    match finding.verdict {
+        StarvationVerdict::StarvationWarning => warn!(
+            "[runqueue] WARNING: thread {victim} waited {:.0}ms for CPU over the last {:.0}s ({pct:.0}% of window) [wait measured, offender unavailable]",
+            finding.wait_ms, finding.window_secs
+        ),
+        StarvationVerdict::StarvationCritical => warn!(
+            "[runqueue] CRITICAL: thread {victim} waited {:.0}ms for CPU over the last {:.0}s ({pct:.0}% of window) — effectively starved [wait measured, offender unavailable]",
+            finding.wait_ms, finding.window_secs
+        ),
+        StarvationVerdict::Healthy => {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    /// A fake `/proc` tree: `<dir>/<pid>/task/<tid>/{schedstat,comm}`.
+    struct FakeProc {
+        dir: TempDir,
+    }
+
+    impl FakeProc {
+        fn new() -> Self {
+            Self {
+                dir: TempDir::new().unwrap(),
+            }
+        }
+
+        fn task_dir(&self, pid: u32, tid: u32) -> PathBuf {
+            let d = self
+                .dir
+                .path()
+                .join(pid.to_string())
+                .join("task")
+                .join(tid.to_string());
+            fs::create_dir_all(&d).unwrap();
+            d
+        }
+
+        /// (Re)places a thread's schedstat (cpu_ns fixed) and comm, plus a
+        /// default `<pid>/stat` (constant CPU time) so the process ranks.
+        /// Use `set_stat` afterwards for explicit CPU-time control.
+        fn set_thread(&self, pid: u32, tid: u32, comm: &str, wait_ns: u64) {
+            let d = self.task_dir(pid, tid);
+            fs::write(d.join("schedstat"), format!("1000000 {wait_ns} 7\n")).unwrap();
+            fs::write(d.join("comm"), format!("{comm}\n")).unwrap();
+            self.set_stat(pid, 1000, 0);
+            if pid == tid {
+                // The kernel aliases /proc/<tgid>/schedstat to
+                // /proc/<tgid>/task/<tgid>/schedstat; mirror the alias so
+                // the monitor reads what the fixture wrote.
+                let leader = self.dir.path().join(pid.to_string());
+                fs::write(leader.join("schedstat"), format!("1000000 {wait_ns} 7\n")).unwrap();
+                fs::write(leader.join("comm"), format!("{comm}\n")).unwrap();
+            }
+        }
+
+        /// (Re)places `<pid>/stat` with the given utime/stime (ticks).
+        /// Fields 14/15 are parsed after the last `)`; the comm may itself
+        /// contain parens.
+        fn set_stat(&self, pid: u32, utime: u64, stime: u64) {
+            let d = self.dir.path().join(pid.to_string());
+            fs::create_dir_all(&d).unwrap();
+            fs::write(
+                d.join("stat"),
+                format!(
+                    "{pid} (comm (with) parens) R 0 0 0 0 0 0 0 0 0 0 {utime} {stime} 0 0 0 0 0\n"
+                ),
+            )
+            .unwrap();
+        }
+
+        fn remove_pid(&self, pid: u32) {
+            fs::remove_dir_all(self.dir.path().join(pid.to_string())).unwrap();
+        }
+
+        fn monitor(&self) -> RunqueueStarvationMonitor {
+            RunqueueStarvationMonitor::new(Duration::from_secs(5)).with_proc_root(self.dir.path())
+        }
+    }
+
+    fn warning_finding(comm: &str) -> CpuStarvation {
+        CpuStarvation {
+            tid: 4242,
+            tgid: 4242,
+            comm: Some(comm.to_string()),
+            wait_ms: 2500.0,
+            window_secs: 10.0,
+            top_waiters: vec![(4242, 4242, Some(comm.to_string()), 2500.0)],
+            verdict: StarvationVerdict::StarvationWarning,
+        }
+    }
+
+    #[test]
+    fn classify_matrix() {
+        assert_eq!(classify(0.0), StarvationVerdict::Healthy);
+        assert_eq!(classify(1999.9), StarvationVerdict::Healthy);
+        assert_eq!(classify(2000.0), StarvationVerdict::StarvationWarning);
+        assert_eq!(classify(4999.9), StarvationVerdict::StarvationWarning);
+        assert_eq!(classify(5000.0), StarvationVerdict::StarvationCritical);
+        assert_eq!(classify(60_000.0), StarvationVerdict::StarvationCritical);
+    }
+
+    #[test]
+    fn first_tick_establishes_baseline() {
+        let fake = FakeProc::new();
+        fake.set_thread(1, 1, "init", 0);
+        let mut mon = fake.monitor();
+        assert!(
+            mon.tick_at(Instant::now()).is_none(),
+            "first sighting of a thread must be baseline-only"
+        );
+    }
+
+    #[test]
+    fn detects_warning_and_critical_waits() {
+        let t0 = Instant::now();
+        // 2500 ms waited over the 10s window -> warning.
+        let fake = FakeProc::new();
+        let mut mon = fake.monitor();
+        fake.set_thread(1, 7, "hungry", 0);
+        assert!(mon.tick_at(t0).is_none());
+        fake.set_thread(1, 7, "hungry", 1_250_000_000);
+        assert!(mon.tick_at(t0 + Duration::from_secs(5)).is_none());
+        fake.set_thread(1, 7, "hungry", 2_500_000_000);
+        let finding = mon
+            .tick_at(t0 + Duration::from_secs(10))
+            .expect("2500ms wait must warn");
+        assert_eq!(finding.verdict, StarvationVerdict::StarvationWarning);
+        assert!((finding.wait_ms - 2500.0).abs() < 1e-9);
+        assert_eq!(finding.tid, 7);
+        assert_eq!(finding.comm.as_deref(), Some("hungry"));
+
+        // 6000 ms waited over the window -> critical. The intermediate
+        // 5s poll already sees 3000 ms -> warning.
+        let fake = FakeProc::new();
+        let mut mon = fake.monitor();
+        fake.set_thread(1, 7, "hungry", 0);
+        assert!(mon.tick_at(t0).is_none());
+        fake.set_thread(1, 7, "hungry", 3_000_000_000);
+        let mid = mon
+            .tick_at(t0 + Duration::from_secs(5))
+            .expect("3000ms over 5s must warn");
+        assert_eq!(mid.verdict, StarvationVerdict::StarvationWarning);
+        fake.set_thread(1, 7, "hungry", 6_000_000_000);
+        let finding = mon
+            .tick_at(t0 + Duration::from_secs(10))
+            .expect("6000ms wait must be critical");
+        assert_eq!(finding.verdict, StarvationVerdict::StarvationCritical);
+    }
+
+    #[test]
+    fn warmup_does_not_inflate_partial_windows() {
+        // 1500 ms waited over the first 5s is reported as 1500 ms — not
+        // scaled up to a full window. A partial window can only
+        // under-report, never inflate into a verdict.
+        let fake = FakeProc::new();
+        fake.set_thread(1, 7, "hungry", 0);
+        let mut mon = fake.monitor();
+        let t0 = Instant::now();
+        assert!(mon.tick_at(t0).is_none());
+        fake.set_thread(1, 7, "hungry", 1_500_000_000);
+        assert!(
+            mon.tick_at(t0 + Duration::from_secs(5)).is_none(),
+            "a partial-window wait must not be scaled up into a warning"
+        );
+        // Once the window fills with a genuinely large wait, it fires.
+        fake.set_thread(1, 7, "hungry", 2_500_000_000);
+        let finding = mon
+            .tick_at(t0 + Duration::from_secs(10))
+            .expect("2500ms over the full window must warn");
+        assert_eq!(finding.verdict, StarvationVerdict::StarvationWarning);
+    }
+
+    #[test]
+    fn ranks_worst_waiter_first() {
+        let fake = FakeProc::new();
+        fake.set_thread(1, 7, "hungry", 0);
+        fake.set_thread(1, 8, "full", 0);
+        let mut mon = fake.monitor();
+        let t0 = Instant::now();
+        assert!(mon.tick_at(t0).is_none());
+        fake.set_thread(1, 7, "hungry", 4_000_000_000);
+        fake.set_thread(1, 8, "full", 100_000_000);
+        let finding = mon
+            .tick_at(t0 + Duration::from_secs(10))
+            .expect("worst waiter must fire");
+        assert_eq!(finding.tid, 7);
+        assert_eq!(finding.comm.as_deref(), Some("hungry"));
+        assert_eq!(finding.top_waiters.len(), 2);
+        assert_eq!(finding.top_waiters[0].0, 7);
+        assert_eq!(finding.top_waiters[1].0, 8);
+    }
+
+    #[test]
+    fn top_pids_by_cpu_ranking() {
+        // 60 processes with distinct deltas: the 50 highest win, highest
+        // first.
+        let mut deltas: Vec<(u32, u64)> = (1..=60).map(|pid| (pid, u64::from(pid))).collect();
+        let top = top_pids_by_cpu(&mut deltas);
+        assert_eq!(top.len(), 50);
+        assert_eq!(top[0], 60, "highest delta ranks first");
+        assert_eq!(top[49], 11, "the 50th-highest delta ranks last");
+        assert!(!top.contains(&10));
+        assert!(!top.contains(&1));
+
+        // Ties break by lowest pid, so the choice is deterministic.
+        let mut tied: Vec<(u32, u64)> = (1..=55).map(|pid| (pid, 100)).collect();
+        let top = top_pids_by_cpu(&mut tied);
+        assert_eq!(top.len(), 50);
+        assert_eq!(top[0], 1);
+        assert_eq!(top[49], 50);
+        assert!(!top.contains(&55));
+
+        // Fewer than 50 processes: everyone ranks, highest delta first.
+        let mut few: Vec<(u32, u64)> = vec![(7, 0), (3, 5)];
+        assert_eq!(top_pids_by_cpu(&mut few), vec![3, 7]);
+    }
+
+    #[test]
+    fn victim_outside_top50_is_not_measured() {
+        // 51 processes: pid 1's runqueue wait explodes to 6000 ms but it
+        // burns no CPU, while 50 others each burn CPU. Pid 1 falls outside
+        // the top-50, so its schedstat is never read and no finding fires.
+        // This is the documented coverage tradeoff of the cost bound.
+        let fake = FakeProc::new();
+        let mut mon = fake.monitor();
+        let t0 = Instant::now();
+        for pid in 1..=51u32 {
+            fake.set_thread(pid, pid, "worker", 0);
+            fake.set_stat(pid, 1000, 0);
+        }
+        assert!(mon.tick_at(t0).is_none());
+        for pid in 1..=51u32 {
+            fake.set_thread(pid, pid, "worker", if pid == 1 { 6_000_000_000 } else { 0 });
+            fake.set_stat(pid, 1000 + if pid == 1 { 0 } else { 1000 }, 0);
+        }
+        assert!(
+            mon.tick_at(t0 + Duration::from_secs(5)).is_none(),
+            "a starving thread outside the top-50 by CPU is not measured"
+        );
+    }
+
+    #[test]
+    fn victim_inside_top50_is_measured() {
+        // Same 51 processes, but the starving thread's process also burns
+        // the most CPU: it ranks in the top-50 and its 6000 ms wait fires
+        // critical.
+        let fake = FakeProc::new();
+        let mut mon = fake.monitor();
+        let t0 = Instant::now();
+        for pid in 1..=51u32 {
+            fake.set_thread(pid, pid, "worker", 0);
+            fake.set_stat(pid, 1000, 0);
+        }
+        assert!(mon.tick_at(t0).is_none());
+        for pid in 1..=51u32 {
+            fake.set_thread(pid, pid, "worker", if pid == 1 { 6_000_000_000 } else { 0 });
+            fake.set_stat(pid, 1000 + if pid == 1 { 2000 } else { 1000 }, 0);
+        }
+        let finding = mon
+            .tick_at(t0 + Duration::from_secs(5))
+            .expect("a top-50 victim's 6000ms wait must fire");
+        assert_eq!(finding.verdict, StarvationVerdict::StarvationCritical);
+        assert_eq!(finding.tid, 1);
+        assert!((finding.wait_ms - 6000.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn schedstat_absent_degrades_gracefully() {
+        // No schedstat files at all (CONFIG_SCHEDSTATS off): the monitor
+        // must never fabricate a finding.
+        let fake = FakeProc::new();
+        let mut mon = fake.monitor();
+        let t0 = Instant::now();
+        assert!(mon.tick_at(t0).is_none());
+        assert!(mon.tick_at(t0 + Duration::from_secs(5)).is_none());
+        assert_eq!(mon.schedstat_available, Some(false));
+        // Recovery: files appear later, detection resumes.
+        fake.set_thread(1, 7, "hungry", 0);
+        assert!(mon.tick_at(t0 + Duration::from_secs(10)).is_none());
+        assert_eq!(mon.schedstat_available, Some(true));
+        fake.set_thread(1, 7, "hungry", 6_000_000_000);
+        let finding = mon
+            .tick_at(t0 + Duration::from_secs(20))
+            .expect("detection must resume once schedstat appears");
+        assert_eq!(finding.verdict, StarvationVerdict::StarvationCritical);
+    }
+
+    #[test]
+    fn wait_counter_regression_rebaselines() {
+        let fake = FakeProc::new();
+        fake.set_thread(1, 7, "hungry", 5_000_000_000);
+        let mut mon = fake.monitor();
+        let t0 = Instant::now();
+        assert!(mon.tick_at(t0).is_none());
+        // Counter regressed (TID recycled or wrapped): re-baseline, don't
+        // fabricate a storm from the drop.
+        fake.set_thread(1, 7, "hungry", 1_000_000_000);
+        assert!(
+            mon.tick_at(t0 + Duration::from_secs(10)).is_none(),
+            "a regressing counter must re-baseline, not fire"
+        );
+        // The next window measures forward from the new baseline.
+        fake.set_thread(1, 7, "hungry", 4_000_000_000);
+        let finding = mon
+            .tick_at(t0 + Duration::from_secs(20))
+            .expect("3000ms after re-baseline must warn");
+        assert_eq!(finding.verdict, StarvationVerdict::StarvationWarning);
+    }
+
+    #[test]
+    fn stale_baselines_are_pruned() {
+        let fake = FakeProc::new();
+        fake.set_thread(1, 7, "hungry", 0);
+        let mut mon = fake.monitor();
+        let t0 = Instant::now();
+        assert!(mon.tick_at(t0).is_none());
+        assert_eq!(mon.wait_baselines.len(), 1);
+        // The thread exits; its baseline must not linger forever.
+        fake.remove_pid(1);
+        mon.tick_at(t0 + Duration::from_secs(61));
+        assert!(
+            mon.wait_baselines.is_empty(),
+            "baselines for long-gone threads must be pruned"
+        );
+    }
+
+    #[test]
+    fn warn_cooldown_dedups_repeat_verdicts() {
+        let mut mon = RunqueueStarvationMonitor::new(Duration::from_secs(5));
+        let finding = warning_finding("hungry");
+        assert!(mon.should_warn(&finding), "first occurrence must warn");
+        assert!(
+            !mon.should_warn(&finding),
+            "immediate repeat must be cooled down"
+        );
+        // A verdict change for the same victim is new information.
+        let escalated = CpuStarvation {
+            verdict: StarvationVerdict::StarvationCritical,
+            ..warning_finding("hungry")
+        };
+        assert!(mon.should_warn(&escalated));
+        // A different victim is unaffected.
+        assert!(mon.should_warn(&warning_finding("other")));
+    }
+
+    #[test]
+    fn warn_cooldown_expires() {
+        let mut mon = RunqueueStarvationMonitor::new(Duration::from_secs(5))
+            .with_warn_cooldown(Duration::from_millis(30));
+        let finding = warning_finding("hungry");
+        assert!(mon.should_warn(&finding));
+        assert!(!mon.should_warn(&finding));
+        std::thread::sleep(Duration::from_millis(60));
+        assert!(mon.should_warn(&finding), "cooldown must expire");
+    }
+
+    #[test]
+    fn zero_warn_cooldown_warns_every_time() {
+        let mut mon = RunqueueStarvationMonitor::new(Duration::from_secs(5))
+            .with_warn_cooldown(Duration::ZERO);
+        let finding = warning_finding("hungry");
+        assert!(mon.should_warn(&finding));
+        assert!(mon.should_warn(&finding));
+    }
+
+    #[test]
+    fn warn_cooldown_map_is_bounded() {
+        let mut mon = RunqueueStarvationMonitor::new(Duration::from_secs(5))
+            .with_warn_cooldown(Duration::from_secs(3600));
+        for i in 0..(MAX_COOLDOWN_ENTRIES + 50) {
+            let finding = warning_finding(&format!("hungry-{i}"));
+            assert!(mon.should_warn(&finding), "new victim must warn");
+        }
+        assert!(
+            mon.last_warned.len() <= MAX_COOLDOWN_ENTRIES,
+            "cooldown map grew past its cap: {}",
+            mon.last_warned.len()
+        );
+    }
+
+    #[test]
+    fn incident_from_finding_maps_fields() {
+        let finding = CpuStarvation {
+            tid: 4242,
+            tgid: 4200,
+            comm: Some("hungry".to_string()),
+            wait_ms: 6500.0,
+            window_secs: 10.0,
+            top_waiters: vec![
+                (4242, 4200, Some("hungry".to_string()), 6500.0),
+                (4243, 4200, Some("hungry".to_string()), 2100.0),
+            ],
+            verdict: StarvationVerdict::StarvationCritical,
+        };
+        let incident = incident_from_finding(&finding);
+        assert_eq!(incident.event_type, "cpu_starvation");
+        assert_eq!(incident.action, "alert");
+        assert_eq!(incident.target_pid, Some(4242));
+        assert_eq!(incident.target_name.as_deref(), Some("hungry"));
+        // Host-level fields this monitor doesn't sample stay zero/empty;
+        // the triggering reading lives in the snapshot.
+        assert_eq!(incident.psi_cpu, 0.0);
+        assert_eq!(incident.cpu_percent, 0.0);
+        let snapshot: serde_json::Value =
+            serde_json::from_str(incident.system_snapshot.as_deref().unwrap()).unwrap();
+        assert_eq!(snapshot["verdict"], "StarvationCritical");
+        assert_eq!(snapshot["source_tier"], "polling");
+        assert!((snapshot["wait_ms"].as_f64().unwrap() - 6500.0).abs() < 1e-9);
+        assert_eq!(snapshot["top_waiters"].as_array().unwrap().len(), 2);
+        // The victim's wait is measured; the offender is honestly
+        // unavailable — naming it needs eBPF.
+        assert_eq!(snapshot["evidence"]["runqueue_wait"], "measured");
+        assert_eq!(snapshot["evidence"]["offender"], "unavailable");
+    }
+
+    #[tokio::test]
+    async fn finding_is_recorded_as_incident() {
+        let fake = FakeProc::new();
+        let db_dir = tempfile::tempdir().unwrap();
+        let store = Arc::new(
+            IncidentStore::new(db_dir.path().join("incidents.db"))
+                .await
+                .unwrap(),
+        );
+        let mut mon = fake.monitor().with_incident_store(Some(Arc::clone(&store)));
+        let t0 = Instant::now();
+        fake.set_thread(1, 7, "hungry", 0);
+        assert!(mon.tick_at(t0).is_none());
+        fake.set_thread(1, 7, "hungry", 6_000_000_000);
+        let finding = mon
+            .tick_at(t0 + Duration::from_secs(10))
+            .expect("6000ms wait must be critical");
+        mon.handle_finding(&finding).await;
+
+        let incidents = store
+            .recent_filtered(10, Some("cpu_starvation"), None)
+            .await
+            .unwrap();
+        assert_eq!(incidents.len(), 1, "one finding, one incident");
+        assert_eq!(incidents[0].event_type, "cpu_starvation");
+        assert_eq!(incidents[0].target_name.as_deref(), Some("hungry"));
+
+        // The store already has this finding: handling it again must not
+        // write a second row. Recording is decided against the store, not
+        // the log cooldown.
+        mon.handle_finding(&finding).await;
+        let incidents = store
+            .recent_filtered(10, Some("cpu_starvation"), None)
+            .await
+            .unwrap();
+        assert_eq!(
+            incidents.len(),
+            1,
+            "repeat findings must not duplicate incidents"
+        );
+
+        // A fresh monitor — the daemon restarted, so the bounded in-memory
+        // cooldown map is empty — must not re-record either.
+        let mut mon2 = fake.monitor().with_incident_store(Some(Arc::clone(&store)));
+        assert!(mon2.tick_at(t0).is_none());
+        fake.set_thread(1, 7, "hungry", 12_000_000_000);
+        let finding2 = mon2
+            .tick_at(t0 + Duration::from_secs(10))
+            .expect("starvation must fire");
+        mon2.handle_finding(&finding2).await;
+        let incidents = store
+            .recent_filtered(10, Some("cpu_starvation"), None)
+            .await
+            .unwrap();
+        assert_eq!(
+            incidents.len(),
+            1,
+            "a restarted monitor must not duplicate incidents the store already has"
+        );
+    }
+
+    #[tokio::test]
+    async fn failed_insert_is_retried_on_the_next_scan() {
+        let db_dir = tempfile::tempdir().unwrap();
+        let db_path = db_dir.path().join("incidents.db");
+        let finding = warning_finding("hungry");
+
+        // The store is down: the finding is logged, but the failed insert
+        // must not poison future record attempts — recording has no
+        // in-memory cooldown, only the store's own contents.
+        let down_store = Arc::new(IncidentStore::new(&db_path).await.unwrap());
+        down_store.close_pool_for_test().await;
+        let mut mon = RunqueueStarvationMonitor::new(Duration::from_secs(5))
+            .with_incident_store(Some(Arc::clone(&down_store)));
+        mon.handle_finding(&finding).await;
+
+        // The store recovers (fresh pool on the same file). The next scan
+        // must retry the insert instead of sitting out a cooldown.
+        let up_store = Arc::new(IncidentStore::new(&db_path).await.unwrap());
+        mon.incident_store = Some(Arc::clone(&up_store));
+        mon.handle_finding(&finding).await;
+        let incidents = up_store
+            .recent_filtered(10, Some("cpu_starvation"), None)
+            .await
+            .unwrap();
+        assert_eq!(
+            incidents.len(),
+            1,
+            "a failed insert must be retried once the store recovers"
+        );
+
+        // And the now-recorded finding dedups against the store: no second row.
+        mon.handle_finding(&finding).await;
+        let incidents = up_store
+            .recent_filtered(10, Some("cpu_starvation"), None)
+            .await
+            .unwrap();
+        assert_eq!(incidents.len(), 1, "a recorded finding must not duplicate");
+    }
+
+    #[tokio::test]
+    async fn monitor_without_store_stays_log_only() {
+        // No incident store configured: handle_finding must not fail, just log.
+        let mut mon = RunqueueStarvationMonitor::new(Duration::from_secs(5))
+            .with_warn_cooldown(Duration::ZERO);
+        mon.handle_finding(&warning_finding("hungry")).await;
+    }
+}

--- a/cognitod/src/collectors/runqueue_starvation.rs
+++ b/cognitod/src/collectors/runqueue_starvation.rs
@@ -112,10 +112,17 @@ pub struct CpuStarvation {
 }
 
 impl CpuStarvation {
-    /// Stable identity for cooldown and incident-dedup keys. TIDs recycle;
-    /// the command name is the identity that survives.
+    /// Stable identity for cooldown and incident-dedup keys: the victim
+    /// thread plus its command name. TIDs are unique per thread
+    /// system-wide, so this distinguishes two `java` workers where a
+    /// comm-only key suppressed every same-named victim for the whole
+    /// cooldown. A recycled TID's counters regress, which re-baselines
+    /// the measurement — and the store keys the verdict to this identity,
+    /// so the new thread dedups against its own history, not another
+    /// victim's. The tgid rides along in the incident snapshot.
     fn victim_label(&self) -> String {
-        self.comm.clone().unwrap_or_else(|| "unknown".to_string())
+        let comm = self.comm.clone().unwrap_or_else(|| "unknown".to_string());
+        format!("{comm} (tid={}, tgid={})", self.tid, self.tgid)
     }
 }
 
@@ -365,6 +372,13 @@ impl RunqueueStarvationMonitor {
     /// window, or `None` until two samples exist. The wait is the raw Δ —
     /// never divided by a short warm-up span, so a partial window can only
     /// under-report, never inflate.
+    ///
+    /// The newest sample at or before the window cutoff is retained as
+    /// the baseline anchor: polls land slightly more than 5s apart (the
+    /// loop sleeps after each scan), so without the anchor the sample
+    /// from two polls ago ages just past the window and gets pruned —
+    /// leaving a ~5s delta reported as `window_secs = 10`, which can
+    /// misclassify a critical as a warning.
     fn update_baseline(&mut self, tid: u32, now: Instant, wait_ns: u64) -> Option<f64> {
         let baseline = self
             .wait_baselines
@@ -387,7 +401,12 @@ impl RunqueueStarvationMonitor {
         }
         baseline.samples.push_back((now, wait_ns));
         let cutoff = now.checked_sub(WINDOW).unwrap_or(now);
-        while baseline.samples.front().is_some_and(|&(t, _)| t < cutoff) {
+        // Prune aged samples but keep the anchor: pop the front only while
+        // the *second* sample is still at or before the cutoff, so the
+        // front remains the newest sample on or before the cutoff. When
+        // every sample has aged out, one anchor survives and the
+        // two-sample check below yields `None` until fresh data arrives.
+        while baseline.samples.len() > 1 && baseline.samples[1].0 <= cutoff {
             baseline.samples.pop_front();
         }
         let &(first_t, first_w) = baseline.samples.front()?;
@@ -840,6 +859,59 @@ mod tests {
     }
 
     #[test]
+    fn window_anchor_spans_full_window_at_uneven_poll_spacing() {
+        // Polls land 5.2s apart: the loop sleeps 5s *after* each scan and
+        // any incident handling. Without a baseline anchor, the t0 sample
+        // ages just past the 10s window on the third poll and gets pruned,
+        // leaving a ~5.2s delta reported as window_secs = 10 — a 5000ms
+        // critical misclassified as a warning. The anchor retains the
+        // newest sample at or before the cutoff, so the delta spans the
+        // full window.
+        let fake = FakeProc::new();
+        let mut mon = fake.monitor();
+        let t0 = Instant::now();
+        fake.set_thread(1, 7, "hungry", 0);
+        assert!(mon.tick_at(t0).is_none());
+        fake.set_thread(1, 7, "hungry", 2_500_000_000);
+        let mid = mon
+            .tick_at(t0 + Duration::from_millis(5200))
+            .expect("2500ms over 5.2s must warn");
+        assert_eq!(mid.verdict, StarvationVerdict::StarvationWarning);
+        fake.set_thread(1, 7, "hungry", 5_000_000_000);
+        let finding = mon
+            .tick_at(t0 + Duration::from_millis(10_400))
+            .expect("5000ms over the full window must fire");
+        assert_eq!(
+            finding.verdict,
+            StarvationVerdict::StarvationCritical,
+            "the window delta must span the full 10s, not just the last 5.2s"
+        );
+        assert!((finding.wait_ms - 5000.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn same_comm_victims_do_not_suppress_each_other() {
+        // Two threads sharing a comm (think `java` workers): the dedup
+        // identity includes the TID, so each victim warns on its own.
+        let mut mon = RunqueueStarvationMonitor::new(Duration::from_secs(5));
+        let a = CpuStarvation {
+            tid: 7,
+            tgid: 1,
+            ..warning_finding("worker")
+        };
+        let b = CpuStarvation {
+            tid: 8,
+            tgid: 1,
+            ..warning_finding("worker")
+        };
+        assert!(mon.should_warn(&a), "first victim must warn");
+        assert!(
+            mon.should_warn(&b),
+            "a different TID with the same comm must warn too"
+        );
+    }
+
+    #[test]
     fn ranks_worst_waiter_first() {
         let fake = FakeProc::new();
         fake.set_thread(1, 7, "hungry", 0);
@@ -1065,7 +1137,11 @@ mod tests {
         assert_eq!(incident.event_type, "cpu_starvation");
         assert_eq!(incident.action, "alert");
         assert_eq!(incident.target_pid, Some(4242));
-        assert_eq!(incident.target_name.as_deref(), Some("hungry"));
+        assert_eq!(
+            incident.target_name.as_deref(),
+            Some("hungry (tid=4242, tgid=4200)"),
+            "the incident identity names the victim thread, not just the comm"
+        );
         // Host-level fields this monitor doesn't sample stay zero/empty;
         // the triggering reading lives in the snapshot.
         assert_eq!(incident.psi_cpu, 0.0);
@@ -1107,7 +1183,10 @@ mod tests {
             .unwrap();
         assert_eq!(incidents.len(), 1, "one finding, one incident");
         assert_eq!(incidents[0].event_type, "cpu_starvation");
-        assert_eq!(incidents[0].target_name.as_deref(), Some("hungry"));
+        assert_eq!(
+            incidents[0].target_name.as_deref(),
+            Some("hungry (tid=7, tgid=1)")
+        );
 
         // The store already has this finding: handling it again must not
         // write a second row. Recording is decided against the store, not
@@ -1140,6 +1219,43 @@ mod tests {
             incidents.len(),
             1,
             "a restarted monitor must not duplicate incidents the store already has"
+        );
+    }
+
+    #[tokio::test]
+    async fn same_comm_victims_record_independently() {
+        // The store dedup key is (target_name, verdict) and the target
+        // name carries the TID: two same-comm victims are two identities,
+        // so both record — one `java` victim no longer suppresses the
+        // others for the whole cooldown.
+        let db_dir = tempfile::tempdir().unwrap();
+        let store = Arc::new(
+            IncidentStore::new(db_dir.path().join("incidents.db"))
+                .await
+                .unwrap(),
+        );
+        let mut mon = RunqueueStarvationMonitor::new(Duration::from_secs(5))
+            .with_incident_store(Some(Arc::clone(&store)));
+        let a = CpuStarvation {
+            tid: 7,
+            tgid: 1,
+            ..warning_finding("worker")
+        };
+        let b = CpuStarvation {
+            tid: 8,
+            tgid: 1,
+            ..warning_finding("worker")
+        };
+        mon.handle_finding(&a).await;
+        mon.handle_finding(&b).await;
+        let incidents = store
+            .recent_filtered(10, Some("cpu_starvation"), None)
+            .await
+            .unwrap();
+        assert_eq!(
+            incidents.len(),
+            2,
+            "same-comm victims are distinct incident identities"
         );
     }
 

--- a/cognitod/src/main.rs
+++ b/cognitod/src/main.rs
@@ -991,6 +991,38 @@ async fn main() -> Result<(), Box<dyn Error>> {
         });
     }
 
+    // Runqueue starvation monitor: per-thread schedstat runqueue-wait Δ
+    // over a 10s window, polled every 5s. The victim's wait is measured;
+    // offender identity is eBPF-only and stays unlabeled. Degrades
+    // gracefully on kernels without CONFIG_SCHEDSTATS.
+    {
+        let monitor = cognitod::collectors::runqueue_starvation::RunqueueStarvationMonitor::new(
+            std::time::Duration::from_secs(5),
+        )
+        // Starvation findings become queryable incidents for the API and
+        // MCP tools, not just log lines.
+        .with_incident_store(incident_store.clone());
+        tokio::spawn(async move {
+            monitor.run().await;
+        });
+    }
+
+    // Block-IO stall monitor: per-process wchan sampling (tier B) every 2s
+    // over a 60s window, cross-checked against /proc/<pid>/io deltas. The
+    // wait fraction is inferred (sampled peeks, not delay accounting);
+    // tier A (taskstats netlink) is the documented upgrade path.
+    {
+        let monitor = cognitod::collectors::blkio_stall::BlkioStallMonitor::new(
+            std::time::Duration::from_secs(2),
+        )
+        // Stall findings become queryable incidents for the API and MCP
+        // tools, not just log lines.
+        .with_incident_store(incident_store.clone());
+        tokio::spawn(async move {
+            monitor.run().await;
+        });
+    }
+
     // Initialize Slack Notifier
     let _slack_notifier = if let Some(ref notif_cfg) = config.notifications {
         if let Some(ref slack_cfg) = notif_cfg.slack {


### PR DESCRIPTION
## Summary

D4 + D5 from the userspace detector spec: runqueue starvation and block-IO stall victims. Rounds out the victim picture — D2/D3 say who's stalled and who's forking; these add who's starved of CPU time and who's stuck on disk. Same monitor/incident pattern as #109/#110/#111. No eBPF, no privileges beyond /proc.

## D4 — runqueue starvation (`cpu_starvation` incidents)

- **Signal (measured):** per-thread `/proc/<pid>/task/<tid>/schedstat` runqueue-wait Δ over a 10 s sliding window, polled every 5 s. Warn at >= 2000 ms waited/window, critical at >= 5000 ms — grounded in a 2-CPU sandbox experiment (uncontended spinner ~31 ms/5 s vs ~6514 ms/10 s against 4 hogs).
- **Cost bound (per spec):** schedstat is read only for threads of the top-50 processes by recent `utime+stime` Δ. Stated plainly in the docs: threads outside the top-50 aren't measured on that poll (pinned by a test).
- **Honesty:** victim wait is `measured`; offender identity is eBPF-only and labeled `unavailable`. Kernels without `CONFIG_SCHEDSTATS` degrade gracefully (warn once, emit nothing, resume if files appear).
- **Warm-up honesty:** the window wait is the raw Δ, never divided by a short warm-up span — a partial window can only under-report.

## D5 — block-IO stall victims (`blkio_stall` incidents)

- **Signal (tier B, inferred):** `wchan` sampling every 2 s over a 60 s window; the wait fraction is the share of samples in block-layer wait states (`io_schedule*`, `wait_on_page*`, `blkdev_issue*`, `get_request*` — exact/prefix-scoped, futex/poll/pipe excluded). Warn at >= 50%, critical at >= 80%.
- **Cross-check:** `/proc/<pid>/io` read/write byte deltas ride along (measured); zero movement across the window is flagged as the hung-storage shape. Never gates the finding.
- Warm-up under-reports by design (fraction vs full 30-sample window); tier A (taskstats netlink) is the documented upgrade path.

## Incident wiring

Both follow the #110/#111 discipline: store-backed dedup via `recent_incident_keys` (store is the source of truth, batched once per scan, fail-open), 15-min per-(comm, verdict) log cooldown on the bounded 1024-entry map, failed inserts retried next scan with warn-once-then-debug logging. No CLI changes — the generic snapshot renderer covers the new types.

## Validation

- `cargo test -p cognitod --lib`: 216/216 (181 pre-existing + 35 new)
- `cargo test -p linnix-cli`: all pass
- `cargo +nightly fmt --all -- --check`: clean
- `cargo clippy -p cognitod --all-targets -- -D warnings` and linnix-cli: clean

## Notes

- Thresholds are sandbox-calibrated, not production data — expect retuning on many-core hosts.
- D5 can't distinguish cache-hot from device-bound waits in the log line; the snapshot carries both signals so consumers can tell.