### PR TITLE
store: add incident retention (TTL) with daily prune loop

### DIFF
--- a/cognitod/src/api/mod.rs
+++ b/cognitod/src/api/mod.rs
@@ -1245,6 +1245,7 @@ pub async fn healthz(State(app_state): State<Arc<AppState>>) -> axum::Json<serde
         "status": "ok",
         "kernel_instrumentation": if instrumented { "active" } else { "unavailable" },
         "transport": app_state.transport,
+        "incident_retention_days": app_state.incident_retention_days,
     }))
 }
 
@@ -1824,6 +1825,9 @@ pub struct AppState {
     pub slack_signing_secret: Option<String>,
     pub enforcement: Option<Arc<crate::enforcement::EnforcementQueue>>,
     pub incident_store: Option<Arc<IncidentStore>>,
+    /// Configured incident retention in days (`[incidents] retention_days`).
+    /// `None` means pruning is disabled and incidents are kept forever.
+    pub incident_retention_days: Option<u64>,
     pub k8s: Option<Arc<cognitod::k8s::K8sContext>>,
     /// Noisy-neighbour counters fed by the PSI monitor's attribution sink.
     pub blame_metrics: Arc<cognitod::attribution::BlameMetrics>,
@@ -2783,6 +2787,7 @@ mod tests {
             auth_token,
             slack_signing_secret,
             incident_store: None,
+            incident_retention_days: None,
             k8s: None,
             blame_metrics: Arc::new(cognitod::attribution::BlameMetrics::new("test-node")),
         })
@@ -2805,6 +2810,7 @@ mod tests {
             auth_token: None,
             slack_signing_secret: None,
             incident_store: Some(store),
+            incident_retention_days: None,
             k8s: None,
             blame_metrics: Arc::new(cognitod::attribution::BlameMetrics::new("test-node")),
         })
@@ -3170,6 +3176,7 @@ mod tests {
             auth_token: None,
             slack_signing_secret: None,
             incident_store: None,
+            incident_retention_days: None,
             k8s: None,
             blame_metrics: Arc::new(cognitod::attribution::BlameMetrics::new("test-node")),
         })
@@ -3219,6 +3226,7 @@ mod tests {
             auth_token: None,
             slack_signing_secret: None,
             incident_store: None,
+            incident_retention_days: None,
             k8s: None,
             blame_metrics: Arc::new(cognitod::attribution::BlameMetrics::new("test-node")),
         });
@@ -3281,6 +3289,7 @@ mod tests {
             auth_token: None,
             slack_signing_secret: None,
             incident_store: None,
+            incident_retention_days: None,
             k8s: None,
             blame_metrics: Arc::new(cognitod::attribution::BlameMetrics::new("test-node")),
         });
@@ -3332,6 +3341,7 @@ mod tests {
             auth_token: None,
             slack_signing_secret: None,
             incident_store: None,
+            incident_retention_days: None,
             k8s: None,
             blame_metrics: Arc::new(cognitod::attribution::BlameMetrics::new("test-node")),
         });
@@ -3366,6 +3376,7 @@ mod tests {
             auth_token: None,
             slack_signing_secret: None,
             incident_store: None,
+            incident_retention_days: None,
             k8s: None,
             blame_metrics: Arc::new(cognitod::attribution::BlameMetrics::new("test-node")),
         });
@@ -3403,6 +3414,7 @@ mod tests {
             auth_token: None,
             slack_signing_secret: None,
             incident_store: None,
+            incident_retention_days: None,
             k8s: None,
             blame_metrics: Arc::new(cognitod::attribution::BlameMetrics::new("test-node")),
         });
@@ -3454,6 +3466,7 @@ mod tests {
             auth_token: None,
             slack_signing_secret: None,
             incident_store: None,
+            incident_retention_days: None,
             k8s: None,
             blame_metrics: Arc::new(cognitod::attribution::BlameMetrics::new("test-node")),
         });
@@ -3556,6 +3569,7 @@ mod tests {
             prometheus_enabled: false,
             alert_history: Arc::new(AlertHistory::new(16)),
             incident_store: None,
+            incident_retention_days: None,
             auth_token: Some("secret123".to_string()),
             slack_signing_secret: None,
             k8s: None,
@@ -3607,6 +3621,7 @@ mod tests {
             auth_token: Some("secret-from-kubernetes".to_string()),
             slack_signing_secret: None,
             incident_store: None,
+            incident_retention_days: None,
             k8s: None,
             blame_metrics: Arc::new(cognitod::attribution::BlameMetrics::new("test-node")),
         });
