### PR TITLE
collectors: add userspace memory-leak-trend and OOM-kill-witness monitors

### DIFF
--- a/cognitod/src/collectors/memory_leak.rs
+++ b/cognitod/src/collectors/memory_leak.rs
@@ -1,0 +1,1126 @@
+//! Userspace memory-leak-trend detector: no eBPF, no privileges beyond /proc.
+//!
+//! A process whose resident set grows steadily for fifteen minutes is worth
+//! an operator's attention — but RSS growth is *not* proof of a leak. Page
+//! cache, allocator arenas, and lazy freeing all look identical from
+//! `/proc/<pid>/statm`. This monitor therefore reports a "growth trend
+//! consistent with a leak" (confidence `inferred`, everywhere), never a
+//! leak, and attaches `smaps_rollup` allocator hints at fire time so a human
+//! or agent can tell anon growth from file-backed growth.
+//!
+//! Design:
+//!
+//! * **Signal (inferred):** per-process RSS (`statm` resident field × page
+//!   size), sampled every 30s. Least-squares linear fit over the in-window
+//!   samples (15-min window ⇒ 30 samples at full coverage).
+//! * **Fire:** positive slope AND R² > 0.8 AND fitted growth (slope ×
+//!   in-window span) > 50MB. All three thresholds are spec-derived
+//!   heuristics, not production-calibrated — they sit in named constants
+//!   and are documented as such. The R² gate is what keeps a sawtooth
+//!   (alloc/free churn with net drift) from firing.
+//! * **Warm-up honesty:** a verdict needs at least half a window of samples
+//!   (15). The fit runs only over samples inside the window and growth is
+//!   slope × *in-window* span, so a partial window can only under-report,
+//!   never inflate into a finding.
+//! * **Process identity:** baselines are keyed on `(pid, starttime)` — the
+//!   `starttime` field (field 22) of `/proc/<pid>/stat` is unique per
+//!   process incarnation, so a recycled PID starts a fresh baseline
+//!   instead of inheriting the dead process's trend. `comm` alone would
+//!   collide; `pid` alone would too.
+//! * **Cost:** one `statm` read per process per 30s is negligible (spec §5).
+//!   `smaps_rollup` is read *once per firing*, not per poll, for the
+//!   anon/private-dirty breakdown. Sample deques are pruned to the window
+//!   (with the same anchor-retention discipline as the runqueue monitor)
+//!   and idle PIDs are dropped after two windows.
+//! * **Degradation:** an unreadable `statm` skips that process's sample
+//!   for the poll — absence is not zero, and the baseline is left intact.
+//!   A missing `smaps_rollup` yields `smaps: unavailable`, never fabricated
+//!   zeros.
+//! * **eBPF upgrade:** allocation-site attribution via uprobes (spec §4).
+//!
+//! Findings become `memory_leak` incidents via the same store-backed dedup
+//! discipline as the other monitors: the incident store — not the bounded
+//! in-memory warn map — is the source of truth for what was already
+//! persisted, so map eviction and daemon restarts cannot duplicate rows.
+
+use log::{debug, info, warn};
+use std::collections::{HashMap, HashSet, VecDeque};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+use tokio::time::sleep;
+
+use crate::incidents::{Incident, IncidentStore};
+
+/// Sliding window for the linear fit.
+const WINDOW: Duration = Duration::from_secs(15 * 60);
+/// Minimum samples before any verdict: half the window at full coverage.
+/// Fewer than this and the fit is noise — the monitor stays silent.
+const MIN_SAMPLES: usize = 15;
+/// R² at or above which the trend is "sustained" rather than churn.
+const MIN_R_SQUARED: f64 = 0.8;
+/// Fitted window growth (slope × in-window span) at or above which a
+/// sustained trend becomes actionable. Spec-derived heuristic.
+const MIN_GROWTH_BYTES: u64 = 50 * 1024 * 1024;
+/// Default quiet period between repeat warnings for the same
+/// process+verdict, mirroring the other monitors.
+const DEFAULT_WARN_COOLDOWN: Duration = Duration::from_secs(15 * 60);
+/// Cap on the warn-cooldown map; oldest entries are evicted past this.
+const MAX_COOLDOWN_ENTRIES: usize = 1024;
+/// Baselines idle longer than this are dropped — the process exited or the
+/// host went quiet; either way the memory shouldn't linger.
+const STALE_BASELINE: Duration = Duration::from_secs(30 * 60);
+/// Page-size fallback if `sysconf` fails; the real size comes from the
+/// kernel at runtime.
+const FALLBACK_PAGE_SIZE: u64 = 4096;
+
+/// What a process's RSS trend means. There is a single actionable verdict:
+/// RSS growth is never proof of a leak, so there is no "critical" — only
+/// the sustained-trend warning.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum LeakVerdict {
+    Healthy,
+    /// Positive slope, R² > 0.8, growth > 50MB over the window: a growth
+    /// trend consistent with a leak.
+    LeakWarning,
+}
+
+impl LeakVerdict {
+    /// `false` for `Healthy`; used to filter log/report noise.
+    pub fn actionable(self) -> bool {
+        !matches!(self, LeakVerdict::Healthy)
+    }
+}
+
+/// Allocator hints from `smaps_rollup`, read once per firing.
+#[derive(Debug, Clone)]
+pub struct SmapsHints {
+    /// Total RSS from the rollup, KiB.
+    pub rss_kb: u64,
+    /// Anonymous (non-file-backed) memory, KiB — the leak-suspect part.
+    pub anon_kb: u64,
+    /// Private dirty pages, KiB.
+    pub private_dirty_kb: u64,
+}
+
+/// One actionable leak-trend finding for a scan window.
+#[derive(Debug, Clone)]
+pub struct MemoryLeak {
+    pub pid: u32,
+    /// `/proc/<pid>/stat` field 22: unique per process incarnation.
+    pub starttime: u64,
+    pub comm: Option<String>,
+    /// Fitted RSS growth rate, bytes/sec.
+    pub slope_bytes_per_sec: f64,
+    /// Goodness of the linear fit.
+    pub r_squared: f64,
+    /// Fitted growth over the in-window span, bytes.
+    pub growth_bytes: u64,
+    /// Seconds the window covers.
+    pub window_secs: f64,
+    /// Samples the fit ran on.
+    pub sample_count: usize,
+    /// Allocator hints; `None` when `smaps_rollup` was unreadable.
+    pub smaps: Option<SmapsHints>,
+    pub verdict: LeakVerdict,
+}
+
+impl MemoryLeak {
+    /// Stable identity for cooldown and incident-dedup keys: the process
+    /// incarnation, not just the PID. Two same-named processes are distinct
+    /// (different PIDs); a recycled PID is distinct (different starttime),
+    /// so one victim never suppresses another's incident for the whole
+    /// cooldown.
+    fn victim_label(&self) -> String {
+        let comm = self.comm.clone().unwrap_or_else(|| "unknown".to_string());
+        format!("{comm} (pid={}, start={})", self.pid, self.starttime)
+    }
+
+    /// Slope in MiB/hour for human- and agent-readable output.
+    fn slope_mib_per_hr(&self) -> f64 {
+        self.slope_bytes_per_sec * 3600.0 / (1024.0 * 1024.0)
+    }
+
+    fn growth_mib(&self) -> f64 {
+        self.growth_bytes as f64 / (1024.0 * 1024.0)
+    }
+}
+
+fn classify(slope: f64, r2: f64, growth_bytes: u64) -> LeakVerdict {
+    if slope > 0.0 && r2 >= MIN_R_SQUARED && growth_bytes >= MIN_GROWTH_BYTES {
+        LeakVerdict::LeakWarning
+    } else {
+        LeakVerdict::Healthy
+    }
+}
+
+/// Page size in bytes, from the kernel; falls back to 4KiB if `sysconf`
+/// fails rather than failing the whole scan.
+fn page_size_bytes() -> u64 {
+    let raw = unsafe { libc::sysconf(libc::_SC_PAGESIZE) };
+    if raw > 0 {
+        raw as u64
+    } else {
+        FALLBACK_PAGE_SIZE
+    }
+}
+
+/// Resident set size in bytes from `/proc/<pid>/statm` (field 2, pages).
+/// `None` when the file is missing or unparseable — absence is not zero.
+fn read_rss_bytes(proc_root: &Path, pid: u32) -> Option<u64> {
+    let content = std::fs::read_to_string(proc_root.join(pid.to_string()).join("statm")).ok()?;
+    let resident_pages = content.split_whitespace().nth(1)?.parse::<u64>().ok()?;
+    Some(resident_pages.saturating_mul(page_size_bytes()))
+}
+
+/// Process start time (jiffies since boot) from `/proc/<pid>/stat` field
+/// 22. Unique per process incarnation: the PID-reuse-safe half of the
+/// baseline key. `None` when missing/unparseable — absence is not zero.
+/// Fields are split after the *last* `)` since comm may contain parens.
+fn read_starttime(proc_root: &Path, pid: u32) -> Option<u64> {
+    let content = std::fs::read_to_string(proc_root.join(pid.to_string()).join("stat")).ok()?;
+    let after_comm = content.rfind(')')?;
+    content[after_comm + 1..]
+        .split_whitespace()
+        .nth(19)?
+        .parse::<u64>()
+        .ok()
+}
+
+fn read_comm(proc_root: &Path, pid: u32) -> Option<String> {
+    std::fs::read_to_string(proc_root.join(pid.to_string()).join("comm"))
+        .ok()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+}
+
+/// Numeric `/proc` entries: the live PID set.
+fn list_pids(proc_root: &Path) -> Vec<u32> {
+    let mut out = Vec::new();
+    let Ok(entries) = std::fs::read_dir(proc_root) else {
+        return out;
+    };
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let Some(name_str) = name.to_str() else {
+            continue;
+        };
+        if let Ok(pid) = name_str.parse::<u32>() {
+            out.push(pid);
+        }
+    }
+    out
+}
+
+/// Least-squares fit of `ys` over `xs` (seconds). Returns
+/// `(slope_per_sec, r_squared)`, or `None` when the fit is degenerate
+/// (fewer than two points, or all `xs` identical).
+fn linear_fit(xs: &[f64], ys: &[f64]) -> Option<(f64, f64)> {
+    if xs.len() < 2 || xs.len() != ys.len() {
+        return None;
+    }
+    let n = xs.len() as f64;
+    let mean_x = xs.iter().sum::<f64>() / n;
+    let mean_y = ys.iter().sum::<f64>() / n;
+    let mut ss_xy = 0.0;
+    let mut ss_xx = 0.0;
+    let mut ss_yy = 0.0;
+    for (x, y) in xs.iter().zip(ys.iter()) {
+        let dx = x - mean_x;
+        let dy = y - mean_y;
+        ss_xy += dx * dy;
+        ss_xx += dx * dx;
+        ss_yy += dy * dy;
+    }
+    if ss_xx == 0.0 {
+        return None;
+    }
+    let slope = ss_xy / ss_xx;
+    // Constant RSS ⇒ no variance to explain; that's a zero-slope healthy
+    // trend, not a perfect fit.
+    let r2 = if ss_yy == 0.0 {
+        0.0
+    } else {
+        (ss_xy * ss_xy) / (ss_xx * ss_yy)
+    };
+    Some((slope, r2.clamp(0.0, 1.0)))
+}
+
+/// Allocator hints from `/proc/<pid>/smaps_rollup`: the `Rss:`, `Anon:`,
+/// and `Private_Dirty:` summary lines (KiB). `None` when the file is
+/// missing or unparseable — absence is not zero. Read once per firing,
+/// never per poll.
+fn read_smaps_hints(proc_root: &Path, pid: u32) -> Option<SmapsHints> {
+    let content =
+        std::fs::read_to_string(proc_root.join(pid.to_string()).join("smaps_rollup")).ok()?;
+    fn kb(content: &str, key: &str) -> Option<u64> {
+        for line in content.lines() {
+            let mut parts = line.split_whitespace();
+            if parts.next() == Some(key) {
+                return parts.next()?.parse::<u64>().ok();
+            }
+        }
+        None
+    }
+    Some(SmapsHints {
+        rss_kb: kb(&content, "Rss:")?,
+        anon_kb: kb(&content, "Anon:")?,
+        private_dirty_kb: kb(&content, "Private_Dirty:")?,
+    })
+}
+
+/// Per-process RSS history for the leak-trend fit.
+struct ProcBaseline {
+    comm: Option<String>,
+    /// `(sampled_at, rss_bytes)` within the sliding window, plus the anchor.
+    samples: VecDeque<(Instant, u64)>,
+    last_seen: Instant,
+}
+
+/// Stateful memory-leak-trend monitor.
+pub struct MemoryLeakMonitor {
+    proc_root: PathBuf,
+    interval: Duration,
+    baselines: HashMap<(u32, u64), ProcBaseline>,
+    warn_cooldown: Duration,
+    max_iterations: Option<u64>,
+    /// When each process-incarnation+verdict was last warned about.
+    last_warned: HashMap<(String, LeakVerdict), Instant>,
+    /// Whether the last incident-record attempt failed (warn-once, then
+    /// debug until a record succeeds — `handle_finding` retries every scan).
+    record_unhealthy: bool,
+    /// Where findings are recorded so they are visible through the API
+    /// and MCP tools, not just the daemon logs. `None` keeps the monitor
+    /// log-only.
+    incident_store: Option<Arc<IncidentStore>>,
+}
+
+impl MemoryLeakMonitor {
+    pub fn new(interval: Duration) -> Self {
+        Self {
+            proc_root: PathBuf::from("/proc"),
+            interval,
+            baselines: HashMap::new(),
+            warn_cooldown: DEFAULT_WARN_COOLDOWN,
+            max_iterations: None,
+            last_warned: HashMap::new(),
+            record_unhealthy: false,
+            incident_store: None,
+        }
+    }
+
+    /// Points the monitor at a fixture tree instead of the live `/proc`.
+    /// Test-only in practice; mirrors the other monitors.
+    pub fn with_proc_root(mut self, root: impl Into<PathBuf>) -> Self {
+        self.proc_root = root.into();
+        self
+    }
+
+    /// Bounds the scan loop so it terminates. Only useful for tests.
+    pub fn with_max_iterations(mut self, iterations: u64) -> Self {
+        self.max_iterations = Some(iterations);
+        self
+    }
+
+    /// Quiet period between repeat warnings for the same process+verdict.
+    /// `Duration::ZERO` warns on every occurrence (useful for tests).
+    pub fn with_warn_cooldown(mut self, cooldown: Duration) -> Self {
+        self.warn_cooldown = cooldown;
+        self
+    }
+
+    /// Records findings as `memory_leak` incidents so they surface through
+    /// `/incidents` and the MCP tools, not just the daemon logs. Takes
+    /// `Option` to mirror the other monitors: the store may be unavailable
+    /// (no DB path), in which case the monitor stays log-only.
+    pub fn with_incident_store(mut self, store: Option<Arc<IncidentStore>>) -> Self {
+        self.incident_store = store;
+        self
+    }
+
+    /// Log-reporting gate: true the first time a process reports a given
+    /// verdict, and again once the cooldown has elapsed. This gates the log
+    /// line only — incident recording is decided separately against the
+    /// store (see `handle_finding`), so a failed insert is retried on the
+    /// next scan instead of being swallowed by this cooldown.
+    fn should_warn(&mut self, finding: &MemoryLeak) -> bool {
+        if self.warn_cooldown.is_zero() {
+            return true;
+        }
+        let key = (finding.victim_label(), finding.verdict);
+        let now = Instant::now();
+        if let Some(last) = self.last_warned.get(&key)
+            && now.duration_since(*last) < self.warn_cooldown
+        {
+            return false;
+        }
+        if self.last_warned.len() >= MAX_COOLDOWN_ENTRIES {
+            let cooldown = self.warn_cooldown;
+            self.last_warned
+                .retain(|_, last| now.duration_since(*last) < cooldown);
+            // Expiry frees nothing when every entry is still inside its
+            // cooldown; evict the oldest instead so the map stays bounded.
+            // Mirrors the other monitors' cap discipline.
+            while self.last_warned.len() >= MAX_COOLDOWN_ENTRIES {
+                let Some(oldest) = self
+                    .last_warned
+                    .iter()
+                    .min_by_key(|(_, last)| **last)
+                    .map(|(k, _)| k.clone())
+                else {
+                    break;
+                };
+                self.last_warned.remove(&oldest);
+            }
+        }
+        self.last_warned.insert(key, now);
+        true
+    }
+
+    /// Folds one poll's RSS reading into the process's baseline. A missing
+    /// `statm` leaves the baseline untouched — absence is not zero, and the
+    /// fit simply runs on fewer samples.
+    ///
+    /// The newest sample at or before the window cutoff is retained as the
+    /// baseline anchor (same discipline as the runqueue monitor): polls
+    /// land slightly more than 30s apart, so without the anchor the window
+    /// would silently shrink and the fitted growth would understate the
+    /// real trend.
+    fn update_baseline(&mut self, pid: u32, starttime: u64, now: Instant, rss_bytes: u64) {
+        let baseline = self
+            .baselines
+            .entry((pid, starttime))
+            .or_insert_with(|| ProcBaseline {
+                comm: None,
+                samples: VecDeque::new(),
+                last_seen: now,
+            });
+        baseline.last_seen = now;
+        baseline.samples.push_back((now, rss_bytes));
+        let cutoff = now.checked_sub(WINDOW).unwrap_or(now);
+        // Prune aged samples but keep the anchor: pop the front only while
+        // the *second* sample is still at or before the cutoff, so the
+        // front remains the newest sample on or before the cutoff.
+        while baseline.samples.len() > 1 && baseline.samples[1].0 <= cutoff {
+            baseline.samples.pop_front();
+        }
+    }
+
+    /// One poll: sample every process's RSS, refresh baselines, fit the
+    /// in-window trend for processes with enough history, and return a
+    /// finding for the worst sustained grower when it is actionable. The
+    /// first sightings of a process only establish its baseline.
+    pub fn tick(&mut self) -> Option<MemoryLeak> {
+        self.tick_at(Instant::now())
+    }
+
+    fn tick_at(&mut self, now: Instant) -> Option<MemoryLeak> {
+        // `(pid, starttime)` pairs observed alive this poll. A PID seen
+        // under a *different* starttime than a baseline's means that
+        // incarnation is dead (PID reuse) — its trend must not linger or,
+        // worse, keep firing from frozen samples.
+        let mut live: HashMap<u32, u64> = HashMap::new();
+        for pid in list_pids(&self.proc_root) {
+            // starttime is the incarnation identity: a recycled PID gets a
+            // fresh baseline instead of inheriting the dead process's
+            // trend. Unreadable stat ⇒ skip the process this poll.
+            let Some(starttime) = read_starttime(&self.proc_root, pid) else {
+                continue;
+            };
+            live.insert(pid, starttime);
+            let key = (pid, starttime);
+            // Touch last_seen for live processes even when statm is
+            // unreadable, so a transient read failure doesn't age out a
+            // live baseline.
+            match self.baselines.get_mut(&key) {
+                Some(baseline) => {
+                    baseline.last_seen = now;
+                    if let Some(comm) = read_comm(&self.proc_root, pid) {
+                        baseline.comm = Some(comm);
+                    }
+                }
+                None => {
+                    self.baselines.insert(
+                        key,
+                        ProcBaseline {
+                            comm: read_comm(&self.proc_root, pid),
+                            samples: VecDeque::new(),
+                            last_seen: now,
+                        },
+                    );
+                }
+            }
+            // Absence is not zero: no sample this poll, baseline intact.
+            if let Some(rss) = read_rss_bytes(&self.proc_root, pid) {
+                self.update_baseline(pid, starttime, now, rss);
+            }
+        }
+
+        // Drop baselines for dead incarnations and long-gone processes so
+        // the map stays bounded and stale trends never fire.
+        self.baselines.retain(|&(pid, starttime), baseline| {
+            match live.get(&pid) {
+                // Same incarnation still alive: age out only when idle.
+                Some(&cur) if cur == starttime => {
+                    now.duration_since(baseline.last_seen) < STALE_BASELINE
+                }
+                // PID alive under a new starttime: the old incarnation is
+                // gone — drop its trend immediately.
+                Some(_) => {
+                    debug!(
+                        "[memleak] pid={pid} reused (starttime {starttime} gone); \
+                         dropping its RSS baseline"
+                    );
+                    false
+                }
+                // Not observed this poll (unreadable stat or exited):
+                // age it out.
+                None => now.duration_since(baseline.last_seen) < STALE_BASELINE,
+            }
+        });
+
+        // Fit every process with enough in-window history; the worst
+        // sustained grower becomes the finding.
+        let mut worst: Option<MemoryLeak> = None;
+        for (&(pid, starttime), baseline) in &self.baselines {
+            if baseline.samples.len() < MIN_SAMPLES {
+                continue;
+            }
+            let t0 = baseline.samples[0].0;
+            let xs: Vec<f64> = baseline
+                .samples
+                .iter()
+                .map(|(t, _)| t.duration_since(t0).as_secs_f64())
+                .collect();
+            let ys: Vec<f64> = baseline
+                .samples
+                .iter()
+                .map(|(_, rss)| *rss as f64)
+                .collect();
+            let Some((slope, r2)) = linear_fit(&xs, &ys) else {
+                continue;
+            };
+            let span_secs = xs[xs.len() - 1] - xs[0];
+            // Fitted growth over the in-window span: a partial window
+            // under-reports by construction, never inflates.
+            let growth_bytes = (slope * span_secs).max(0.0) as u64;
+            if !classify(slope, r2, growth_bytes).actionable() {
+                continue;
+            }
+            let candidate = MemoryLeak {
+                pid,
+                starttime,
+                comm: baseline.comm.clone(),
+                slope_bytes_per_sec: slope,
+                r_squared: r2,
+                growth_bytes,
+                window_secs: WINDOW.as_secs_f64(),
+                sample_count: baseline.samples.len(),
+                // Allocator hints are read once per firing, not per poll.
+                smaps: read_smaps_hints(&self.proc_root, pid),
+                verdict: LeakVerdict::LeakWarning,
+            };
+            let worse = match &worst {
+                None => true,
+                Some(prev) => candidate.growth_bytes > prev.growth_bytes,
+            };
+            if worse {
+                worst = Some(candidate);
+            }
+        }
+        worst
+    }
+
+    pub async fn run(mut self) {
+        info!("[memleak] starting memory leak trend monitor");
+        let mut iterations = 0u64;
+        loop {
+            if let Some(finding) = self.tick() {
+                self.handle_finding(&finding).await;
+            }
+            iterations += 1;
+            if let Some(max) = self.max_iterations
+                && iterations >= max
+            {
+                break;
+            }
+            sleep(self.interval).await;
+        }
+    }
+
+    /// Reports one actionable finding: log the warning and, when an incident
+    /// store is configured, record it.
+    ///
+    /// Logging rides `should_warn`'s cooldown. Recording is gated only on
+    /// the store itself, which is the source of truth for what was
+    /// persisted: the log cooldown never suppresses a record attempt, so a
+    /// transient insert failure is retried on the next scan instead of
+    /// vanishing for the whole cooldown.
+    async fn handle_finding(&mut self, finding: &MemoryLeak) {
+        if self.should_warn(finding) {
+            report(finding);
+        }
+        let recorded = self.recently_recorded_keys().await;
+        let key = (finding.victim_label(), format!("{:?}", finding.verdict));
+        if recorded.contains(&key) {
+            return;
+        }
+        self.record_incident(finding).await;
+    }
+
+    /// `(victim, verdict)` pairs already incidented within the cooldown
+    /// window. Empty when no store is configured; fail-open when the store
+    /// can't be read — a store that won't answer the dedup query probably
+    /// won't take the insert either, and a duplicate row beats a silently
+    /// dropped incident.
+    async fn recently_recorded_keys(&self) -> HashSet<(String, String)> {
+        let Some(store) = &self.incident_store else {
+            return HashSet::new();
+        };
+        match store
+            .recent_incident_keys("memory_leak", self.warn_cooldown.as_secs())
+            .await
+        {
+            Ok(keys) => keys,
+            Err(e) => {
+                warn!("[memleak] couldn't check recent incidents: {e}");
+                HashSet::new()
+            }
+        }
+    }
+
+    /// Best-effort: a failing store must not break the monitoring loop.
+    /// The first failure logs at warn level; repeats stay at debug until a
+    /// record succeeds, since `handle_finding` retries the insert on every
+    /// scan while the trend continues.
+    async fn record_incident(&mut self, finding: &MemoryLeak) {
+        let Some(store) = &self.incident_store else {
+            return;
+        };
+        let incident = incident_from_finding(finding);
+        match store.insert(&incident).await {
+            Ok(id) => {
+                debug!(
+                    "[memleak] recorded incident #{id} for {}",
+                    finding.victim_label()
+                );
+                self.record_unhealthy = false;
+            }
+            Err(e) => {
+                if self.record_unhealthy {
+                    debug!(
+                        "[memleak] still failing to record incident for {}: {e}",
+                        finding.victim_label()
+                    );
+                } else {
+                    warn!(
+                        "[memleak] failed to record incident for {}: {e}",
+                        finding.victim_label()
+                    );
+                    self.record_unhealthy = true;
+                }
+            }
+        }
+    }
+}
+
+/// Builds the `memory_leak` incident row for one finding.
+///
+/// Field mapping, kept honest about what this monitor measures:
+/// * `psi_cpu` / `psi_memory` / `cpu_percent` / `load_avg` are host-level
+///   fields this monitor doesn't sample, so they're zero/empty; the
+///   triggering reading is the RSS trend, carried in `system_snapshot`.
+/// * `target_pid` / `target_name` name the growing process incarnation.
+/// * The trend is `inferred` — RSS growth is consistent with a leak, not
+///   proof of one. The smaps hints are `measured` kernel accounting when
+///   readable, `unavailable` otherwise.
+fn incident_from_finding(finding: &MemoryLeak) -> Incident {
+    let smaps = finding.smaps.as_ref().map(|h| {
+        serde_json::json!({
+            "rss_kb": h.rss_kb,
+            "anon_kb": h.anon_kb,
+            "private_dirty_kb": h.private_dirty_kb,
+        })
+    });
+    let snapshot = serde_json::json!({
+        "pid": finding.pid,
+        "starttime": finding.starttime,
+        "comm": finding.comm,
+        "slope_mib_per_hr": finding.slope_mib_per_hr(),
+        "r_squared": finding.r_squared,
+        "growth_mib": finding.growth_mib(),
+        "window_secs": finding.window_secs,
+        "sample_count": finding.sample_count,
+        "smaps": smaps,
+        "source_tier": "polling",
+        "verdict": format!("{:?}", finding.verdict),
+        // RSS growth is consistent with a leak, not proof of one; the
+        // smaps breakdown is measured kernel accounting when readable.
+        "evidence": {
+            "rss_trend": "inferred",
+            "smaps": if finding.smaps.is_some() { "measured" } else { "unavailable" },
+        },
+    });
+    Incident {
+        id: None,
+        timestamp: chrono::Utc::now().timestamp(),
+        event_type: "memory_leak".to_string(),
+        psi_cpu: 0.0,
+        psi_memory: 0.0,
+        cpu_percent: 0.0,
+        load_avg: String::new(),
+        action: "alert".to_string(),
+        target_pid: Some(finding.pid as i32),
+        target_name: Some(finding.victim_label()),
+        system_snapshot: serde_json::to_string(&snapshot).ok(),
+        llm_analysis: None,
+        llm_analyzed_at: None,
+        investigation: None,
+        recovery_time_ms: None,
+        psi_after: None,
+    }
+}
+
+/// One human- and agent-readable line per actionable finding. The trend is
+/// `inferred` — the line says "consistent with a leak", never "leak".
+fn report(finding: &MemoryLeak) {
+    let victim = match finding.comm.as_deref() {
+        Some(comm) => format!("{comm} (pid={})", finding.pid),
+        None => format!("pid={}", finding.pid),
+    };
+    let smaps_note = match &finding.smaps {
+        Some(h) => format!(
+            "; smaps_rollup: rss={}MB anon={}MB private_dirty={}MB",
+            h.rss_kb / 1024,
+            h.anon_kb / 1024,
+            h.private_dirty_kb / 1024,
+        ),
+        None => "; smaps_rollup unavailable".to_string(),
+    };
+    if finding.verdict.actionable() {
+        warn!(
+            "[memleak] WARNING: process {victim} shows a growth trend consistent with a leak: \
+             +{:.0}MB over {:.0}s ({:.0} samples, slope {:.1}MiB/hr, R²={:.2}) \
+             [rss trend inferred]{smaps_note}",
+            finding.growth_mib(),
+            finding.window_secs,
+            finding.sample_count,
+            finding.slope_mib_per_hr(),
+            finding.r_squared,
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    /// MiB → resident pages, using the same page size the monitor reads.
+    /// Whole MiB values are exact on any power-of-two page size.
+    fn mib_pages(mib: u64) -> u64 {
+        mib * 1024 * 1024 / page_size_bytes()
+    }
+
+    struct FakeProc {
+        dir: TempDir,
+    }
+
+    impl FakeProc {
+        fn new() -> Self {
+            Self {
+                dir: TempDir::new().unwrap(),
+            }
+        }
+
+        /// (Re)places a fake process: `<pid>/stat` (starttime in field 22),
+        /// `<pid>/statm` (resident pages), `<pid>/comm`, and optionally
+        /// `<pid>/smaps_rollup`.
+        fn set_proc(
+            &self,
+            pid: u32,
+            comm: &str,
+            starttime: u64,
+            resident_pages: u64,
+            smaps: Option<(u64, u64, u64)>,
+        ) {
+            let d = self.dir.path().join(pid.to_string());
+            fs::create_dir_all(&d).unwrap();
+            // Fields after the last `)`: index 0 is field 3 (state), so
+            // field 22 (starttime) is index 19.
+            fs::write(
+                d.join("stat"),
+                format!("{pid} ({comm}) R 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 {starttime}\n"),
+            )
+            .unwrap();
+            fs::write(d.join("statm"), format!("0 {resident_pages} 0 0 0 0 0\n")).unwrap();
+            fs::write(d.join("comm"), format!("{comm}\n")).unwrap();
+            if let Some((rss_kb, anon_kb, pd_kb)) = smaps {
+                fs::write(
+                    d.join("smaps_rollup"),
+                    format!(
+                        "Rss:                  {rss_kb} kB\n\
+                         Anon:                 {anon_kb} kB\n\
+                         Private_Dirty:        {pd_kb} kB\n"
+                    ),
+                )
+                .unwrap();
+            }
+        }
+
+        fn remove_statm(&self, pid: u32) {
+            fs::remove_file(self.dir.path().join(pid.to_string()).join("statm")).unwrap();
+        }
+
+        fn monitor(&self) -> MemoryLeakMonitor {
+            MemoryLeakMonitor::new(Duration::from_secs(30)).with_proc_root(self.dir.path())
+        }
+    }
+
+    fn warning_finding(comm: &str) -> MemoryLeak {
+        MemoryLeak {
+            pid: 4242,
+            starttime: 999,
+            comm: Some(comm.to_string()),
+            slope_bytes_per_sec: 100_000.0,
+            r_squared: 0.95,
+            growth_bytes: 60 * 1024 * 1024,
+            window_secs: 900.0,
+            sample_count: 30,
+            smaps: None,
+            verdict: LeakVerdict::LeakWarning,
+        }
+    }
+
+    #[test]
+    fn classify_matrix() {
+        // Sustained growth above all gates fires.
+        assert_eq!(
+            classify(1000.0, 0.9, 60 * 1024 * 1024),
+            LeakVerdict::LeakWarning
+        );
+        // Flat, shrinking, noisy, or small growth stays healthy.
+        assert_eq!(classify(0.0, 0.99, 100 * 1024 * 1024), LeakVerdict::Healthy);
+        assert_eq!(classify(-1000.0, 0.99, 0), LeakVerdict::Healthy);
+        assert_eq!(
+            classify(1000.0, 0.5, 60 * 1024 * 1024),
+            LeakVerdict::Healthy
+        );
+        assert_eq!(
+            classify(1000.0, 0.9, 10 * 1024 * 1024),
+            LeakVerdict::Healthy
+        );
+        // Boundary: exactly at the gates fires.
+        assert_eq!(
+            classify(1.0, MIN_R_SQUARED, MIN_GROWTH_BYTES),
+            LeakVerdict::LeakWarning
+        );
+    }
+
+    #[test]
+    fn linear_fit_math() {
+        // Perfect line: exact slope, R² = 1.
+        let xs: Vec<f64> = (0..10).map(|i| i as f64).collect();
+        let ys: Vec<f64> = xs.iter().map(|x| 2.0 * x + 1.0).collect();
+        let (slope, r2) = linear_fit(&xs, &ys).unwrap();
+        assert!((slope - 2.0).abs() < 1e-9);
+        assert!((r2 - 1.0).abs() < 1e-9);
+        // Constant series: zero slope, R² = 0 (not a spurious perfect fit).
+        let flat = vec![5.0; 10];
+        let (slope, r2) = linear_fit(&xs, &flat).unwrap();
+        assert_eq!(slope, 0.0);
+        assert_eq!(r2, 0.0);
+        // Sawtooth churn: poor fit despite net drift.
+        let saw: Vec<f64> = (0..20)
+            .map(|i| if i % 2 == 0 { 0.0 } else { 10.0 })
+            .collect();
+        let xs2: Vec<f64> = (0..20).map(|i| i as f64).collect();
+        let (_, r2) = linear_fit(&xs2, &saw).unwrap();
+        assert!(r2 < MIN_R_SQUARED, "sawtooth must not look sustained");
+        // Degenerate inputs.
+        assert!(linear_fit(&[1.0], &[2.0]).is_none());
+        assert!(linear_fit(&[1.0, 1.0], &[2.0, 3.0]).is_none());
+    }
+
+    #[test]
+    fn fires_on_sustained_growth() {
+        let fake = FakeProc::new();
+        let mut mon = fake.monitor();
+        let t0 = Instant::now();
+        // 100MB of linear growth over the 15-min window: 30 samples.
+        let mut last = None;
+        for i in 0..30u64 {
+            let mib = 100 + i * 100 / 29;
+            fake.set_proc(7, "leaky", 1000, mib_pages(mib), None);
+            last = mon.tick_at(t0 + Duration::from_secs(30 * i));
+            if i < 14 {
+                assert!(last.is_none(), "needs {MIN_SAMPLES} samples first");
+            }
+        }
+        let finding = last.expect("sustained 100MB+ growth must fire");
+        assert_eq!(finding.verdict, LeakVerdict::LeakWarning);
+        assert_eq!(finding.pid, 7);
+        assert!(finding.r_squared > 0.99);
+        assert!(finding.growth_bytes >= MIN_GROWTH_BYTES);
+        assert_eq!(finding.sample_count, 30, "window holds 30 samples");
+        assert!(finding.smaps.is_none(), "no smaps_rollup in fixture");
+    }
+
+    #[test]
+    fn noisy_rss_does_not_fire() {
+        let fake = FakeProc::new();
+        let mut mon = fake.monitor();
+        let t0 = Instant::now();
+        // Sawtooth with net upward drift: the R² gate must hold it back.
+        let mut finding = None;
+        for i in 0..30u64 {
+            let mib = 100 + (i % 2) * 40 + i / 3;
+            fake.set_proc(9, "churny", 2000, mib_pages(mib), None);
+            finding = mon.tick_at(t0 + Duration::from_secs(30 * i));
+        }
+        assert!(
+            finding.is_none(),
+            "churn must not fire: R² gate, not just net drift"
+        );
+    }
+
+    #[test]
+    fn partial_window_never_inflates() {
+        let fake = FakeProc::new();
+        let mut mon = fake.monitor();
+        let t0 = Instant::now();
+        // Steep growth but only 10 samples (< MIN_SAMPLES): silence, not a
+        // finding scaled up from a short span.
+        for i in 0..10u64 {
+            fake.set_proc(11, "fast", 3000, mib_pages(100 + i * 20), None);
+            assert!(mon.tick_at(t0 + Duration::from_secs(30 * i)).is_none());
+        }
+    }
+
+    #[test]
+    fn pid_reuse_starts_a_fresh_baseline() {
+        let fake = FakeProc::new();
+        let mut mon = fake.monitor();
+        let t0 = Instant::now();
+        // Incarnation 1 grows for 20 samples (enough to fire on its own).
+        for i in 0..20u64 {
+            fake.set_proc(13, "recycled", 4000, mib_pages(100 + i * 5), None);
+            mon.tick_at(t0 + Duration::from_secs(30 * i));
+        }
+        // The PID is reused: new starttime, flat RSS. The old trend must
+        // not leak into the new incarnation's baseline.
+        for i in 20..40u64 {
+            fake.set_proc(13, "recycled", 9999, mib_pages(100), None);
+            let finding = mon.tick_at(t0 + Duration::from_secs(30 * i));
+            assert!(
+                finding.is_none() || finding.unwrap().starttime == 9999,
+                "old incarnation's growth must not fire for the new one"
+            );
+        }
+        assert_eq!(
+            mon.baselines.len(),
+            1,
+            "old incarnation pruned or never refit"
+        );
+        assert!(mon.baselines.contains_key(&(13, 9999)));
+    }
+
+    #[test]
+    fn unreadable_statm_skips_the_sample() {
+        let fake = FakeProc::new();
+        let mut mon = fake.monitor();
+        let t0 = Instant::now();
+        for i in 0..20u64 {
+            fake.set_proc(15, "flaky", 5000, mib_pages(100 + i * 5), None);
+            if i == 10 {
+                fake.remove_statm(15);
+            }
+            mon.tick_at(t0 + Duration::from_secs(30 * i));
+            if i == 10 {
+                // Restore for the next poll; the missed sample is just gone.
+                fake.set_proc(15, "flaky", 5000, mib_pages(100 + i * 5), None);
+            }
+        }
+        let baseline = &mon.baselines[&(15, 5000)];
+        assert_eq!(
+            baseline.samples.len(),
+            19,
+            "one missed sample, baseline intact"
+        );
+    }
+
+    #[test]
+    fn smaps_hints_ride_along_when_readable() {
+        let fake = FakeProc::new();
+        let mut mon = fake.monitor();
+        let t0 = Instant::now();
+        for i in 0..30u64 {
+            fake.set_proc(
+                17,
+                "leaky",
+                6000,
+                mib_pages(100 + i * 100 / 29),
+                Some((200 * 1024, 150 * 1024, 140 * 1024)),
+            );
+            mon.tick_at(t0 + Duration::from_secs(30 * i));
+        }
+        fake.set_proc(
+            17,
+            "leaky",
+            6000,
+            mib_pages(205),
+            Some((205 * 1024, 155 * 1024, 145 * 1024)),
+        );
+        let finding = mon
+            .tick_at(t0 + Duration::from_secs(30 * 30))
+            .expect("must fire");
+        let hints = finding.smaps.expect("smaps_rollup readable in fixture");
+        assert_eq!(hints.anon_kb, 155 * 1024);
+    }
+
+    #[test]
+    fn incident_mapping_labels_evidence_honestly() {
+        let mut finding = warning_finding("leaky");
+        finding.smaps = Some(SmapsHints {
+            rss_kb: 100,
+            anon_kb: 80,
+            private_dirty_kb: 70,
+        });
+        let incident = incident_from_finding(&finding);
+        assert_eq!(incident.event_type, "memory_leak");
+        assert_eq!(incident.action, "alert");
+        assert_eq!(incident.target_pid, Some(4242));
+        assert_eq!(
+            incident.target_name.as_deref(),
+            Some("leaky (pid=4242, start=999)")
+        );
+        assert_eq!(incident.psi_cpu, 0.0);
+        let snapshot: serde_json::Value =
+            serde_json::from_str(incident.system_snapshot.as_deref().unwrap()).unwrap();
+        assert_eq!(snapshot["verdict"], "LeakWarning");
+        // The trend is inferred — RSS growth is consistent with a leak,
+        // never proof of one.
+        assert_eq!(snapshot["evidence"]["rss_trend"], "inferred");
+        assert_eq!(snapshot["evidence"]["smaps"], "measured");
+        assert!((snapshot["growth_mib"].as_f64().unwrap() - 60.0).abs() < 1e-9);
+
+        // Without smaps_rollup the label is unavailable, not fabricated.
+        let bare = incident_from_finding(&warning_finding("leaky"));
+        let snapshot: serde_json::Value =
+            serde_json::from_str(bare.system_snapshot.as_deref().unwrap()).unwrap();
+        assert_eq!(snapshot["evidence"]["smaps"], "unavailable");
+        assert!(snapshot["smaps"].is_null());
+    }
+
+    #[test]
+    fn warn_cooldown_suppresses_repeat_logs_not_records() {
+        let mut mon = MemoryLeakMonitor::new(Duration::from_secs(30));
+        let finding = warning_finding("leaky");
+        assert!(mon.should_warn(&finding), "first sighting warns");
+        assert!(!mon.should_warn(&finding), "cooldown suppresses the log");
+        // A *different* process incarnation is a different victim.
+        let mut other = warning_finding("leaky");
+        other.pid = 7777;
+        assert!(
+            mon.should_warn(&other),
+            "distinct victims warn independently"
+        );
+    }
+
+    #[tokio::test]
+    async fn finding_is_recorded_as_incident() {
+        let fake = FakeProc::new();
+        let db_dir = TempDir::new().unwrap();
+        let store = Arc::new(
+            IncidentStore::new(db_dir.path().join("incidents.db"))
+                .await
+                .unwrap(),
+        );
+        let mut mon = fake.monitor().with_incident_store(Some(Arc::clone(&store)));
+        let finding = warning_finding("leaky");
+        mon.handle_finding(&finding).await;
+
+        let incidents = store
+            .recent_filtered(10, Some("memory_leak"), None)
+            .await
+            .unwrap();
+        assert_eq!(incidents.len(), 1, "one finding, one incident");
+        assert_eq!(incidents[0].event_type, "memory_leak");
+        assert_eq!(
+            incidents[0].target_name.as_deref(),
+            Some("leaky (pid=4242, start=999)")
+        );
+
+        // The store already has this finding: handling it again must not
+        // write a second row. Recording is decided against the store, not
+        // the log cooldown.
+        mon.handle_finding(&finding).await;
+        let incidents = store
+            .recent_filtered(10, Some("memory_leak"), None)
+            .await
+            .unwrap();
+        assert_eq!(incidents.len(), 1, "repeat findings must not duplicate");
+
+        // A fresh monitor — the daemon restarted, so the bounded in-memory
+        // cooldown map is empty — must not re-record either.
+        let mut mon2 = fake.monitor().with_incident_store(Some(Arc::clone(&store)));
+        mon2.handle_finding(&finding).await;
+        let incidents = store
+            .recent_filtered(10, Some("memory_leak"), None)
+            .await
+            .unwrap();
+        assert_eq!(
+            incidents.len(),
+            1,
+            "a restarted monitor must not duplicate incidents the store already has"
+        );
+    }
+
+    #[tokio::test]
+    async fn failed_insert_is_retried_on_the_next_scan() {
+        let db_dir = TempDir::new().unwrap();
+        let db_path = db_dir.path().join("incidents.db");
+        let finding = warning_finding("leaky");
+
+        // The store is down: the finding is logged, but the failed insert
+        // must not poison future record attempts — recording has no
+        // in-memory cooldown, only the store's own contents.
+        let down_store = Arc::new(IncidentStore::new(&db_path).await.unwrap());
+        down_store.close_pool_for_test().await;
+        let mut mon = MemoryLeakMonitor::new(Duration::from_secs(30))
+            .with_incident_store(Some(Arc::clone(&down_store)));
+        mon.handle_finding(&finding).await;
+
+        // The store recovers (fresh pool on the same file). The next scan
+        // must retry the insert instead of sitting out a cooldown.
+        let up_store = Arc::new(IncidentStore::new(&db_path).await.unwrap());
+        mon.incident_store = Some(Arc::clone(&up_store));
+        mon.handle_finding(&finding).await;
+        let incidents = up_store
+            .recent_filtered(10, Some("memory_leak"), None)
+            .await
+            .unwrap();
+        assert_eq!(
+            incidents.len(),
+            1,
+            "a failed insert must be retried once the store recovers"
+        );
+
+        // And the now-recorded finding dedups against the store: no second row.
+        mon.handle_finding(&finding).await;
+        let incidents = up_store
+            .recent_filtered(10, Some("memory_leak"), None)
+            .await
+            .unwrap();
+        assert_eq!(incidents.len(), 1, "a recorded finding must not duplicate");
+    }
+
+    #[tokio::test]
+    async fn monitor_without_store_stays_log_only() {
+        // No incident store configured: handle_finding must not fail, just log.
+        let mut mon =
+            MemoryLeakMonitor::new(Duration::from_secs(30)).with_warn_cooldown(Duration::ZERO);
+        mon.handle_finding(&warning_finding("leaky")).await;
+    }
+}

--- a/cognitod/src/collectors/memory_leak.rs
+++ b/cognitod/src/collectors/memory_leak.rs
@@ -246,10 +246,10 @@ fn linear_fit(xs: &[f64], ys: &[f64]) -> Option<(f64, f64)> {
     Some((slope, r2.clamp(0.0, 1.0)))
 }
 
-/// Allocator hints from `/proc/<pid>/smaps_rollup`: the `Rss:`, `Anon:`,
-/// and `Private_Dirty:` summary lines (KiB). `None` when the file is
-/// missing or unparseable — absence is not zero. Read once per firing,
-/// never per poll.
+/// Allocator hints from `/proc/<pid>/smaps_rollup`: the `Rss:`,
+/// `Anonymous:`, and `Private_Dirty:` summary lines (KiB). `None` when the
+/// file is missing or unparseable — absence is not zero. Read once per
+/// firing, never per poll.
 fn read_smaps_hints(proc_root: &Path, pid: u32) -> Option<SmapsHints> {
     let content =
         std::fs::read_to_string(proc_root.join(pid.to_string()).join("smaps_rollup")).ok()?;
@@ -264,7 +264,7 @@ fn read_smaps_hints(proc_root: &Path, pid: u32) -> Option<SmapsHints> {
     }
     Some(SmapsHints {
         rss_kb: kb(&content, "Rss:")?,
-        anon_kb: kb(&content, "Anon:")?,
+        anon_kb: kb(&content, "Anonymous:")?,
         private_dirty_kb: kb(&content, "Private_Dirty:")?,
     })
 }
@@ -479,10 +479,15 @@ impl MemoryLeakMonitor {
             }
         });
 