@@ -3674,6 +3689,7 @@ mod tests {
             prometheus_enabled: false,
             alert_history: Arc::new(AlertHistory::new(16)),
             incident_store: None,
+            incident_retention_days: None,
             auth_token: Some("secret123".to_string()),
             slack_signing_secret: None,
             k8s: None,
@@ -3711,6 +3727,7 @@ mod tests {
             prometheus_enabled: false,
             alert_history: Arc::new(AlertHistory::new(16)),
             incident_store: None,
+            incident_retention_days: None,
             auth_token: Some("secret123".to_string()),
             slack_signing_secret: None,
             k8s: None,
@@ -3748,6 +3765,7 @@ mod tests {
             prometheus_enabled: false,
             alert_history: Arc::new(AlertHistory::new(16)),
             incident_store: None,
+            incident_retention_days: None,
             auth_token: Some("secret123".to_string()),
             slack_signing_secret: None,
             k8s: None,
@@ -4026,6 +4044,7 @@ mod tests {
             auth_token: None,
             slack_signing_secret: None,
             incident_store: None,
+            incident_retention_days: None,
             k8s: None,
             blame_metrics: Arc::clone(&blame),
         });
@@ -4309,6 +4328,7 @@ mod tests {
             auth_token: None,
             slack_signing_secret: None,
             incident_store: Some(Arc::clone(&store)),
+            incident_retention_days: None,
             k8s: None,
             blame_metrics: Arc::new(cognitod::attribution::BlameMetrics::new("test-node")),
         });
@@ -4422,6 +4442,7 @@ mod tests {
             auth_token: None,
             slack_signing_secret: None,
             incident_store: Some(Arc::clone(&store)),
+            incident_retention_days: None,
             k8s: None,
             blame_metrics: Arc::new(cognitod::attribution::BlameMetrics::new("test-node")),
         });
@@ -4748,6 +4769,7 @@ mod tests {
             auth_token: None,
             slack_signing_secret: None,
             incident_store: Some(Arc::clone(&store)),
+            incident_retention_days: None,
             k8s: None,
             blame_metrics: Arc::new(cognitod::attribution::BlameMetrics::new("test-node")),
         });
@@ -4894,6 +4916,7 @@ mod tests {
             auth_token: None,
             slack_signing_secret: None,
             incident_store: Some(Arc::clone(&store)),
+            incident_retention_days: None,
             k8s: None,
             blame_metrics: Arc::new(cognitod::attribution::BlameMetrics::new("test-node")),
         });
@@ -5001,6 +5024,7 @@ mod tests {
             prometheus_enabled: false,
             alert_history: Arc::new(AlertHistory::new(16)),
             incident_store: None,
+            incident_retention_days: None,
             auth_token: Some("secret123".to_string()),
             slack_signing_secret: None,
             k8s: None,

--- a/cognitod/src/config.rs
+++ b/cognitod/src/config.rs
@@ -355,6 +355,11 @@ impl Config {
                 "unrecognised key `{key}` in [telemetry] (not read by the daemon)"
             ));
         }
+        for key in config.incidents.unknown.keys() {
+            problems.push(format!(
+                "unrecognised key `{key}` in [incidents] (not read by the daemon)"
+            ));
+        }
         problems.extend(config.telemetry.range_problems());
         problems
     }
@@ -391,6 +396,16 @@ impl Config {
             log::warn!(
                 "[config] ignoring unrecognised key(s) in [reasoner]: {}. \
                  These are not read by the daemon and have no effect. \
+                 Run `cognitod --check-config` to validate.",
+                keys.join(", ")
+            );
+        }
+        if !self.incidents.unknown.is_empty() {
+            let keys: Vec<&str> = self.incidents.unknown.keys().map(String::as_str).collect();
+            log::warn!(
+                "[config] ignoring unrecognised key(s) in [incidents]: {}. \
+                 These are not read by the daemon and have no effect — a \
+                 typo'd `retention_day` leaves pruning disabled. \
                  Run `cognitod --check-config` to validate.",
                 keys.join(", ")
             );
@@ -707,6 +722,12 @@ pub struct IncidentsConfig {
     /// means "retain forever" — the prune task is not even spawned.
     #[serde(default)]
     pub retention_days: Option<u64>,
+    /// Keys present in `[incidents]` that no field matches. Captured rather
+    /// than discarded so `warn_unknown_keys` and `Config::check` can name
+    /// them — a typo'd `retention_day` is otherwise indistinguishable from
+    /// having configured nothing, and pruning would stay silently disabled.
+    #[serde(flatten)]
+    pub unknown: std::collections::BTreeMap<String, toml::Value>,
 }
 
 fn default_attribution_threshold_ms() -> u64 {
@@ -1229,6 +1250,33 @@ timeout_ms = 30000
         assert_eq!(problems.len(), 2, "got: {problems:?}");
         assert!(problems.iter().any(|p| p.contains("reasner")));
         assert!(problems.iter().any(|p| p.contains("window_seconds")));
+    }
+
+    #[test]
+    fn check_flags_a_misspelled_incidents_key() {
+        // Without the unknown-key capture, a typo'd `retention_day` parses
+        // fine, `retention_days` stays `None`, and pruning stays silently
+        // disabled. The check must name the key.
+        let mut file = NamedTempFile::new().unwrap();
+        writeln!(file, "[incidents]\nretention_day = 30").unwrap();
+
+        let problems = Config::check(file.path());
+        assert!(
+            problems
+                .iter()
+                .any(|p| p.contains("retention_day") && p.contains("[incidents]")),
+            "a typo'd [incidents] key must be flagged, got: {problems:?}"
+        );
+    }
+
+    #[test]
+    fn check_passes_a_correct_incidents_section() {
+        let mut file = NamedTempFile::new().unwrap();
+        writeln!(file, "[incidents]\nretention_days = 30").unwrap();
+        assert!(
+            Config::check(file.path()).is_empty(),
+            "a correct [incidents] section must be clean"
+        );
     }
 
     #[test]

--- a/cognitod/src/config.rs
+++ b/cognitod/src/config.rs
@@ -215,6 +215,8 @@ pub struct Config {
     #[serde(default)]
     pub episode_capture: EpisodeCaptureConfig,
     #[serde(default)]
+    pub incidents: IncidentsConfig,
+    #[serde(default)]
     pub telemetry: TelemetrySettings,
     /// Top-level sections/keys no field matches. Captured so `--check-config`
     /// can name them; a typo'd `[reasner]` is otherwise indistinguishable from
@@ -691,6 +693,22 @@ fn default_episode_capture_output_dir() -> String {
     "/var/lib/linnix/episodes".to_string()
 }
 
+/// `[incidents]` — incident store retention.
+///
+/// The incident store would otherwise grow for the lifetime of the daemon.
+/// A background task prunes rows older than the configured TTL once a day
+/// (and once shortly after startup). Unset or 0 disables pruning entirely:
+/// retention is opt-in at the code level, so an existing config that never
+/// mentions this section can never lose rows to it. The shipped default
+/// config sets 30 days.
+#[derive(Debug, Deserialize, Clone, Default)]
+pub struct IncidentsConfig {
+    /// Days of incident history to retain. `None` (key absent) or `Some(0)`
+    /// means "retain forever" — the prune task is not even spawned.
+    #[serde(default)]
+    pub retention_days: Option<u64>,
+}
+
 fn default_attribution_threshold_ms() -> u64 {
     100
 }
@@ -817,6 +835,35 @@ offline = true
         assert_eq!(cfg.runtime.event_queue_capacity, 4096);
         assert_eq!(cfg.api.listen_addr, "127.0.0.1:3000");
         assert!(cfg.api.auth_token.is_none());
+    }
+
+    #[test]
+    fn incident_retention_is_unset_by_default() {
+        // Absent means retain forever: an existing config that never mentions
+        // the section must not lose rows to pruning.
+        let toml = r#"[runtime]
+offline = true
+"#;
+        let cfg: Config = toml::from_str(toml).unwrap();
+        assert_eq!(cfg.incidents.retention_days, None);
+    }
+
+    #[test]
+    fn incident_retention_days_parses() {
+        let toml = r#"[incidents]
+retention_days = 30
+"#;
+        let cfg: Config = toml::from_str(toml).unwrap();
+        assert_eq!(cfg.incidents.retention_days, Some(30));
+    }
+
+    #[test]
+    fn incident_retention_zero_parses_as_disabled() {
+        let toml = r#"[incidents]
+retention_days = 0
+"#;
+        let cfg: Config = toml::from_str(toml).unwrap();
+        assert_eq!(cfg.incidents.retention_days, Some(0));
     }
 
     #[test]

--- a/cognitod/src/incidents.rs
+++ b/cognitod/src/incidents.rs
@@ -126,6 +126,20 @@ const REQUIRED_COLUMNS: &[RequiredColumn] = &[
     },
 ];
 