-        // Fit every process with enough in-window history; the worst
-        // sustained grower becomes the finding.
+        // Fit every *live* process with enough in-window history. Dead
+        // incarnations keep their samples for transient read failures, but
+        // a frozen trend from an exited process must not select it as the
+        // finding — or crowd out a smaller live trend.
         let mut worst: Option<MemoryLeak> = None;
         for (&(pid, starttime), baseline) in &self.baselines {
+            if live.get(&pid) != Some(&starttime) {
+                continue;
+            }
             if baseline.samples.len() < MIN_SAMPLES {
                 continue;
             }
@@ -761,7 +766,7 @@ mod tests {
                     d.join("smaps_rollup"),
                     format!(
                         "Rss:                  {rss_kb} kB\n\
-                         Anon:                 {anon_kb} kB\n\
+                         Anonymous:            {anon_kb} kB\n\
                          Private_Dirty:        {pd_kb} kB\n"
                     ),
                 )
@@ -977,6 +982,69 @@ mod tests {
             .expect("must fire");
         let hints = finding.smaps.expect("smaps_rollup readable in fixture");
         assert_eq!(hints.anon_kb, 155 * 1024);
+    }
+
+    #[test]
+    fn smaps_rollup_kernel_format_parses() {
+        // Verbatim 6.x kernel layout: a `[rollup]` header line, then the
+        // real field names. The kernel's field is `Anonymous:`, not
+        // `Anon:` — a fixture using the wrong name masks a production
+        // failure where every firing reports hints as unavailable.
+        let fake = FakeProc::new();
+        let d = fake.dir.path().join("42");
+        fs::create_dir_all(&d).unwrap();
+        fs::write(
+            d.join("smaps_rollup"),
+            "58d32c280000-7ffe54261000 ---p 00000000 00:00 0                          [rollup]\n\
+             Rss:                1668 kB\n\
+             Pss:                 558 kB\n\
+             Shared_Clean:       1520 kB\n\
+             Private_Clean:        40 kB\n\
+             Private_Dirty:       108 kB\n\
+             Referenced:         1668 kB\n\
+             Anonymous:           108 kB\n\
+             KSM:                   0 kB\n",
+        )
+        .unwrap();
+        let hints = read_smaps_hints(fake.dir.path(), 42).expect("kernel-format rollup must parse");
+        assert_eq!(hints.rss_kb, 1668);
+        assert_eq!(hints.anon_kb, 108);
+        assert_eq!(hints.private_dirty_kb, 108);
+    }
+
+    #[test]
+    fn dead_process_does_not_crowd_out_live_trend() {
+        // Two growing processes; the bigger trend exits mid-window. Its
+        // baseline is retained for transient read failures, but the frozen
+        // trend must not be selected as the finding — the smaller *live*
+        // trend must win instead.
+        let fake = FakeProc::new();
+        let mut mon = fake.monitor();
+        let t0 = Instant::now();
+        for i in 0..20u64 {
+            // pid 21: fast grower (~190 MiB over the window).
+            fake.set_proc(21, "big", 7000, mib_pages(100 + i * 10), None);
+            // pid 23: slower but actionable (~76 MiB).
+            fake.set_proc(23, "small", 8000, mib_pages(100 + i * 4), None);
+            mon.tick_at(t0 + Duration::from_secs(30 * i));
+        }
+        // pid 21 exits: its whole proc dir vanishes.
+        fs::remove_dir_all(fake.dir.path().join("21")).unwrap();
+        fake.set_proc(23, "small", 8000, mib_pages(100 + 20 * 4), None);
+        let finding = mon
+            .tick_at(t0 + Duration::from_secs(30 * 20))
+            .expect("live trend must still fire");
+        assert_eq!(
+            finding.pid, 23,
+            "dead process's frozen trend must not be selected"
+        );
+        // And it keeps not firing for the dead incarnation on later polls.
+        fake.set_proc(23, "small", 8000, mib_pages(100 + 21 * 4), None);
+        let finding = mon.tick_at(t0 + Duration::from_secs(30 * 21));
+        assert!(
+            finding.is_none() || finding.unwrap().pid == 23,
+            "no refire for the dead process"
+        );
     }
 
     #[test]

--- a/cognitod/src/collectors/mod.rs
+++ b/cognitod/src/collectors/mod.rs
@@ -1,5 +1,7 @@
 pub mod blkio_stall;
 pub mod cgroup_pressure;
 pub mod fork_storm;
+pub mod memory_leak;
+pub mod oom_witness;
 pub mod psi;
 pub mod runqueue_starvation;

--- a/cognitod/src/collectors/oom_witness.rs
+++ b/cognitod/src/collectors/oom_witness.rs
@@ -1,0 +1,1028 @@
+//! Userspace OOM-kill witness: no eBPF, no privileges beyond /proc, sysfs,
+//! and (best-effort) the kernel ring buffer.
+//!
+//! When the OOM killer fires, the interesting questions are: did it happen,
+//! in which cgroup, and *who* did it take? Userspace can answer the first
+//! two with counters and the third on a good day:
+//!
+//! * **Kill happened (measured):** `/proc/vmstat`'s `oom_kill` counter Δ,
+//!   host-wide. This fires even when cgroup attribution is unavailable.
+//! * **Which cgroup (measured):** per-cgroup `memory.events` `max` Δ. The
+//!   counter is hierarchical, so the witness attributes the kill to the
+//!   *deepest* cgroup(s) whose counter moved — the leaf-most selection
+//!   keeps one kill from being reported once per ancestor. Unlike the
+//!   pressure monitor, kubepods subtrees are *included*: nothing else
+//!   attributes pod OOM kills, and leaf-most selection avoids the
+//!   double-counting that motivated the pressure monitor's skip.
+//! * **Victim (best-effort):** the kernel logs
+//!   `Out of memory: Killed process <pid> (<comm>)` to the ring buffer.
+//!   The victim name is `inferred` — the ring may have rotated, and
+//!   `dmesg` may be restricted — and `unavailable` when it can't be read.
+//!   It is never fabricated.
+//!
+//! Relationship to the cgroup pressure monitor: that monitor already
+//! classifies a per-cgroup `OomKill` *stall verdict* when `memory.events`
+//! `max` moves. The witness is complementary, not duplicative — it adds
+//! the host-wide counter, the victim identity from `dmesg`, and a
+//! dedicated `oom_kill` incident type. One burst of kills in a window is
+//! one finding (the kills are counted, not emitted N times); the 15-min
+//! cooldown and store-backed dedup prevent refires.
+//!
+//! Design:
+//!
+//! * **Poll:** 10s. Counter reads only — `dmesg` is consulted only on
+//!   polls where a kill was actually detected, via an injectable
+//!   [`DmesgSource`], so the common case costs nothing and tests can fake
+//!   the ring buffer.
+//! * **Degradation:** on cgroup-v1-only hosts (no `memory.events`) the
+//!   cgroup half is `unavailable` but the host counter still fires. A
+//!   regressing counter (cgroup recreation) re-baselines instead of
+//!   producing a bogus delta. Unreadable files skip the poll without
+//!   poisoning baselines.
+//! * **eBPF upgrade:** none needed — the OOM killer is already fully
+//!   visible from userspace counters; eBPF would only add per-allocation
+//!   *why* (which this monitor deliberately does not claim).
+
+use log::{debug, info, warn};
+use std::collections::{HashMap, HashSet};
+use std::os::unix::fs::MetadataExt;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+use tokio::time::sleep;
+use walkdir::WalkDir;
+
+use crate::incidents::{Incident, IncidentStore};
+
+/// How deep the cgroup walk goes looking for `memory.events`.
+const CGROUP_MAX_DEPTH: usize = 3;
+/// Default quiet period between repeat warnings for the same
+/// cgroup+victim, mirroring the other monitors.
+const DEFAULT_WARN_COOLDOWN: Duration = Duration::from_secs(15 * 60);
+/// Cap on the warn-cooldown map; oldest entries are evicted past this.
+const MAX_COOLDOWN_ENTRIES: usize = 1024;
+
+/// What an OOM-kill observation means.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum OomVerdict {
+    Healthy,
+    /// The OOM killer fired at least once since the last poll.
+    OomKillObserved,
+}
+
+impl OomVerdict {
+    /// `false` for `Healthy`; used to filter log/report noise.
+    pub fn actionable(self) -> bool {
+        !matches!(self, OomVerdict::Healthy)
+    }
+}
+
+/// Where the victim identity came from.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VictimSource {
+    /// Parsed from the kernel ring buffer: the kernel's own kill record,
+    /// but best-effort — the ring may have rotated past it.
+    Dmesg,
+    /// `dmesg` unreadable, restricted, or no matching line.
+    Unavailable,
+}
+
+/// The process the OOM killer took, when the ring buffer says.
+#[derive(Debug, Clone)]
+pub struct OomVictim {
+    pub pid: Option<u32>,
+    pub comm: Option<String>,
+    pub source: VictimSource,
+}
+
+/// One OOM-kill observation for a scan window. A burst of kills in one
+/// window is a single finding: `kill_count` counts them.
+#[derive(Debug, Clone)]
+pub struct OomKill {
+    /// Deepest cgroup whose `memory.events:max` moved, as a path relative
+    /// to the cgroup root (`/` for the root). `None` when unattributable
+    /// (v1 host, or the walk found nothing).
+    pub cgroup: Option<String>,
+    /// That cgroup's `max` Δ; `None` when the cgroup is unattributed.
+    pub cgroup_max_delta: Option<u64>,
+    /// Host-wide `/proc/vmstat` `oom_kill` Δ; `None` when unreadable.
+    pub host_oom_kill_delta: Option<u64>,
+    /// Kills observed this window: the host Δ when readable, else the sum
+    /// of attributed leaf-cgroup Δs.
+    pub kill_count: u64,
+    /// Every leaf cgroup whose counter moved, deepest-first, for snapshot
+    /// context: `(rel_path, max_delta)`.
+    pub attributed_cgroups: Vec<(String, u64)>,
+    pub victim: OomVictim,
+    pub verdict: OomVerdict,
+}
+
+impl OomKill {
+    /// Stable identity for cooldown and incident-dedup keys: the cgroup
+    /// plus what is known of the victim. An unknown victim can't be told
+    /// apart from another unknown victim in the same cgroup — the key says
+    /// so honestly instead of pretending otherwise.
+    fn victim_label(&self) -> String {
+        let cgroup = self.cgroup.as_deref().unwrap_or("unknown cgroup");
+        let victim = match (&self.victim.comm, self.victim.pid) {
+            (Some(comm), Some(pid)) => format!("{comm} (pid={pid})"),
+            (Some(comm), None) => comm.clone(),
+            (None, Some(pid)) => format!("pid={pid}"),
+            (None, None) => "victim unavailable".to_string(),
+        };
+        format!("oom in {cgroup} ({victim})")
+    }
+}
+
+/// Source of kernel-ring-buffer OOM victim lines. Injectable so tests can
+/// fake the ring buffer and production degrades silently when `dmesg` is
+/// restricted.
+pub trait DmesgSource: Send + Sync {
+    /// The most recent `Killed process` victim in the ring buffer, if any.
+    fn recent_oom_victim(&self) -> Option<(u32, String)>;
+}
+
+/// Production source: shells out to `dmesg` and takes the last matching
+/// line. Only consulted on polls where a kill was detected, so the
+/// subprocess cost lands exactly when it matters.
+pub struct SystemDmesg;
+
+impl DmesgSource for SystemDmesg {
+    fn recent_oom_victim(&self) -> Option<(u32, String)> {
+        let output = std::process::Command::new("dmesg").output().ok()?;
+        if !output.status.success() {
+            debug!("[oom] dmesg exited unsuccessfully; victim unavailable");
+            return None;
+        }
+        let text = String::from_utf8_lossy(&output.stdout);
+        text.lines().filter_map(parse_dmesg_kill).next_back()
+    }
+}
+
+/// Parses one `Out of memory: Killed process <pid> (<comm>) ...` line.
+/// `None` for anything else — the ring is full of unrelated lines.
+fn parse_dmesg_kill(line: &str) -> Option<(u32, String)> {
+    let rest = line.split("Killed process ").nth(1)?;
+    let mut parts = rest.splitn(2, ' ');
+    let pid: u32 = parts.next()?.parse().ok()?;
+    let comm = parts.next()?.strip_prefix('(')?.split(')').next()?;
+    if comm.is_empty() {
+        return None;
+    }
+    Some((pid, comm.to_string()))
+}
+
+/// Host-wide OOM-kill count from `/proc/vmstat`. `None` when the file or
+/// key is missing — absence is not zero.
+fn read_vmstat_oom_kill(proc_root: &Path) -> Option<u64> {
+    let content = std::fs::read_to_string(proc_root.join("vmstat")).ok()?;
+    for line in content.lines() {
+        let mut parts = line.split_whitespace();
+        if parts.next() == Some("oom_kill") {
+            return parts.next()?.parse::<u64>().ok();
+        }
+    }
+    None
+}
+
+/// One `key value` counter from a cgroup `memory.events` file. Missing
+/// file or key -> `None`, never zero: zero is a real reading, absence is
+/// not. (Mirrors the pressure monitor's reader.)
+fn read_memory_events_max(dir: &Path) -> Option<u64> {
+    let content = std::fs::read_to_string(dir.join("memory.events")).ok()?;
+    for line in content.lines() {
+        let mut parts = line.split_whitespace();
+        if parts.next() == Some("max")
+            && let Some(value) = parts.next()
+            && let Ok(v) = value.parse::<u64>()
+        {
+            return Some(v);
+        }
+    }
+    None
+}
+
+/// Cgroup directories (depth-limited) exposing `memory.events`. Returns
+/// `(rel_path, abs_dir)`; the root itself is `/`.
+fn find_cgroup_dirs(root: &Path) -> Vec<(String, PathBuf)> {
+    WalkDir::new(root)
+        .max_depth(CGROUP_MAX_DEPTH)
+        .into_iter()
+        .filter_map(|e| e.ok())
+        .filter(|e| e.file_type().is_dir())
+        .filter(|e| e.path().join("memory.events").is_file())
+        .map(|e| {
+            let rel = e
+                .path()
+                .strip_prefix(root)
+                .ok()
+                .map(|p| p.to_string_lossy().to_string())
+                .filter(|s| !s.is_empty())
+                .unwrap_or_else(|| "/".to_string());
+            (rel, e.path().to_path_buf())
+        })
+        .collect()
+}
+
+/// Keeps only the deepest cgroups with a positive Δ: `memory.events`
+/// counters are hierarchical, so a kill in a leaf also moves every
+/// ancestor. String-prefix matching with a trailing separator keeps
+/// `svc` from shadowing `svc2`.
+fn leaf_cgroups(deltas: &[(String, u64)]) -> Vec<(String, u64)> {
+    deltas
+        .iter()
+        .filter(|(path, _)| {
+            let prefix = if path == "/" {
+                "/".to_string()
+            } else {
+                format!("{path}/")
+            };
+            !deltas
+                .iter()
+                .any(|(other, _)| other != path && other.starts_with(&prefix))
+        })
+        .cloned()
+        .collect()
+}
+
+/// Stateful OOM-kill witness.
+pub struct OomWitnessMonitor {
+    proc_root: PathBuf,
+    cgroup_root: PathBuf,
+    interval: Duration,
+    vmstat_baseline: Option<u64>,
+    /// rel_path -> (dir inode, last `max` counter). The inode is the
+    /// instance identity: a recreated cgroup (new inode, counters reset)
+    /// re-baselines instead of diffing against the dead instance.
+    cgroup_baselines: HashMap<String, (u64, u64)>,
+    dmesg: Box<dyn DmesgSource>,
+    warn_cooldown: Duration,
+    max_iterations: Option<u64>,
+    /// When each cgroup+victim was last warned about.
+    last_warned: HashMap<(String, OomVerdict), Instant>,
+    /// Whether the last incident-record attempt failed (warn-once, then
+    /// debug until a record succeeds — `handle_finding` retries every scan).
+    record_unhealthy: bool,
+    /// Where findings are recorded so they are visible through the API
+    /// and MCP tools, not just the daemon logs. `None` keeps the monitor
+    /// log-only.
+    incident_store: Option<Arc<IncidentStore>>,
+}
+
+impl OomWitnessMonitor {
+    pub fn new(interval: Duration) -> Self {
+        Self {
+            proc_root: PathBuf::from("/proc"),
+            cgroup_root: PathBuf::from("/sys/fs/cgroup"),
+            interval,
+            vmstat_baseline: None,
+            cgroup_baselines: HashMap::new(),
+            dmesg: Box::new(SystemDmesg),
+            warn_cooldown: DEFAULT_WARN_COOLDOWN,
+            max_iterations: None,
+            last_warned: HashMap::new(),
+            record_unhealthy: false,
+            incident_store: None,
+        }
+    }
+
+    /// Points the monitor at fixture trees instead of the live `/proc` and
+    /// `/sys/fs/cgroup`. Test-only in practice; mirrors the other monitors.
+    pub fn with_proc_root(mut self, root: impl Into<PathBuf>) -> Self {
+        self.proc_root = root.into();
+        self
+    }
+
+    pub fn with_cgroup_root(mut self, root: impl Into<PathBuf>) -> Self {
+        self.cgroup_root = root.into();
+        self
+    }
+
+    /// Swaps the ring-buffer source (tests inject a fake; production uses
+    /// `dmesg`).
+    pub fn with_dmesg_source(mut self, source: Box<dyn DmesgSource>) -> Self {
+        self.dmesg = source;
+        self
+    }
+
+    /// Bounds the scan loop so it terminates. Only useful for tests.
+    pub fn with_max_iterations(mut self, iterations: u64) -> Self {
+        self.max_iterations = Some(iterations);
+        self
+    }
+
+    /// Quiet period between repeat warnings for the same cgroup+victim.
+    /// `Duration::ZERO` warns on every occurrence (useful for tests).
+    pub fn with_warn_cooldown(mut self, cooldown: Duration) -> Self {
+        self.warn_cooldown = cooldown;
+        self
+    }
+
+    /// Records findings as `oom_kill` incidents so they surface through
+    /// `/incidents` and the MCP tools, not just the daemon logs. Takes
+    /// `Option` to mirror the other monitors: the store may be unavailable
+    /// (no DB path), in which case the monitor stays log-only.
+    pub fn with_incident_store(mut self, store: Option<Arc<IncidentStore>>) -> Self {
+        self.incident_store = store;
+        self
+    }
+
+    /// Log-reporting gate: true the first time a cgroup+victim reports,
+    /// and again once the cooldown has elapsed. This gates the log line
+    /// only — incident recording is decided separately against the store
+    /// (see `handle_finding`), so a failed insert is retried on the next
+    /// scan instead of being swallowed by this cooldown.
+    fn should_warn(&mut self, finding: &OomKill) -> bool {
+        if self.warn_cooldown.is_zero() {
+            return true;
+        }
+        let key = (finding.victim_label(), finding.verdict);
+        let now = Instant::now();
+        if let Some(last) = self.last_warned.get(&key)
+            && now.duration_since(*last) < self.warn_cooldown
+        {
+            return false;
+        }
+        if self.last_warned.len() >= MAX_COOLDOWN_ENTRIES {
+            let cooldown = self.warn_cooldown;
+            self.last_warned
+                .retain(|_, last| now.duration_since(*last) < cooldown);
+            // Expiry frees nothing when every entry is still inside its
+            // cooldown; evict the oldest instead so the map stays bounded.
+            // Mirrors the other monitors' cap discipline.
+            while self.last_warned.len() >= MAX_COOLDOWN_ENTRIES {
+                let Some(oldest) = self
+                    .last_warned
+                    .iter()
+                    .min_by_key(|(_, last)| **last)
+                    .map(|(k, _)| k.clone())
+                else {
+                    break;
+                };
+                self.last_warned.remove(&oldest);
+            }
+        }
+        self.last_warned.insert(key, now);
+        true
+    }
+
+    /// One poll: Δ the host counter and every cgroup's `max` counter,
+    /// attribute kills to the deepest cgroups, and return a single finding
+    /// when at least one kill was observed. First sightings only establish
+    /// baselines. `dmesg` is consulted only when a kill was detected.
+    pub fn tick(&mut self) -> Option<OomKill> {
+        self.tick_at(Instant::now())
+    }
+
+    fn tick_at(&mut self, _now: Instant) -> Option<OomKill> {
+        // Host counter: the kill definitely happened (measured).
+        let host_delta = match (self.vmstat_baseline, read_vmstat_oom_kill(&self.proc_root)) {
+            (_, None) => {
+                debug!("[oom] /proc/vmstat unreadable; host kill count unavailable");
+                None
+            }
+            (None, Some(cur)) => {
+                self.vmstat_baseline = Some(cur);
+                None
+            }
+            (Some(prev), Some(cur)) if cur < prev => {
+                debug!("[oom] host oom_kill regressed ({prev} -> {cur}); re-baselining");
+                self.vmstat_baseline = Some(cur);
+                None
+            }
+            (Some(prev), Some(cur)) => {
+                self.vmstat_baseline = Some(cur);
+                Some(cur.saturating_sub(prev))
+            }
+        };
+
+        // Per-cgroup `max` Δs, with recreation-aware baselines.
+        let mut deltas: Vec<(String, u64)> = Vec::new();
+        for (rel, dir) in find_cgroup_dirs(&self.cgroup_root) {
+            let Some(cur) = read_memory_events_max(&dir) else {
+                continue;
+            };
+            let ino = std::fs::metadata(&dir).map(|m| m.ino()).unwrap_or(0);
+            match self.cgroup_baselines.get(&rel) {
+                None => {
+                    self.cgroup_baselines.insert(rel, (ino, cur));
+                }
+                Some(&(prev_ino, _prev)) if prev_ino != 0 && ino != 0 && prev_ino != ino => {
+                    debug!("[oom] cgroup {rel} recreated; re-baselining max counter");
+                    self.cgroup_baselines.insert(rel, (ino, cur));
+                }
+                Some(&(_, prev)) if cur < prev => {
+                    debug!("[oom] cgroup {rel} max regressed ({prev} -> {cur}); re-baselining");
+                    self.cgroup_baselines.insert(rel, (ino, cur));
+                }
+                Some(_) => {
+                    let delta = cur.saturating_sub(self.cgroup_baselines[&rel].1);
+                    self.cgroup_baselines.insert(rel.clone(), (ino, cur));
+                    if delta > 0 {
+                        deltas.push((rel, delta));
+                    }
+                }
+            }
+        }
+
+        let attributed = leaf_cgroups(&deltas);
+        // The host counter is authoritative, but a cgroup Δ without a host
+        // Δ is still a kill the cgroup counter saw — take the max rather
+        // than trusting one source blindly.
+        let cgroup_sum: u64 = attributed.iter().map(|(_, d)| d).sum();
+        let kill_count = match host_delta {
+            Some(d) => d.max(cgroup_sum),
+            // vmstat unreadable: the attributed cgroup Δs are the count.
+            None => cgroup_sum,
+        };
+        if kill_count == 0 {
+            return None;
+        }
+
+        // The kill happened — now ask the ring buffer who it took. This
+        // runs at most once per kill-bearing poll.
+        let victim = match self.dmesg.recent_oom_victim() {
+            Some((pid, comm)) => OomVictim {
+                pid: Some(pid),
+                comm: Some(comm),
+                source: VictimSource::Dmesg,
+            },
+            None => OomVictim {
+                pid: None,
+                comm: None,
+                source: VictimSource::Unavailable,
+            },
+        };
+
+        let (cgroup, cgroup_max_delta) = attributed
+            .iter()
+            .max_by_key(|(_, d)| d)
+            .map(|(path, d)| (Some(path.clone()), Some(*d)))
+            .unwrap_or((None, None));
+
+        Some(OomKill {
+            cgroup,
+            cgroup_max_delta,
+            host_oom_kill_delta: host_delta,
+            kill_count,
+            attributed_cgroups: attributed,
+            victim,
+            verdict: OomVerdict::OomKillObserved,
+        })
+    }
+
+    pub async fn run(mut self) {
+        info!("[oom] starting OOM kill witness");
+        let mut iterations = 0u64;
+        loop {
+            if let Some(finding) = self.tick() {
+                self.handle_finding(&finding).await;
+            }
+            iterations += 1;
+            if let Some(max) = self.max_iterations
+                && iterations >= max
+            {
+                break;
+            }
+            sleep(self.interval).await;
+        }
+    }
+
+    /// Reports one actionable finding: log the warning and, when an incident
+    /// store is configured, record it.
+    ///
+    /// Logging rides `should_warn`'s cooldown. Recording is gated only on
+    /// the store itself, which is the source of truth for what was
+    /// persisted: the log cooldown never suppresses a record attempt, so a
+    /// transient insert failure is retried on the next scan instead of
+    /// vanishing for the whole cooldown.
+    async fn handle_finding(&mut self, finding: &OomKill) {
+        if self.should_warn(finding) {
+            report(finding);
+        }
+        let recorded = self.recently_recorded_keys().await;
+        let key = (finding.victim_label(), format!("{:?}", finding.verdict));
+        if recorded.contains(&key) {
+            return;
+        }
+        self.record_incident(finding).await;
+    }
+
+    /// `(victim, verdict)` pairs already incidented within the cooldown
+    /// window. Empty when no store is configured; fail-open when the store
+    /// can't be read — a store that won't answer the dedup query probably
+    /// won't take the insert either, and a duplicate row beats a silently
+    /// dropped incident.
+    async fn recently_recorded_keys(&self) -> HashSet<(String, String)> {
+        let Some(store) = &self.incident_store else {
+            return HashSet::new();
+        };
+        match store
+            .recent_incident_keys("oom_kill", self.warn_cooldown.as_secs())
+            .await
+        {
+            Ok(keys) => keys,
+            Err(e) => {
+                warn!("[oom] couldn't check recent incidents: {e}");
+                HashSet::new()
+            }
+        }
+    }
+
+    /// Best-effort: a failing store must not break the monitoring loop.
+    /// The first failure logs at warn level; repeats stay at debug until a
+    /// record succeeds, since `handle_finding` retries the insert on every
+    /// scan while kills keep being observed.
+    async fn record_incident(&mut self, finding: &OomKill) {
+        let Some(store) = &self.incident_store else {
+            return;
+        };
+        let incident = incident_from_finding(finding);
+        match store.insert(&incident).await {
+            Ok(id) => {
+                debug!(
+                    "[oom] recorded incident #{id} for {}",
+                    finding.victim_label()
+                );
+                self.record_unhealthy = false;
+            }
+            Err(e) => {
+                if self.record_unhealthy {
+                    debug!(
+                        "[oom] still failing to record incident for {}: {e}",
+                        finding.victim_label()
+                    );
+                } else {
+                    warn!(
+                        "[oom] failed to record incident for {}: {e}",
+                        finding.victim_label()
+                    );
+                    self.record_unhealthy = true;
+                }
+            }
+        }
+    }
+}
+
+/// Builds the `oom_kill` incident row for one finding.
+///
+/// Field mapping, kept honest about what this monitor measures:
+/// * `psi_cpu` / `psi_memory` / `cpu_percent` / `load_avg` are host-level
+///   fields this monitor doesn't sample, so they're zero/empty; the
+///   triggering reading is the kill count, carried in `system_snapshot`.
+/// * `target_pid` / `target_name` name the cgroup and, when known, the
+///   victim the ring buffer reported.
+/// * That a kill happened, and in which cgroup, is `measured` counter
+///   data. The victim name is `inferred` (best-effort ring-buffer parse)
+///   or `unavailable`.
+fn incident_from_finding(finding: &OomKill) -> Incident {
+    let attributed: Vec<serde_json::Value> = finding
+        .attributed_cgroups
+        .iter()
+        .map(|(path, delta)| serde_json::json!({ "cgroup": path, "max_delta": delta }))
+        .collect();
+    let victim = serde_json::json!({
+        "pid": finding.victim.pid,
+        "comm": finding.victim.comm,
+        "source": match finding.victim.source {
+            VictimSource::Dmesg => "dmesg",
+            VictimSource::Unavailable => "unavailable",
+        },
+    });
+    let snapshot = serde_json::json!({
+        "cgroup": finding.cgroup,
+        "cgroup_max_delta": finding.cgroup_max_delta,
+        "host_oom_kill_delta": finding.host_oom_kill_delta,
+        "kill_count": finding.kill_count,
+        "attributed_cgroups": attributed,
+        "victim": victim,
+        "source_tier": "polling",
+        "verdict": format!("{:?}", finding.verdict),
+        // The kill and its cgroup are measured counters; the victim name
+        // is a best-effort ring-buffer parse.
+        "evidence": {
+            "kill_occurred": "measured",
+            "cgroup": if finding.cgroup.is_some() { "measured" } else { "unavailable" },
+            "victim": match finding.victim.source {
+                VictimSource::Dmesg => "inferred",
+                VictimSource::Unavailable => "unavailable",
+            },
+        },
+    });
+    Incident {
+        id: None,
+        timestamp: chrono::Utc::now().timestamp(),
+        event_type: "oom_kill".to_string(),
+        psi_cpu: 0.0,
+        psi_memory: 0.0,
+        cpu_percent: 0.0,
+        load_avg: String::new(),
+        action: "alert".to_string(),
+        target_pid: finding.victim.pid.map(|p| p as i32),
+        target_name: Some(finding.victim_label()),
+        system_snapshot: serde_json::to_string(&snapshot).ok(),
+        llm_analysis: None,
+        llm_analyzed_at: None,
+        investigation: None,
+        recovery_time_ms: None,
+        psi_after: None,
+    }
+}
+
+/// One human- and agent-readable line per kill observation. The victim is
+/// labeled with its source — or as unavailable, never guessed.
+fn report(finding: &OomKill) {
+    let cgroup = finding.cgroup.as_deref().unwrap_or("unknown cgroup");
+    let host = match finding.host_oom_kill_delta {
+        Some(d) => format!("host Δ={d}"),
+        None => "host counter unavailable".to_string(),
+    };
+    let victim = match (&finding.victim.comm, finding.victim.pid) {
+        (Some(comm), Some(pid)) => {
+            format!("victim: {comm} (pid={pid}) [via dmesg, best-effort]")
+        }
+        _ => "victim unavailable (dmesg unreadable or ring rotated)".to_string(),
+    };
+    let times = if finding.kill_count == 1 {
+        "once".to_string()
+    } else {
+        format!("{}×", finding.kill_count)
+    };
+    if finding.verdict.actionable() {
+        warn!("[oom] WARNING: OOM killer fired {times} in cgroup {cgroup} ({host}) — {victim}");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    struct FakeDmesg(Option<(u32, String)>);
+
+    impl DmesgSource for FakeDmesg {
+        fn recent_oom_victim(&self) -> Option<(u32, String)> {
+            self.0.clone()
+        }
+    }
+
+    struct FakeProc {
+        dir: TempDir,
+    }
+
+    impl FakeProc {
+        fn new() -> Self {
+            let fake = Self {
+                dir: TempDir::new().unwrap(),
+            };
+            fs::create_dir_all(fake.dir.path().join("proc")).unwrap();
+            fs::create_dir_all(fake.dir.path().join("cgroup")).unwrap();
+            fake
+        }
+
+        fn set_vmstat(&self, oom_kill: u64) {
+            fs::write(
+                self.dir.path().join("proc").join("vmstat"),
+                format!("nr_free_pages 12345\nnr_zone_inactive_anon 678\noom_kill {oom_kill}\n"),
+            )
+            .unwrap();
+        }
+
+        /// (Re)places `<cgroup-root>/<rel>/memory.events` with a `max`
+        /// counter. `rel` is a `/`-separated path like `system.slice/svc`.
+        fn set_cgroup_max(&self, rel: &str, max: u64) {
+            let d = self.dir.path().join("cgroup").join(rel);
+            fs::create_dir_all(&d).unwrap();
+            fs::write(
+                d.join("memory.events"),
+                format!("low 0\nhigh 0\nmax {max}\noom 0\noom_kill {max}\n"),
+            )
+            .unwrap();
+        }
+
+        fn monitor(&self, dmesg: Option<(u32, String)>) -> OomWitnessMonitor {
+            OomWitnessMonitor::new(Duration::from_secs(10))
+                .with_proc_root(self.dir.path().join("proc"))
+                .with_cgroup_root(self.dir.path().join("cgroup"))
+                .with_dmesg_source(Box::new(FakeDmesg(dmesg)))
+        }
+    }
+
+    fn observed_finding(cgroup: Option<&str>, victim: Option<(u32, &str)>) -> OomKill {
+        OomKill {
+            cgroup: cgroup.map(str::to_string),
+            cgroup_max_delta: Some(2),
+            host_oom_kill_delta: Some(2),
+            kill_count: 2,
+            attributed_cgroups: vec![("system.slice/svc".to_string(), 2)],
+            victim: match victim {
+                Some((pid, comm)) => OomVictim {
+                    pid: Some(pid),
+                    comm: Some(comm.to_string()),
+                    source: VictimSource::Dmesg,
+                },
+                None => OomVictim {
+                    pid: None,
+                    comm: None,
+                    source: VictimSource::Unavailable,
+                },
+            },
+            verdict: OomVerdict::OomKillObserved,
+        }
+    }
+
+    #[test]
+    fn parse_dmesg_kill_matrix() {
+        assert_eq!(
+            parse_dmesg_kill(
+                "[12345.678901] Out of memory: Killed process 31359 (myapp) total-vm:123456kB"
+            ),
+            Some((31359, "myapp".to_string()))
+        );
+        // Comm with spaces survives the paren split.
+        assert_eq!(
+            parse_dmesg_kill("[1.2] Out of memory: Killed process 7 (my app) total-vm:1kB"),
+            Some((7, "my app".to_string()))
+        );
+        // Unrelated ring lines parse to nothing.
+        assert_eq!(
+            parse_dmesg_kill("[1.2] CPU0: Core temperature above threshold"),
+            None
+        );
+        assert_eq!(
+            parse_dmesg_kill("[1.2] Out of memory: Kill process 9 (x)"),
+            None
+        );
+        assert_eq!(
+            parse_dmesg_kill("[1.2] Out of memory: Killed process 9 () total-vm:1kB"),
+            None
+        );
+        assert_eq!(parse_dmesg_kill(""), None);
+    }
+
+    #[test]
+    fn detects_host_oom_kill_delta() {
+        let fake = FakeProc::new();
+        let mut mon = fake.monitor(None);
+        let t0 = Instant::now();
+        fake.set_vmstat(0);
+        assert!(
+            mon.tick_at(t0).is_none(),
+            "first poll establishes baselines"
+        );
+        fake.set_vmstat(3);
+        let finding = mon
+            .tick_at(t0 + Duration::from_secs(10))
+            .expect("host oom_kill Δ=3 must fire");
+        assert_eq!(finding.verdict, OomVerdict::OomKillObserved);
+        assert_eq!(finding.kill_count, 3);
+        assert_eq!(finding.host_oom_kill_delta, Some(3));
+        assert!(finding.cgroup.is_none(), "no cgroup dirs in fixture");
+        assert_eq!(finding.victim.source, VictimSource::Unavailable);
+        // No further kills: silence.
+        assert!(mon.tick_at(t0 + Duration::from_secs(20)).is_none());
+    }
+
+    #[test]
+    fn attributes_kill_to_cgroup() {
+        let fake = FakeProc::new();
+        let mut mon = fake.monitor(Some((4242, "hungry".to_string())));
+        let t0 = Instant::now();
+        fake.set_vmstat(0);
+        fake.set_cgroup_max("system.slice/svc", 0);
+        assert!(mon.tick_at(t0).is_none());
+        fake.set_vmstat(2);
+        fake.set_cgroup_max("system.slice/svc", 2);
+        let finding = mon
+            .tick_at(t0 + Duration::from_secs(10))
+            .expect("cgroup max Δ=2 must fire");
+        assert_eq!(finding.cgroup.as_deref(), Some("system.slice/svc"));
+        assert_eq!(finding.cgroup_max_delta, Some(2));
+        assert_eq!(finding.kill_count, 2);
+        assert_eq!(finding.victim.pid, Some(4242));
+        assert_eq!(finding.victim.comm.as_deref(), Some("hungry"));
+        assert_eq!(finding.victim.source, VictimSource::Dmesg);
+    }
+
+    #[test]
+    fn leaf_most_cgroup_wins() {
+        let fake = FakeProc::new();
+        let mut mon = fake.monitor(None);
+        let t0 = Instant::now();
+        fake.set_vmstat(0);
+        fake.set_cgroup_max("app", 0);
+        fake.set_cgroup_max("app/worker", 0);
+        assert!(mon.tick_at(t0).is_none());
+        // Hierarchical counters: the kill moves the leaf and its ancestor.
+        fake.set_vmstat(1);
+        fake.set_cgroup_max("app", 1);
+        fake.set_cgroup_max("app/worker", 1);
+        let finding = mon
+            .tick_at(t0 + Duration::from_secs(10))
+            .expect("must fire");
+        assert_eq!(finding.cgroup.as_deref(), Some("app/worker"));
+        assert_eq!(finding.attributed_cgroups.len(), 1, "one kill, one leaf");
+        // A sibling prefix must not shadow: app2 is not under app/.
+        fake.set_cgroup_max("app2", 0);
+        assert!(mon.tick_at(t0 + Duration::from_secs(20)).is_none());
+        fake.set_vmstat(2);
+        fake.set_cgroup_max("app2", 1);
+        let finding = mon
+            .tick_at(t0 + Duration::from_secs(30))
+            .expect("must fire");
+        assert_eq!(finding.cgroup.as_deref(), Some("app2"));
+    }
+
+    #[test]
+    fn burst_of_kills_is_one_finding() {
+        let fake = FakeProc::new();
+        let mut mon = fake.monitor(None);
+        let t0 = Instant::now();
+        fake.set_vmstat(10);
+        assert!(mon.tick_at(t0).is_none());
+        fake.set_vmstat(15);
+        let finding = mon
+            .tick_at(t0 + Duration::from_secs(10))
+            .expect("Δ=5 must fire");
+        assert_eq!(finding.kill_count, 5, "burst counted, not quintupled");
+    }
+
+    #[test]
+    fn v1_host_still_fires_without_cgroup_attribution() {
+        // No memory.events anywhere (cgroup v1): the host counter alone
+        // must still witness the kill, with the cgroup honestly unknown.
+        let fake = FakeProc::new();
+        let mut mon = fake.monitor(None);
+        let t0 = Instant::now();
+        fake.set_vmstat(0);
+        assert!(mon.tick_at(t0).is_none());
+        fake.set_vmstat(1);
+        let finding = mon
+            .tick_at(t0 + Duration::from_secs(10))
+            .expect("host Δ must fire without cgroups");
+        assert_eq!(finding.kill_count, 1);
+        assert!(finding.cgroup.is_none());
+        assert!(finding.cgroup_max_delta.is_none());
+    }
+
+    #[test]
+    fn regressing_cgroup_counter_rebaselines() {
+        let fake = FakeProc::new();
+        let mut mon = fake.monitor(None);
+        let t0 = Instant::now();
+        fake.set_vmstat(0);
+        fake.set_cgroup_max("svc", 5);
+        assert!(mon.tick_at(t0).is_none());
+        // Cgroup recreated: counter reset to 2. That's a re-baseline, not
+        // a negative (or wrapped) delta — and the host saw no kill.
+        fake.set_cgroup_max("svc", 2);
+        assert!(
+            mon.tick_at(t0 + Duration::from_secs(10)).is_none(),
+            "recreated cgroup must not fabricate a kill"
+        );
+        // …but the new instance's kills are still observed.
+        fake.set_cgroup_max("svc", 3);
+        let finding = mon
+            .tick_at(t0 + Duration::from_secs(20))
+            .expect("new instance kills must fire");
+        assert_eq!(finding.cgroup_max_delta, Some(1));
+    }
+
+    #[test]
+    fn incident_mapping_labels_evidence_honestly() {
+        let finding = observed_finding(Some("system.slice/svc"), Some((4242, "hungry")));
+        let incident = incident_from_finding(&finding);
+        assert_eq!(incident.event_type, "oom_kill");
+        assert_eq!(incident.action, "alert");
+        assert_eq!(incident.target_pid, Some(4242));
+        assert_eq!(
+            incident.target_name.as_deref(),
+            Some("oom in system.slice/svc (hungry (pid=4242))")
+        );
+        let snapshot: serde_json::Value =
+            serde_json::from_str(incident.system_snapshot.as_deref().unwrap()).unwrap();
+        assert_eq!(snapshot["verdict"], "OomKillObserved");
+        assert_eq!(snapshot["kill_count"], 2);
+        // The kill and its cgroup are measured counters; the victim name
+        // is a best-effort ring-buffer parse.
+        assert_eq!(snapshot["evidence"]["kill_occurred"], "measured");
+        assert_eq!(snapshot["evidence"]["cgroup"], "measured");
+        assert_eq!(snapshot["evidence"]["victim"], "inferred");
+        assert_eq!(snapshot["victim"]["source"], "dmesg");
+
+        // Unknown victim: unavailable, never fabricated.
+        let bare = observed_finding(None, None);
+        let incident = incident_from_finding(&bare);
+        assert_eq!(incident.target_pid, None);
+        let snapshot: serde_json::Value =
+            serde_json::from_str(incident.system_snapshot.as_deref().unwrap()).unwrap();
+        assert_eq!(snapshot["evidence"]["cgroup"], "unavailable");
+        assert_eq!(snapshot["evidence"]["victim"], "unavailable");
+        assert_eq!(
+            incident.target_name.as_deref(),
+            Some("oom in unknown cgroup (victim unavailable)")
+        );
+    }
+
+    #[test]
+    fn warn_cooldown_suppresses_repeat_logs() {
+        let mut mon = OomWitnessMonitor::new(Duration::from_secs(10));
+        let finding = observed_finding(Some("svc"), Some((1, "a")));
+        assert!(mon.should_warn(&finding), "first sighting warns");
+        assert!(!mon.should_warn(&finding), "cooldown suppresses the log");
+        // A different victim is a different identity.
+        let mut other = observed_finding(Some("svc"), Some((2, "b")));
+        other.victim.comm = Some("b".to_string());
+        other.victim.pid = Some(2);
+        assert!(
+            mon.should_warn(&other),
+            "distinct victims warn independently"
+        );
+    }
+
+    #[tokio::test]
+    async fn finding_is_recorded_as_incident() {
+        let db_dir = TempDir::new().unwrap();
+        let store = Arc::new(
+            IncidentStore::new(db_dir.path().join("incidents.db"))
+                .await
+                .unwrap(),
+        );
+        let mut mon = OomWitnessMonitor::new(Duration::from_secs(10))
+            .with_incident_store(Some(Arc::clone(&store)));
+        let finding = observed_finding(Some("system.slice/svc"), Some((4242, "hungry")));
+        mon.handle_finding(&finding).await;
+
+        let incidents = store
+            .recent_filtered(10, Some("oom_kill"), None)
+            .await
+            .unwrap();
+        assert_eq!(incidents.len(), 1, "one finding, one incident");
+        assert_eq!(incidents[0].event_type, "oom_kill");
+
+        // The store already has this finding: handling it again must not
+        // write a second row.
+        mon.handle_finding(&finding).await;
+        let incidents = store
+            .recent_filtered(10, Some("oom_kill"), None)
+            .await
+            .unwrap();
+        assert_eq!(incidents.len(), 1, "repeat findings must not duplicate");
+
+        // A fresh monitor — the daemon restarted — must not re-record.
+        let mut mon2 = OomWitnessMonitor::new(Duration::from_secs(10))
+            .with_incident_store(Some(Arc::clone(&store)));
+        mon2.handle_finding(&finding).await;
+        let incidents = store
+            .recent_filtered(10, Some("oom_kill"), None)
+            .await
+            .unwrap();
+        assert_eq!(
+            incidents.len(),
+            1,
+            "a restarted monitor must not duplicate incidents the store already has"
+        );
+    }
+
+    #[tokio::test]
+    async fn failed_insert_is_retried_on_the_next_scan() {
+        let db_dir = TempDir::new().unwrap();
+        let db_path = db_dir.path().join("incidents.db");
+        let finding = observed_finding(Some("svc"), Some((9, "x")));
+
+        let down_store = Arc::new(IncidentStore::new(&db_path).await.unwrap());
+        down_store.close_pool_for_test().await;
+        let mut mon = OomWitnessMonitor::new(Duration::from_secs(10))
+            .with_incident_store(Some(Arc::clone(&down_store)));
+        mon.handle_finding(&finding).await;
+
+        let up_store = Arc::new(IncidentStore::new(&db_path).await.unwrap());
+        mon.incident_store = Some(Arc::clone(&up_store));
+        mon.handle_finding(&finding).await;
+        let incidents = up_store
+            .recent_filtered(10, Some("oom_kill"), None)
+            .await
+            .unwrap();
+        assert_eq!(
+            incidents.len(),
+            1,
+            "a failed insert must be retried once the store recovers"
+        );
+
+        mon.handle_finding(&finding).await;
+        let incidents = up_store
+            .recent_filtered(10, Some("oom_kill"), None)
+            .await
+            .unwrap();
+        assert_eq!(incidents.len(), 1, "a recorded finding must not duplicate");
+    }
+
+    #[tokio::test]
+    async fn monitor_without_store_stays_log_only() {
+        let mut mon =
+            OomWitnessMonitor::new(Duration::from_secs(10)).with_warn_cooldown(Duration::ZERO);
+        mon.handle_finding(&observed_finding(Some("svc"), None))
+            .await;
+    }
+}

--- a/cognitod/src/collectors/oom_witness.rs
+++ b/cognitod/src/collectors/oom_witness.rs
@@ -7,13 +7,15 @@
 //!
 //! * **Kill happened (measured):** `/proc/vmstat`'s `oom_kill` counter Δ,
 //!   host-wide. This fires even when cgroup attribution is unavailable.
-//! * **Which cgroup (measured):** per-cgroup `memory.events` `max` Δ. The
-//!   counter is hierarchical, so the witness attributes the kill to the
-//!   *deepest* cgroup(s) whose counter moved — the leaf-most selection
-//!   keeps one kill from being reported once per ancestor. Unlike the
-//!   pressure monitor, kubepods subtrees are *included*: nothing else
-//!   attributes pod OOM kills, and leaf-most selection avoids the
-//!   double-counting that motivated the pressure monitor's skip.
+//! * **Which cgroup (measured):** per-cgroup `memory.events` `oom_kill`
+//!   Δ. The counter is hierarchical, so the witness attributes the kill
+//!   to the *deepest* cgroup(s) whose counter moved — the leaf-most
+//!   selection keeps one kill from being reported once per ancestor.
+//!   (`max` also moves on limit pressure that reclaim survives, so it is
+//!   not a kill signal and is deliberately not read.) Unlike the pressure
+//!   monitor, kubepods subtrees are *included*: nothing else attributes
+//!   pod OOM kills, and leaf-most selection avoids the double-counting
+//!   that motivated the pressure monitor's skip.
 //! * **Victim (best-effort):** the kernel logs
 //!   `Out of memory: Killed process <pid> (<comm>)` to the ring buffer.
 //!   The victim name is `inferred` — the ring may have rotated, and
@@ -22,8 +24,8 @@
 //!
 //! Relationship to the cgroup pressure monitor: that monitor already
 //! classifies a per-cgroup `OomKill` *stall verdict* when `memory.events`
-//! `max` moves. The witness is complementary, not duplicative — it adds
-//! the host-wide counter, the victim identity from `dmesg`, and a
+//! `oom_kill` moves. The witness is complementary, not duplicative — it
+//! adds the host-wide counter, the victim identity from `dmesg`, and a
 //! dedicated `oom_kill` incident type. One burst of kills in a window is
 //! one finding (the kills are counted, not emitted N times); the 15-min
 //! cooldown and store-backed dedup prevent refires.
@@ -99,19 +101,19 @@ pub struct OomVictim {
 /// window is a single finding: `kill_count` counts them.
 #[derive(Debug, Clone)]
 pub struct OomKill {
-    /// Deepest cgroup whose `memory.events:max` moved, as a path relative
-    /// to the cgroup root (`/` for the root). `None` when unattributable
-    /// (v1 host, or the walk found nothing).
+    /// Deepest cgroup whose `memory.events:oom_kill` moved, as a path
+    /// relative to the cgroup root (`/` for the root). `None` when
+    /// unattributable (v1 host, or the walk found nothing).
     pub cgroup: Option<String>,
-    /// That cgroup's `max` Δ; `None` when the cgroup is unattributed.
-    pub cgroup_max_delta: Option<u64>,
+    /// That cgroup's `oom_kill` Δ; `None` when the cgroup is unattributed.
+    pub cgroup_oom_kill_delta: Option<u64>,
     /// Host-wide `/proc/vmstat` `oom_kill` Δ; `None` when unreadable.
     pub host_oom_kill_delta: Option<u64>,
     /// Kills observed this window: the host Δ when readable, else the sum
     /// of attributed leaf-cgroup Δs.
     pub kill_count: u64,
     /// Every leaf cgroup whose counter moved, deepest-first, for snapshot
-    /// context: `(rel_path, max_delta)`.
+    /// context: `(rel_path, oom_kill_delta)`.
     pub attributed_cgroups: Vec<(String, u64)>,
     pub victim: OomVictim,
     pub verdict: OomVerdict,
@@ -185,14 +187,17 @@ fn read_vmstat_oom_kill(proc_root: &Path) -> Option<u64> {
     None
 }
 
-/// One `key value` counter from a cgroup `memory.events` file. Missing
+/// The `oom_kill` counter from a cgroup `memory.events` file — the only
+/// per-cgroup field that means a kill actually happened (`max` also moves
+/// on limit pressure that reclaim survives, so it is not read). Missing
 /// file or key -> `None`, never zero: zero is a real reading, absence is
-/// not. (Mirrors the pressure monitor's reader.)
-fn read_memory_events_max(dir: &Path) -> Option<u64> {
+/// not. (Mirrors the pressure monitor's reader, which reads this same
+/// key.)
+fn read_memory_events_oom_kill(dir: &Path) -> Option<u64> {
     let content = std::fs::read_to_string(dir.join("memory.events")).ok()?;
     for line in content.lines() {
         let mut parts = line.split_whitespace();
-        if parts.next() == Some("max")
+        if parts.next() == Some("oom_kill")
             && let Some(value) = parts.next()
             && let Ok(v) = value.parse::<u64>()
         {
@@ -227,9 +232,15 @@ fn find_cgroup_dirs(root: &Path) -> Vec<(String, PathBuf)> {
 /// Keeps only the deepest cgroups with a positive Δ: `memory.events`
 /// counters are hierarchical, so a kill in a leaf also moves every
 /// ancestor. String-prefix matching with a trailing separator keeps
-/// `svc` from shadowing `svc2`.
+/// `svc` from shadowing `svc2`. The root entry (`/`) is itself an
+/// ancestor of every descendant, but its rel path carries no leading
+/// slash, so no descendant prefix-matches it — without special handling
+/// the hierarchical root counter would survive alongside the real leaf
+/// and one kill would be counted twice. The root is dropped whenever any
+/// non-root delta exists; it is kept only when it is the sole signal
+/// (host-level kill with no cgroup attribution).
 fn leaf_cgroups(deltas: &[(String, u64)]) -> Vec<(String, u64)> {
-    deltas
+    let mut leaves: Vec<(String, u64)> = deltas
         .iter()
         .filter(|(path, _)| {
             let prefix = if path == "/" {
@@ -242,7 +253,11 @@ fn leaf_cgroups(deltas: &[(String, u64)]) -> Vec<(String, u64)> {
                 .any(|(other, _)| other != path && other.starts_with(&prefix))
         })
         .cloned()
-        .collect()
+        .collect();
+    if leaves.iter().any(|(path, _)| path != "/") {
+        leaves.retain(|(path, _)| path != "/");
+    }
+    leaves
 }
 
 /// Stateful OOM-kill witness.
@@ -251,7 +266,7 @@ pub struct OomWitnessMonitor {
     cgroup_root: PathBuf,
     interval: Duration,
     vmstat_baseline: Option<u64>,
-    /// rel_path -> (dir inode, last `max` counter). The inode is the
+    /// rel_path -> (dir inode, last `oom_kill` counter). The inode is the
     /// instance identity: a recreated cgroup (new inode, counters reset)
     /// re-baselines instead of diffing against the dead instance.
     cgroup_baselines: HashMap<String, (u64, u64)>,
@@ -366,7 +381,7 @@ impl OomWitnessMonitor {
         true
     }
 
-    /// One poll: Δ the host counter and every cgroup's `max` counter,
+    /// One poll: Δ the host counter and every cgroup's `oom_kill` counter,
     /// attribute kills to the deepest cgroups, and return a single finding
     /// when at least one kill was observed. First sightings only establish
     /// baselines. `dmesg` is consulted only when a kill was detected.
@@ -396,10 +411,12 @@ impl OomWitnessMonitor {
             }
         };
 
-        // Per-cgroup `max` Δs, with recreation-aware baselines.
+        // Per-cgroup `oom_kill` Δs, with recreation-aware baselines.
         let mut deltas: Vec<(String, u64)> = Vec::new();
+        let mut seen: HashSet<String> = HashSet::new();
         for (rel, dir) in find_cgroup_dirs(&self.cgroup_root) {
-            let Some(cur) = read_memory_events_max(&dir) else {
+            seen.insert(rel.clone());
+            let Some(cur) = read_memory_events_oom_kill(&dir) else {
                 continue;
             };
             let ino = std::fs::metadata(&dir).map(|m| m.ino()).unwrap_or(0);
@@ -408,11 +425,13 @@ impl OomWitnessMonitor {
                     self.cgroup_baselines.insert(rel, (ino, cur));
                 }
                 Some(&(prev_ino, _prev)) if prev_ino != 0 && ino != 0 && prev_ino != ino => {
-                    debug!("[oom] cgroup {rel} recreated; re-baselining max counter");
+                    debug!("[oom] cgroup {rel} recreated; re-baselining oom_kill counter");
                     self.cgroup_baselines.insert(rel, (ino, cur));
                 }
                 Some(&(_, prev)) if cur < prev => {
-                    debug!("[oom] cgroup {rel} max regressed ({prev} -> {cur}); re-baselining");
+                    debug!(
+                        "[oom] cgroup {rel} oom_kill regressed ({prev} -> {cur}); re-baselining"
+                    );
                     self.cgroup_baselines.insert(rel, (ino, cur));
                 }
                 Some(_) => {
@@ -424,15 +443,29 @@ impl OomWitnessMonitor {
                 }
             }
         }
+        // Drop baselines for cgroups the walk no longer returns (pod churn
+        // on K8s nodes would otherwise grow this map for the daemon's
+        // lifetime). Mirrors the pressure collector's pruning.
+        self.cgroup_baselines.retain(|rel, _| seen.contains(rel));
 
         let attributed = leaf_cgroups(&deltas);
-        // The host counter is authoritative, but a cgroup Δ without a host
-        // Δ is still a kill the cgroup counter saw — take the max rather
-        // than trusting one source blindly.
+        // Firing rule: the host counter is the confirmed kill count. A
+        // cgroup `oom_kill` Δ without a host Δ is inconsistent — the two
+        // move through the same code path — so it is logged, not fired.
+        // When the host counter is unreadable, the per-cgroup `oom_kill`
+        // counters are genuine kill signals on their own.
         let cgroup_sum: u64 = attributed.iter().map(|(_, d)| d).sum();
         let kill_count = match host_delta {
-            Some(d) => d.max(cgroup_sum),
-            // vmstat unreadable: the attributed cgroup Δs are the count.
+            Some(d) if d > 0 => d.max(cgroup_sum),
+            Some(_) => {
+                if cgroup_sum > 0 {
+                    debug!(
+                        "[oom] cgroup oom_kill Δ={cgroup_sum} with no host Δ; \
+                         counters inconsistent, not firing"
+                    );
+                }
+                0
+            }
             None => cgroup_sum,
         };
         if kill_count == 0 {
@@ -454,7 +487,7 @@ impl OomWitnessMonitor {
             },
         };
 
-        let (cgroup, cgroup_max_delta) = attributed
+        let (cgroup, cgroup_oom_kill_delta) = attributed
             .iter()
             .max_by_key(|(_, d)| d)
             .map(|(path, d)| (Some(path.clone()), Some(*d)))
@@ -462,7 +495,7 @@ impl OomWitnessMonitor {
 
         Some(OomKill {
             cgroup,
-            cgroup_max_delta,
+            cgroup_oom_kill_delta,
             host_oom_kill_delta: host_delta,
             kill_count,
             attributed_cgroups: attributed,
@@ -579,7 +612,7 @@ fn incident_from_finding(finding: &OomKill) -> Incident {
     let attributed: Vec<serde_json::Value> = finding
         .attributed_cgroups
         .iter()
-        .map(|(path, delta)| serde_json::json!({ "cgroup": path, "max_delta": delta }))
+        .map(|(path, delta)| serde_json::json!({ "cgroup": path, "oom_kill_delta": delta }))
         .collect();
     let victim = serde_json::json!({
         "pid": finding.victim.pid,
@@ -591,7 +624,7 @@ fn incident_from_finding(finding: &OomKill) -> Incident {
     });
     let snapshot = serde_json::json!({
         "cgroup": finding.cgroup,
-        "cgroup_max_delta": finding.cgroup_max_delta,
+        "cgroup_oom_kill_delta": finding.cgroup_oom_kill_delta,
         "host_oom_kill_delta": finding.host_oom_kill_delta,
         "kill_count": finding.kill_count,
         "attributed_cgroups": attributed,
@@ -689,14 +722,24 @@ mod tests {
             .unwrap();
         }
 
-        /// (Re)places `<cgroup-root>/<rel>/memory.events` with a `max`
-        /// counter. `rel` is a `/`-separated path like `system.slice/svc`.
-        fn set_cgroup_max(&self, rel: &str, max: u64) {
+        /// (Re)places `<cgroup-root>/<rel>/memory.events` with independent
+        /// `max` and `oom_kill` counters. `rel` is a `/`-separated path
+        /// like `system.slice/svc`.
+        fn set_cgroup(&self, rel: &str, max: u64, oom_kill: u64) {
             let d = self.dir.path().join("cgroup").join(rel);
             fs::create_dir_all(&d).unwrap();
             fs::write(
                 d.join("memory.events"),
-                format!("low 0\nhigh 0\nmax {max}\noom 0\noom_kill {max}\n"),
+                format!("low 0\nhigh 0\nmax {max}\noom 0\noom_kill {oom_kill}\n"),
+            )
+            .unwrap();
+        }
+
+        /// (Re)places the cgroup *root's* `memory.events` (rel path `/`).
+        fn set_root_cgroup(&self, max: u64, oom_kill: u64) {
+            fs::write(
+                self.dir.path().join("cgroup").join("memory.events"),
+                format!("low 0\nhigh 0\nmax {max}\noom 0\noom_kill {oom_kill}\n"),
             )
             .unwrap();
         }
@@ -712,7 +755,7 @@ mod tests {
     fn observed_finding(cgroup: Option<&str>, victim: Option<(u32, &str)>) -> OomKill {
         OomKill {
             cgroup: cgroup.map(str::to_string),
-            cgroup_max_delta: Some(2),
+            cgroup_oom_kill_delta: Some(2),
             host_oom_kill_delta: Some(2),
             kill_count: 2,
             attributed_cgroups: vec![("system.slice/svc".to_string(), 2)],
@@ -790,15 +833,15 @@ mod tests {
         let mut mon = fake.monitor(Some((4242, "hungry".to_string())));
         let t0 = Instant::now();
         fake.set_vmstat(0);
-        fake.set_cgroup_max("system.slice/svc", 0);
+        fake.set_cgroup("system.slice/svc", 0, 0);
         assert!(mon.tick_at(t0).is_none());
         fake.set_vmstat(2);
-        fake.set_cgroup_max("system.slice/svc", 2);
+        fake.set_cgroup("system.slice/svc", 2, 2);
         let finding = mon
             .tick_at(t0 + Duration::from_secs(10))
-            .expect("cgroup max Δ=2 must fire");
+            .expect("cgroup oom_kill Δ=2 must fire");
         assert_eq!(finding.cgroup.as_deref(), Some("system.slice/svc"));
-        assert_eq!(finding.cgroup_max_delta, Some(2));
+        assert_eq!(finding.cgroup_oom_kill_delta, Some(2));
         assert_eq!(finding.kill_count, 2);
         assert_eq!(finding.victim.pid, Some(4242));
         assert_eq!(finding.victim.comm.as_deref(), Some("hungry"));
@@ -811,23 +854,23 @@ mod tests {
         let mut mon = fake.monitor(None);
         let t0 = Instant::now();
         fake.set_vmstat(0);
-        fake.set_cgroup_max("app", 0);
-        fake.set_cgroup_max("app/worker", 0);
+        fake.set_cgroup("app", 0, 0);
+        fake.set_cgroup("app/worker", 0, 0);
         assert!(mon.tick_at(t0).is_none());
         // Hierarchical counters: the kill moves the leaf and its ancestor.
         fake.set_vmstat(1);
-        fake.set_cgroup_max("app", 1);
-        fake.set_cgroup_max("app/worker", 1);
+        fake.set_cgroup("app", 1, 1);
+        fake.set_cgroup("app/worker", 1, 1);
         let finding = mon
             .tick_at(t0 + Duration::from_secs(10))
             .expect("must fire");
         assert_eq!(finding.cgroup.as_deref(), Some("app/worker"));
         assert_eq!(finding.attributed_cgroups.len(), 1, "one kill, one leaf");
         // A sibling prefix must not shadow: app2 is not under app/.
-        fake.set_cgroup_max("app2", 0);
+        fake.set_cgroup("app2", 0, 0);
         assert!(mon.tick_at(t0 + Duration::from_secs(20)).is_none());
         fake.set_vmstat(2);
-        fake.set_cgroup_max("app2", 1);
+        fake.set_cgroup("app2", 1, 1);
         let finding = mon
             .tick_at(t0 + Duration::from_secs(30))
             .expect("must fire");
@@ -863,7 +906,7 @@ mod tests {
             .expect("host Δ must fire without cgroups");
         assert_eq!(finding.kill_count, 1);
         assert!(finding.cgroup.is_none());
-        assert!(finding.cgroup_max_delta.is_none());
+        assert!(finding.cgroup_oom_kill_delta.is_none());
     }
 
     #[test]
@@ -872,21 +915,136 @@ mod tests {
         let mut mon = fake.monitor(None);
         let t0 = Instant::now();
         fake.set_vmstat(0);
-        fake.set_cgroup_max("svc", 5);
+        fake.set_cgroup("svc", 5, 5);
         assert!(mon.tick_at(t0).is_none());
         // Cgroup recreated: counter reset to 2. That's a re-baseline, not
         // a negative (or wrapped) delta — and the host saw no kill.
-        fake.set_cgroup_max("svc", 2);
+        fake.set_cgroup("svc", 2, 2);
         assert!(
             mon.tick_at(t0 + Duration::from_secs(10)).is_none(),
             "recreated cgroup must not fabricate a kill"
         );
-        // …but the new instance's kills are still observed.
-        fake.set_cgroup_max("svc", 3);
+        // …but the new instance's kills are still observed (host and
+        // cgroup agree a kill happened).
+        fake.set_vmstat(1);
+        fake.set_cgroup("svc", 3, 3);
         let finding = mon
             .tick_at(t0 + Duration::from_secs(20))
             .expect("new instance kills must fire");
-        assert_eq!(finding.cgroup_max_delta, Some(1));
+        assert_eq!(finding.cgroup_oom_kill_delta, Some(1));
+        assert_eq!(finding.kill_count, 1);
+    }
+
+    #[test]
+    fn max_only_delta_does_not_fire() {
+        // `max` moves on limit pressure that reclaim survives — it is not
+        // a kill signal, so a `max`-only delta must not fire even when the
+        // host reports no kill.
+        let fake = FakeProc::new();
+        let mut mon = fake.monitor(None);
+        let t0 = Instant::now();
+        fake.set_vmstat(0);
+        fake.set_cgroup("system.slice/svc", 0, 0);
+        assert!(mon.tick_at(t0).is_none());
+        fake.set_cgroup("system.slice/svc", 7, 0);
+        assert!(
+            mon.tick_at(t0 + Duration::from_secs(10)).is_none(),
+            "max-only pressure must not fabricate an oom_kill incident"
+        );
+        // The `oom_kill` field moving with the host counter is a kill.
+        fake.set_vmstat(2);
+        fake.set_cgroup("system.slice/svc", 7, 2);
+        let finding = mon
+            .tick_at(t0 + Duration::from_secs(20))
+            .expect("oom_kill Δ + host Δ must fire");
+        assert_eq!(finding.cgroup.as_deref(), Some("system.slice/svc"));
+        assert_eq!(finding.cgroup_oom_kill_delta, Some(2));
+        assert_eq!(finding.kill_count, 2);
+    }
+
+    #[test]
+    fn cgroup_delta_without_host_delta_does_not_fire() {
+        // Both counters move through the same kernel path: a cgroup
+        // `oom_kill` Δ with no host Δ is inconsistent data, not a kill.
+        let fake = FakeProc::new();
+        let mut mon = fake.monitor(None);
+        let t0 = Instant::now();
+        fake.set_vmstat(0);
+        fake.set_cgroup("svc", 0, 0);
+        assert!(mon.tick_at(t0).is_none());
+        fake.set_cgroup("svc", 0, 1);
+        assert!(
+            mon.tick_at(t0 + Duration::from_secs(10)).is_none(),
+            "cgroup-only delta with host Δ=0 must not fire"
+        );
+    }
+
+    #[test]
+    fn root_cgroup_is_dropped_when_a_child_reports() {
+        // The root's hierarchical counter moves with every child kill, but
+        // its rel path ("/") never prefix-matches descendants — without
+        // special handling one kill would be counted twice in cgroup_sum.
+        let fake = FakeProc::new();
+        let mut mon = fake.monitor(None);
+        let t0 = Instant::now();
+        fake.set_vmstat(0);
+        fake.set_root_cgroup(0, 0);
+        fake.set_cgroup("app", 0, 0);
+        assert!(mon.tick_at(t0).is_none());
+        fake.set_vmstat(1);
+        fake.set_root_cgroup(1, 1);
+        fake.set_cgroup("app", 1, 1);
+        let finding = mon
+            .tick_at(t0 + Duration::from_secs(10))
+            .expect("must fire");
+        assert_eq!(finding.cgroup.as_deref(), Some("app"));
+        assert!(
+            !finding.attributed_cgroups.iter().any(|(p, _)| p == "/"),
+            "root must not survive leaf-most filtering alongside a child"
+        );
+        assert_eq!(finding.kill_count, 1, "one kill, counted once");
+    }
+
+    #[test]
+    fn root_only_kill_is_still_reported() {
+        // Root retained only when it is the sole signal (host-level kill
+        // with no cgroup attribution).
+        let fake = FakeProc::new();
+        let mut mon = fake.monitor(None);
+        let t0 = Instant::now();
+        fake.set_vmstat(0);
+        fake.set_root_cgroup(0, 0);
+        assert!(mon.tick_at(t0).is_none());
+        fake.set_vmstat(1);
+        fake.set_root_cgroup(1, 1);
+        let finding = mon
+            .tick_at(t0 + Duration::from_secs(10))
+            .expect("must fire");
+        assert_eq!(finding.cgroup.as_deref(), Some("/"));
+        assert_eq!(finding.kill_count, 1);
+    }
+
+    #[test]
+    fn vanished_cgroup_baseline_is_pruned() {
+        // Pod churn must not grow cgroup_baselines for the daemon's
+        // lifetime: entries for dirs the walk no longer returns are
+        // dropped after the scan.
+        let fake = FakeProc::new();
+        let mut mon = fake.monitor(None);
+        let t0 = Instant::now();
+        fake.set_vmstat(0);
+        fake.set_cgroup("kubepods/pod-a", 0, 0);
+        assert!(mon.tick_at(t0).is_none());
+        assert!(
+            mon.cgroup_baselines.contains_key("kubepods/pod-a"),
+            "baseline established on first sighting"
+        );
+        std::fs::remove_dir_all(fake.dir.path().join("cgroup").join("kubepods")).unwrap();
+        assert!(mon.tick_at(t0 + Duration::from_secs(10)).is_none());
+        assert!(
+            !mon.cgroup_baselines.contains_key("kubepods/pod-a"),
+            "vanished cgroup must be pruned"
+        );
     }
 
     #[test]

--- a/cognitod/src/main.rs
+++ b/cognitod/src/main.rs
@@ -1023,6 +1023,39 @@ async fn main() -> Result<(), Box<dyn Error>> {
         });
     }
 
+    // Memory leak trend monitor: per-process RSS from /proc/<pid>/statm
+    // sampled every 30s, least-squares fit over a 15-min window. Fires on a
+    // sustained positive trend (R² > 0.8, >50MB fitted growth) — reported
+    // as "consistent with a leak", never a leak (inferred).
+    {
+        let monitor = cognitod::collectors::memory_leak::MemoryLeakMonitor::new(
+            std::time::Duration::from_secs(30),
+        )
+        // Leak findings become queryable incidents for the API and MCP
+        // tools, not just log lines.
+        .with_incident_store(incident_store.clone());
+        tokio::spawn(async move {
+            monitor.run().await;
+        });
+    }
+
+    // OOM kill witness: /proc/vmstat oom_kill Δ (host-wide, measured) plus
+    // per-cgroup memory.events max Δ (deepest cgroup attributed), with
+    // best-effort victim identity from the kernel ring buffer. Complements
+    // the cgroup pressure monitor's OomKill stall verdict with a dedicated
+    // incident type and victim attribution.
+    {
+        let monitor = cognitod::collectors::oom_witness::OomWitnessMonitor::new(
+            std::time::Duration::from_secs(10),
+        )
+        // Kill findings become queryable incidents for the API and MCP
+        // tools, not just log lines.
+        .with_incident_store(incident_store.clone());
+        tokio::spawn(async move {
+            monitor.run().await;
+        });
+    }
+
     // Initialize Slack Notifier
     let _slack_notifier = if let Some(ref notif_cfg) = config.notifications {
         if let Some(ref slack_cfg) = notif_cfg.slack {


### PR DESCRIPTION
## Summary

D6 + D7 from the userspace detector spec: the memory pillar. This completes all 8 spec detectors in userspace. Same monitor/incident pattern as #109–#112. No eBPF, no privileges beyond /proc.

## D6 — memory leak trend (`memory_leak` incidents)

- **Signal:** per-process RSS from `/proc/<pid>/statm` sampled every 30 s; least-squares linear fit over a 15-min window (30 samples at full coverage).
- **Fire:** positive slope AND R² > 0.8 AND fitted growth (slope × in-window span) > 50 MB. Single `LeakWarning` verdict — RSS growth is never proof of a leak, so there is no "critical".
- **Honesty:** the finding says "growth trend consistent with a leak"; evidence is `inferred` everywhere. A one-time `smaps_rollup` read per firing adds anon/file-backed breakdown hints; unreadable → `smaps: unavailable`, never fabricated.
- **PID reuse:** baselines keyed on (pid, process starttime); a new incarnation drops the old baseline immediately so a dead process's frozen trend can't keep firing.
- **Warm-up:** ≥ 15 samples required; growth uses the in-window span, so partial windows under-report by construction.

## D7 — OOM kill witness (`oom_kill` incidents)

- **Signals:** `/proc/vmstat oom_kill` Δ (host, measured) + per-cgroup `memory.events` `max` Δ (depth-3 walk). Attribution is **leaf-most**: hierarchical counters move ancestors too, so only the deepest cgroups with Δ > 0 are reported (prefix matching with a trailing separator so `svc` can't shadow `svc2`).
- **kubepods:** included, unlike the pressure monitor — nothing else attributes pod OOM kills, and leaf-most selection avoids the double-counting that motivated the pressure monitor's skip.
- **Victim identity:** best-effort from the kernel ring buffer (last `Killed process <pid> (<comm>)` line, read only on kill-bearing polls); labeled `inferred`, `unavailable` when the ring rotated or dmesg is restricted. Injectable `DmesgSource` keeps this testable.
- **One burst = one finding** (`kill_count` counts kills); kill_count = max(host Δ, cgroup Σ) so a cgroup Δ without a host Δ still fires. v1 hosts degrade to host-only with cgroup `unavailable`; cgroup recreation detected via inode + counter regression → re-baseline.

## Incident wiring

Same discipline as #110–#112: store-backed dedup via `recent_incident_keys`, 15-min per-identity log cooldown on the bounded 1024-entry map, failed inserts retried next scan with warn-once-then-debug. No CLI changes — the generic snapshot renderer covers the new types.

## Validation

- `cargo test -p cognitod --lib`: 250/250 (225 pre-existing + 25 new)
- `cargo test -p linnix-cli`: all suites pass
- `cargo +nightly fmt --all -- --check`: clean
- `cargo clippy` (cognitod + linnix-cli, --all-targets, -D warnings): clean

## Notes

- D6 thresholds (50 MB, R² > 0.8) are spec heuristics, not production data — expect retuning against real fleets.
- A cgroup OOM now surfaces as both a `cgroup_pressure` incident (verdict `OomKill`) and an `oom_kill` witness incident: complementary, not duplicative — stall ranking vs victim identity.
- With simultaneous kills in different cgroups, the dmesg victim may belong to a different kill than the attributed cgroup; the snapshot carries both, labeled accordingly.