+/// Cutoff (unix seconds) for incident retention: rows with
+/// `timestamp < cutoff` are pruned by
+/// [`IncidentStore::prune_older_than`].
+///
+/// Returns `None` when retention is disabled — an unset key and an explicit
+/// `0` both mean "retain forever", and the daemon must not delete anything
+/// in that case. Saturating arithmetic keeps absurd values (e.g.
+/// `u64::MAX` days) from wrapping the cutoff into the future.
+pub fn retention_cutoff_unix(retention_days: Option<u64>, now_unix: i64) -> Option<i64> {
+    let days = retention_days.filter(|d| *d > 0)?;
+    let ttl_secs = i64::try_from(days.saturating_mul(86_400)).unwrap_or(i64::MAX);
+    Some(now_unix.saturating_sub(ttl_secs))
+}
+
 impl IncidentStore {
     /// Create a new incident store
     pub async fn new<P: AsRef<Path>>(db_path: P) -> Result<Self, sqlx::Error> {
@@ -685,6 +699,22 @@ impl IncidentStore {
             .await
     }
 
+    /// Delete incident rows strictly older than `cutoff` (unix seconds).
+    /// Returns the number of rows deleted.
+    ///
+    /// Type-agnostic: every event type is pruned by the same TTL. The
+    /// comparison is strictly older-than, so a row exactly at the cutoff is
+    /// kept. The monitor dedup windows (minutes) are orders of magnitude
+    /// shorter than any sane TTL (days), so pruning can never remove a row
+    /// the dedup logic still needs.
+    pub async fn prune_older_than(&self, cutoff: i64) -> Result<u64, sqlx::Error> {
+        let result = sqlx::query("DELETE FROM incidents WHERE timestamp < ?")
+            .bind(cutoff)
+            .execute(&self.pool)
+            .await?;
+        Ok(result.rows_affected())
+    }
+
     /// Test-only: simulates a transient store outage by closing the pool,
     /// so inserts and queries fail with `PoolClosed`. The pool cannot be
     /// reopened — build a new store to recover.
@@ -1036,6 +1066,116 @@ mod tests {
                     "wrong_culprit".to_string()
                 ),
             ]
+        );
+    }
+
+    fn incident_at(event_type: &str, timestamp: i64) -> Incident {
+        let mut inc = incident(event_type);
+        inc.timestamp = timestamp;
+        inc
+    }
+
+    #[test]
+    fn retention_cutoff_none_or_zero_is_disabled() {
+        let now = 1_800_000_000_i64;
+        assert_eq!(retention_cutoff_unix(None, now), None);
+        assert_eq!(retention_cutoff_unix(Some(0), now), None);
+        assert_eq!(
+            retention_cutoff_unix(Some(30), now),
+            Some(now - 30 * 86_400)
+        );
+    }
+
+    #[tokio::test]
+    async fn prune_deletes_only_strictly_older_rows() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = IncidentStore::new(dir.path().join("incidents.db"))
+            .await
+            .unwrap();
+        let now = Utc::now().timestamp();
+        let cutoff = now - 30 * 86_400;
+
+        let old_id = store
+            .insert(&incident_at("fork_storm", cutoff - 1))
+            .await
+            .unwrap();
+        let boundary_id = store
+            .insert(&incident_at("fork_storm", cutoff))
+            .await
+            .unwrap();
+        let recent_id = store.insert(&incident_at("fork_storm", now)).await.unwrap();
+
+        let deleted = store.prune_older_than(cutoff).await.unwrap();
+        assert_eq!(deleted, 1, "only the strictly-older row is deleted");
+
+        assert!(store.get(old_id).await.unwrap().is_none());
+        assert!(store.get(boundary_id).await.unwrap().is_some());
+        assert!(store.get(recent_id).await.unwrap().is_some());
+    }
+
+    #[tokio::test]
+    async fn prune_is_type_agnostic() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = IncidentStore::new(dir.path().join("incidents.db"))
+            .await
+            .unwrap();
+        let now = Utc::now().timestamp();
+        let cutoff = now - 30 * 86_400;
+
+        for event_type in [
+            "cgroup_pressure",
+            "fork_storm",
+            "cpu_starvation",
+            "blkio_stall",
+            "memory_leak",
+            "oom_kill",
+        ] {
+            store
+                .insert(&incident_at(event_type, cutoff - 10))
+                .await
+                .unwrap();
+        }
+
+        let deleted = store.prune_older_than(cutoff).await.unwrap();
+        assert_eq!(deleted, 6, "every event type is pruned by the same TTL");
+        let remaining = store.recent(100).await.unwrap();
+        assert!(remaining.is_empty());
+    }
+
+    #[tokio::test]
+    async fn recently_recorded_incident_survives_prune() {
+        // The dedup windows (minutes) are far shorter than any TTL (days),
+        // but prove it directly: a recent incident must still dedup after a
+        // prune run.
+        let dir = tempfile::tempdir().unwrap();
+        let store = IncidentStore::new(dir.path().join("incidents.db"))
+            .await
+            .unwrap();
+        let now = Utc::now().timestamp();
+        let cutoff = now - 30 * 86_400;
+
+        let mut recent = incident_at("cpu_starvation", now);
+        recent.target_name = Some("hungry (tid=7, tgid=1)".to_string());
+        recent.system_snapshot = Some(r#"{"verdict": "StarvationWarning"}"#.to_string());
+        store.insert(&recent).await.unwrap();
+        store
+            .insert(&incident_at("cpu_starvation", cutoff - 10))
+            .await
+            .unwrap();
+
+        let deleted = store.prune_older_than(cutoff).await.unwrap();
+        assert_eq!(deleted, 1);
+
+        let keys = store
+            .recent_incident_keys("cpu_starvation", 900)
+            .await
+            .unwrap();
+        assert!(
+            keys.contains(&(
+                "hungry (tid=7, tgid=1)".to_string(),
+                "StarvationWarning".to_string()
+            )),
+            "the recent incident still dedups after pruning"
         );
     }
 }

--- a/cognitod/src/main.rs
+++ b/cognitod/src/main.rs
@@ -13,7 +13,7 @@ use aya::util::online_cpus;
 use aya::{Ebpf, EbpfLoader};
 use aya_log::EbpfLogger;
 use caps::{CapSet, Capability};
-use log::{info, warn};
+use log::{debug, info, warn};
 use std::{convert::TryFrom, error::Error, net::IpAddr, path::PathBuf, sync::Arc, time::Duration};
 use tokio::fs::OpenOptions;
 use tokio::io::{AsyncWriteExt, BufWriter};
@@ -740,6 +740,54 @@ async fn main() -> Result<(), Box<dyn Error>> {
     } else {
         None
     };
+
+    // Incident retention: prune rows older than the configured TTL on a
+    // background loop. Best-effort by design — a failed prune logs a warning
+    // and retries on the next cycle; it never blocks inserts or breaks the
+    // monitoring loop. Unset or 0 disables pruning entirely (retain forever).
+    const INCIDENT_PRUNE_INTERVAL: Duration = Duration::from_secs(24 * 60 * 60);
+    // First prune runs shortly after startup so a long-configured TTL takes
+    // effect promptly instead of waiting out a full interval.
+    const INCIDENT_PRUNE_STARTUP_DELAY: Duration = Duration::from_secs(60);
+    let retention_days = config.incidents.retention_days;
+    match retention_days {
+        Some(days) if days > 0 => match incident_store.clone() {
+            Some(store) => {
+                info!(
+                    "[cognitod] Incident retention: pruning incidents older than {} days every 24h",
+                    days
+                );
+                tokio::spawn(async move {
+                    tokio::time::sleep(INCIDENT_PRUNE_STARTUP_DELAY).await;
+                    loop {
+                        if let Some(cutoff) = cognitod::incidents::retention_cutoff_unix(
+                            Some(days),
+                            chrono::Utc::now().timestamp(),
+                        ) {
+                            match store.prune_older_than(cutoff).await {
+                                Ok(deleted) => info!(
+                                    "[cognitod] Incident retention: pruned {} incident(s) older than {} days",
+                                    deleted, days
+                                ),
+                                Err(e) => warn!(
+                                    "[cognitod] Incident retention: prune failed ({}); will retry on the next cycle",
+                                    e
+                                ),
+                            }
+                        }
+                        tokio::time::sleep(INCIDENT_PRUNE_INTERVAL).await;
+                    }
+                });
+            }
+            None => warn!(
+                "[cognitod] Incident retention configured ({} days) but no incident store is available; pruning disabled",
+                days
+            ),
+        },
+        _ => debug!(
+            "[cognitod] Incident retention not configured (retention_days unset or 0); keeping incidents forever"
+        ),
+    }
 
     let incident_analyzer = if config.reasoner.enabled && !config.reasoner.endpoint.is_empty() {
         match cognitod::IncidentAnalyzer::new(
@@ -1493,6 +1541,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         slack_signing_secret,
         enforcement: enforcement_queue.clone(),
         incident_store: incident_store.clone(),
+        incident_retention_days: retention_days.filter(|d| *d > 0),
         k8s: k8s_context.clone(),
         blame_metrics: blame_metrics.clone(),
     });

--- a/configs/linnix.darwin.toml
+++ b/configs/linnix.darwin.toml
@@ -42,3 +42,9 @@ mode = "monitor"  # Options: monitor, enforce
 psi_threshold = 40.0
 cpu_threshold = 90.0
 sustained_seconds = 15
+
+[incidents]
+# Days of incident history to keep in the incident store. Rows older than
+# this are pruned once a day (and once shortly after startup). 0 or unset
+# disables pruning and keeps incidents forever.
+retention_days = 30

--- a/configs/linnix.toml
+++ b/configs/linnix.toml
@@ -62,3 +62,9 @@ attribution_threshold_ms = 100
 # whole hour. Set to 0 to report every occurrence; the Prometheus counters are
 # unaffected either way.
 attribution_cooldown_seconds = 300
+
+[incidents]
+# Days of incident history to keep in the incident store. Rows older than
+# this are pruned once a day (and once shortly after startup). 0 or unset
+# disables pruning and keeps incidents forever.
+retention_days = 30

--- a/k8s/configmap.yaml
+++ b/k8s/configmap.yaml
@@ -42,3 +42,8 @@ data:
     attribution_threshold_ms = 100
     # Quiet period before the same offender/victim pair is reported again.
     attribution_cooldown_seconds = 300
+
+    [incidents]
+    # Days of incident history to retain; older rows are pruned once a day.
+    # 0 (or the whole section absent) disables pruning entirely.
+    retention_days = 30


### PR DESCRIPTION
## Summary

Follow-up to the review thread on #110: the incidents table grew forever. This adds a configurable store-wide TTL with a best-effort daily prune loop.

## Design

- **Config:** new `[incidents]` section, `retention_days: Option<u64>`. Unset *or* explicit `0` → pruning disabled entirely (retain forever) — an existing config that never mentions the section can never lose rows. The shipped configs (`configs/linnix.toml`, `configs/linnix.darwin.toml`) set `retention_days = 30`, which is the documented default.
- **Prune:** single `DELETE FROM incidents WHERE timestamp < ?`, type-agnostic across all six event types; returns the deleted row count. Strictly-older-than, so a row exactly at the cutoff is kept. Cutoff computed by a pure `retention_cutoff_unix` helper with saturating arithmetic (absurd values can't wrap into the future).
- **Scheduling:** background loop every 24h, first run 60s after startup so a long-configured TTL takes effect promptly. Failures log a warning and retry next cycle; pruning never blocks inserts or breaks the monitoring loop. Each run info-logs the deleted count; enablement is startup-info-logged.
- **Observability:** `/healthz` now includes `"incident_retention_days": <n|null>` (null when disabled). No new endpoints.

## Validation

- `cargo test -p cognitod --lib`: 264/264 (257 pre-existing + 7 new)
- `cargo test -p linnix-cli`: all suites pass
- `cargo +nightly fmt --all -- --check`: clean
- `cargo clippy` (cognitod + linnix-cli, --all-targets, -D warnings): clean

Tests cover: old rows deleted / recent survive; boundary row at cutoff kept; correct deleted count; type-agnostic across all 6 event types; recently-recorded incidents still visible to `recent_incident_keys` after a prune (dedup unaffected); config absent → None, `30` → Some(30), `0` → Some(0).

## Notes

- Upgrading deployments with the stock config will start deleting incidents older than 30 days on first boot (after the 60s startup delay). This is the requested feature, is info-logged, and custom configs without the key are unaffected.
- Pruning touches only the `incidents` table; `feedback` and `stall_attributions` are untouched (the stall-attributions comments explicitly say old rows stay queryable for reconciliation).