### PR TITLE
Cloud exporter base: config, wire types, identity, scrub, seal, spool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -584,6 +584,7 @@ dependencies = [
  "toml",
  "tower",
  "tracing",
+ "url",
  "uuid",
  "walkdir",
 ]

--- a/cognitod/Cargo.toml
+++ b/cognitod/Cargo.toml
@@ -7,6 +7,9 @@ description = "eBPF-powered Linux observability platform with AI incident detect
 
 [dependencies]
 reqwest = { version = "0.12.15", features = ["json"] }
+# Direct dependency: endpoint validation must parse with the same URL
+# library reqwest uses (WHATWG normalization), not a hand-rolled parser.
+url = "2.5.7"
 # ✅ Axum and dependencies
 axum = {version = "0.8.3", features =["macros"]}
 serde = { version = "1.0.219", features = ["derive"] }

--- a/cognitod/src/cloud/identity.rs
+++ b/cognitod/src/cloud/identity.rs
@@ -1,0 +1,210 @@
+//! Stable agent identity, persisted next to the incident database.
+//!
+//! The schema needs identifiers that survive daemon restarts:
+//! - `cluster_id`: stable installation ID (operator override, else generated
+//!   once — every node then gets its own, which the config docs call out).
+//! - `node_id`: operator override, else `NODE_NAME` → `HOSTNAME` → OS
+//!   hostname (the same order `k8s.rs` uses). The first resolved value is
+//!   persisted, so a later rename doesn't fork the node's identity.
+//! - `agent_instance_id`: UUID v4, generated once. Changes only when the
+//!   state directory is recreated, per schema §2.
+//! - `next_sequence`: the batch sequence counter, monotonic per
+//!   `agent_instance_id` (schema §2: gap detector).
+//! - `export_watermark`: the last incident row id sealed into a batch, so a
+//!   restart resumes export without re-sending or skipping.
+//!
+//! Writes go through write-tmp-then-rename so a crash can't leave a torn
+//! identity file.
+
+use std::io;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+/// File name inside the state directory.
+pub const IDENTITY_FILE_NAME: &str = "cloud_identity.json";
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct IdentityFile {
+    cluster_id: String,
+    node_id: String,
+    agent_instance_id: String,
+    next_sequence: u64,
+    export_watermark: i64,
+}
+
+/// Resolve the node identity: explicit config override wins, then the
+/// `NODE_NAME` downward-API variable, then `HOSTNAME`, then the OS hostname.
+/// Mirrors the order `k8s.rs` uses for its node name.
+pub fn resolve_node_id(override_id: Option<&str>) -> String {
+    if let Some(id) = override_id.filter(|s| !s.trim().is_empty()) {
+        return id.trim().to_string();
+    }
+    if let Ok(name) = std::env::var("NODE_NAME")
+        && !name.trim().is_empty()
+    {
+        return name;
+    }
+    if let Ok(name) = std::env::var("HOSTNAME")
+        && !name.trim().is_empty()
+    {
+        return name;
+    }
+    sysinfo::System::host_name().unwrap_or_else(|| "unknown-host".to_string())
+}
+
+#[derive(Debug)]
+pub struct IdentityStore {
+    path: PathBuf,
+    identity: IdentityFile,
+}
+
+impl IdentityStore {
+    /// Load the identity from `state_dir/cloud_identity.json`, creating it
+    /// (with fresh generated IDs) when absent. `node_id_override` and
+    /// `cluster_id_override` are honored only at creation time — afterwards
+    /// the persisted values win, keeping the identity stable.
+    pub fn load_or_create(
+        state_dir: &Path,
+        cluster_id_override: Option<&str>,
+        node_id_override: Option<&str>,
+    ) -> io::Result<Self> {
+        std::fs::create_dir_all(state_dir)?;
+        let path = state_dir.join(IDENTITY_FILE_NAME);
+        let identity = match std::fs::read_to_string(&path) {
+            Ok(contents) => serde_json::from_str::<IdentityFile>(&contents).map_err(|e| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!("{} is corrupt: {e}", path.display()),
+                )
+            })?,
+            Err(e) if e.kind() == io::ErrorKind::NotFound => {
+                let fresh = IdentityFile {
+                    cluster_id: cluster_id_override
+                        .filter(|s| !s.trim().is_empty())
+                        .map(str::to_string)
+                        .unwrap_or_else(|| uuid::Uuid::new_v4().to_string()),
+                    node_id: resolve_node_id(node_id_override),
+                    agent_instance_id: uuid::Uuid::new_v4().to_string(),
+                    next_sequence: 0,
+                    export_watermark: 0,
+                };
+                let store = Self {
+                    path: path.clone(),
+                    identity: fresh,
+                };
+                store.persist()?;
+                return Ok(store);
+            }
+            Err(e) => return Err(e),
+        };
+        Ok(Self { path, identity })
+    }
+
+    fn persist(&self) -> io::Result<()> {
+        let tmp = self.path.with_extension("json.tmp");
+        std::fs::write(&tmp, serde_json::to_string_pretty(&self.identity).unwrap())?;
+        std::fs::rename(&tmp, &self.path)?;
+        Ok(())
+    }
+
+    pub fn cluster_id(&self) -> &str {
+        &self.identity.cluster_id
+    }
+
+    pub fn node_id(&self) -> &str {
+        &self.identity.node_id
+    }
+
+    pub fn agent_instance_id(&self) -> &str {
+        &self.identity.agent_instance_id
+    }
+
+    /// Claim the next batch sequence number (persisted immediately, so a
+    /// crash between seal and send can't reuse it).
+    pub fn next_sequence(&mut self) -> io::Result<u64> {
+        let seq = self.identity.next_sequence;
+        self.identity.next_sequence = seq.saturating_add(1);
+        self.persist()?;
+        Ok(seq)
+    }
+
+    pub fn export_watermark(&self) -> i64 {
+        self.identity.export_watermark
+    }
+
+    /// Advance the export watermark past the incidents sealed into a batch.
+    /// Call only once the batch is durably spooled — the spool redrives
+    /// after a crash, so advancing here is at-least-once safe.
+    pub fn set_export_watermark(&mut self, last_id: i64) -> io::Result<()> {
+        if last_id > self.identity.export_watermark {
+            self.identity.export_watermark = last_id;
+            self.persist()?;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fresh_store(dir: &Path) -> IdentityStore {
+        IdentityStore::load_or_create(dir, None, Some("test-node")).unwrap()
+    }
+
+    #[test]
+    fn identity_is_stable_across_restarts() {
+        let dir = tempfile::tempdir().unwrap();
+        let first = fresh_store(dir.path());
+        let (cluster, node, instance) = (
+            first.cluster_id().to_string(),
+            first.node_id().to_string(),
+            first.agent_instance_id().to_string(),
+        );
+        drop(first);
+        // Overrides are ignored once an identity exists.
+        let second =
+            IdentityStore::load_or_create(dir.path(), Some("other-cluster"), Some("other-node"))
+                .unwrap();
+        assert_eq!(second.cluster_id(), cluster);
+        assert_eq!(second.node_id(), node);
+        assert_eq!(second.agent_instance_id(), instance);
+        assert_eq!(second.node_id(), "test-node");
+    }
+
+    #[test]
+    fn sequence_is_monotonic_and_persisted() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut store = fresh_store(dir.path());
+        assert_eq!(store.next_sequence().unwrap(), 0);
+        assert_eq!(store.next_sequence().unwrap(), 1);
+        drop(store);
+        let mut reopened = fresh_store(dir.path());
+        assert_eq!(reopened.next_sequence().unwrap(), 2);
+    }
+
+    #[test]
+    fn watermark_only_moves_forward() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut store = fresh_store(dir.path());
+        assert_eq!(store.export_watermark(), 0);
+        store.set_export_watermark(42).unwrap();
+        assert_eq!(store.export_watermark(), 42);
+        store.set_export_watermark(7).unwrap();
+        assert_eq!(store.export_watermark(), 42);
+        drop(store);
+        let reopened = fresh_store(dir.path());
+        assert_eq!(reopened.export_watermark(), 42);
+    }
+
+    #[test]
+    fn corrupt_identity_is_an_error_not_a_reset() {
+        // Silently minting a new agent_instance_id on corrupt state would
+        // fork the node's identity; fail loudly instead.
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join(IDENTITY_FILE_NAME), "not json").unwrap();
+        let err = IdentityStore::load_or_create(dir.path(), None, None).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    }
+}

--- a/cognitod/src/cloud/identity.rs
+++ b/cognitod/src/cloud/identity.rs
@@ -13,8 +13,11 @@
 //! - `export_watermark`: the last incident row id sealed into a batch, so a
 //!   restart resumes export without re-sending or skipping.
 //!
-//! Writes go through write-tmp-then-rename so a crash can't leave a torn
-//! identity file.
+//! Writes go through [`super::persist_durable`]: temp file, `sync_all` the
+//! temp file, atomic rename, then a parent-directory fsync. That covers
+//! process crashes *and* host/power loss (on filesystems that honor sync),
+//! so a torn or rolled-back identity file can never fork the node's
+//! sequence, watermark, or agent instance ID.
 
 use std::io;
 use std::path::{Path, PathBuf};
@@ -102,10 +105,8 @@ impl IdentityStore {
     }
 
     fn persist(&self) -> io::Result<()> {
-        let tmp = self.path.with_extension("json.tmp");
-        std::fs::write(&tmp, serde_json::to_string_pretty(&self.identity).unwrap())?;
-        std::fs::rename(&tmp, &self.path)?;
-        Ok(())
+        let bytes = serde_json::to_string_pretty(&self.identity).unwrap();
+        super::persist_durable(&self.path, bytes.as_bytes())
     }
 
     pub fn cluster_id(&self) -> &str {

--- a/cognitod/src/cloud/mod.rs
+++ b/cognitod/src/cloud/mod.rs
@@ -1,0 +1,36 @@
+//! Agent-side Linnix Cloud exporter.
+//!
+//! Ships evidence batches to the hosted evidence plane per the v1.0.0 event
+//! schema (`linnix-cloud-event-schema`). Strictly opt-in: nothing here runs
+//! unless `[cloud] enabled = true` with an endpoint, tenant, and token, and
+//! even then a failure can only log — it can never break the monitoring loop
+//! or the local API.
+//!
+//! Layout:
+//! - [`model`] — the v1 wire types (envelope, heartbeat, detection,
+//!   degradation_state).
+//! - [`identity`] — stable agent identity persisted next to the incident DB.
+//! - [`scrub`] — privacy enforcement: process identity and secrets never
+//!   leave the node unless explicitly opted in.
+//! - [`seal`] — batch assembly with the schema's seal triggers.
+//! - [`spool`] — crash-safe on-disk spool with caps and drop priorities.
+
+pub mod identity;
+pub mod model;
+pub mod scrub;
+pub mod seal;
+pub mod spool;
+
+/// Seconds between heartbeat events (schema §10: 60s cadence).
+pub const HEARTBEAT_INTERVAL_SECS: u64 = 60;
+/// Normal batch flush cadence (schema §10: seal at 5 seconds).
+pub const SEAL_INTERVAL_SECS: u64 = 5;
+/// Max events per batch (schema §10).
+pub const MAX_EVENTS_PER_BATCH: usize = 500;
+/// Max uncompressed batch body (schema §10: 1 MiB).
+pub const MAX_BATCH_BYTES: usize = 1024 * 1024;
+/// Local spool caps (schema §10: 256 MiB / 24h, whichever first).
+pub const SPOOL_MAX_BYTES: u64 = 256 * 1024 * 1024;
+pub const SPOOL_MAX_AGE_SECS: u64 = 24 * 60 * 60;
+/// How many incidents to pull from the store per exporter tick.
+pub const EXPORT_PULL_LIMIT: i64 = 500;

--- a/cognitod/src/cloud/mod.rs
+++ b/cognitod/src/cloud/mod.rs
@@ -21,6 +21,44 @@ pub mod scrub;
 pub mod seal;
 pub mod spool;
 
+use std::io;
+use std::path::Path;
+
+/// Durably write `bytes` to `path`: create/truncate a temp file, write all
+/// bytes, `sync_all` the temp file, atomically rename over `path`, then
+/// fsync the parent directory so the rename itself survives a power loss.
+///
+/// A bare write-then-rename is only crash-safe against *process* crashes.
+/// Without the two syncs, a host or power loss can roll the rename back
+/// (silently losing the write) or drop the directory entry for a file the
+/// manifest already references. This holds on filesystems that honor sync
+/// (ext4, xfs, btrfs); exotic setups (NFS without sync, some FUSE layers)
+/// may weaken the guarantee. Used for every metadata write whose loss would
+/// corrupt sequence/watermark/accounting state: `cloud_identity.json`,
+/// `spool.json`, and quarantine notes.
+pub(crate) fn persist_durable(path: &Path, bytes: &[u8]) -> io::Result<()> {
+    let tmp = path.with_extension("json.tmp");
+    {
+        let mut f = std::fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .open(&tmp)?;
+        use std::io::Write as _;
+        f.write_all(bytes)?;
+        f.sync_all()?;
+    }
+    std::fs::rename(&tmp, path)?;
+    sync_dir(path.parent().unwrap_or(Path::new(".")))
+}
+
+/// fsync a directory so a newly created file inside it (or a rename into
+/// it) is durable against host/power loss, not just process crashes.
+pub(crate) fn sync_dir(dir: &Path) -> io::Result<()> {
+    let f = std::fs::File::open(dir)?;
+    f.sync_all()
+}
+
 /// Seconds between heartbeat events (schema §10: 60s cadence).
 pub const HEARTBEAT_INTERVAL_SECS: u64 = 60;
 /// Normal batch flush cadence (schema §10: seal at 5 seconds).
@@ -34,3 +72,35 @@ pub const SPOOL_MAX_BYTES: u64 = 256 * 1024 * 1024;
 pub const SPOOL_MAX_AGE_SECS: u64 = 24 * 60 * 60;
 /// How many incidents to pull from the store per exporter tick.
 pub const EXPORT_PULL_LIMIT: i64 = 500;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn persist_durable_round_trips_and_cleans_up() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("state.json");
+        persist_durable(&path, b"{\"a\":1}").unwrap();
+        assert_eq!(std::fs::read(&path).unwrap(), b"{\"a\":1}");
+        // No temp file left behind.
+        assert!(!dir.path().join("state.json.tmp").exists());
+        // Overwriting an existing file is durable too.
+        persist_durable(&path, b"{\"a\":2}").unwrap();
+        assert_eq!(std::fs::read(&path).unwrap(), b"{\"a\":2}");
+        assert!(!dir.path().join("state.json.tmp").exists());
+    }
+
+    #[test]
+    fn persist_durable_fails_loudly_on_missing_parent() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("nope").join("state.json");
+        assert!(persist_durable(&path, b"x").is_err());
+    }
+
+    #[test]
+    fn sync_dir_works_on_a_real_directory() {
+        let dir = tempfile::tempdir().unwrap();
+        sync_dir(dir.path()).unwrap();
+    }
+}

--- a/cognitod/src/cloud/model.rs
+++ b/cognitod/src/cloud/model.rs
@@ -67,15 +67,20 @@ pub const DETECTION_OOM_KILL: &str = "oom_kill";
 /// Map a local incident `event_type` to a cloud `detection_type`.
 /// Returns `None` for incident kinds the v1 contract cannot describe —
 /// callers skip those rather than shipping an event the edge can't validate.
+///
+/// The daemon records `circuit_breaker_cpu` (and the API recognizes
+/// `circuit_breaker_memory`); both normalize to the schema's
+/// `circuit_breaker` rather than being skipped.
 pub fn detection_type_for(incident_event_type: &str) -> Option<&'static str> {
     match incident_event_type {
         "fork_storm" => Some(DETECTION_FORK_STORM),
         "memory_leak" => Some(DETECTION_MEMORY_LEAK),
-        "circuit_breaker" => Some(DETECTION_CIRCUIT_BREAKER),
         "cpu_starvation" => Some(DETECTION_CPU_STARVATION),
         "blkio_stall" => Some(DETECTION_BLKIO_STALL),
         "cgroup_pressure" => Some(DETECTION_CGROUP_PRESSURE),
         "oom_kill" => Some(DETECTION_OOM_KILL),
+        "circuit_breaker" => Some(DETECTION_CIRCUIT_BREAKER),
+        t if t.starts_with("circuit_breaker_") => Some(DETECTION_CIRCUIT_BREAKER),
         _ => None,
     }
 }
@@ -277,6 +282,15 @@ mod tests {
         }
         assert_eq!(
             detection_type_for("circuit_breaker"),
+            Some("circuit_breaker")
+        );
+        // Recorded circuit-breaker variants normalize instead of skipping.
+        assert_eq!(
+            detection_type_for("circuit_breaker_cpu"),
+            Some("circuit_breaker")
+        );
+        assert_eq!(
+            detection_type_for("circuit_breaker_memory"),
             Some("circuit_breaker")
         );
         assert_eq!(detection_type_for("bogus"), None);

--- a/cognitod/src/cloud/model.rs
+++ b/cognitod/src/cloud/model.rs
@@ -1,0 +1,321 @@
+//! v1.0.0 event-schema wire types.
+//!
+//! Field names and shapes follow `linnix-cloud-event-schema` exactly; the
+//! two deliberate deviations are documented on the types that carry them:
+//! - [`DETECTION_CPU_STARVATION`] etc.: the schema's `detection_type` enum
+//!   only defines `fork_storm`, `memory_leak`, `short_lived_jobs`, and
+//!   `circuit_breaker`. Our other four incident types are emitted as
+//!   extended values — a proposed minor schema extension.
+//! - `pressure_sample` is omitted in v1 (the schema permits omission until
+//!   the agent reads avg60/avg300 and cumulative PSI totals).
+
+use serde::Serialize;
+
+/// The wire contract version this exporter speaks.
+pub const SCHEMA_VERSION: &str = "1.0.0";
+
+/// Attribution quality of a batch: `full` (eBPF attached) or `psi_only`.
+/// Serializes exactly as the schema's enum values.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AttributionQuality {
+    Full,
+    PsiOnly,
+}
+
+impl AttributionQuality {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            AttributionQuality::Full => "full",
+            AttributionQuality::PsiOnly => "psi_only",
+        }
+    }
+}
+
+/// Detail level of an event. Default export is `evidence`; `raw` requires
+/// explicit opt-in the agent does not currently offer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DetailLevel {
+    Summary,
+    Evidence,
+    Raw,
+}
+
+/// Event discriminator. Serializes as the schema's `event_type` values.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EventType {
+    Heartbeat,
+    Detection,
+    DegradationState,
+}
+
+/// Schema-defined detection types.
+pub const DETECTION_FORK_STORM: &str = "fork_storm";
+pub const DETECTION_MEMORY_LEAK: &str = "memory_leak";
+pub const DETECTION_CIRCUIT_BREAKER: &str = "circuit_breaker";
+/// Proposed minor extension: our userspace detectors have no schema enum
+/// value yet. Emitted as-is so the edge can store them; a strict v1 reader
+/// should treat unknown `detection_type` values as opaque rather than
+/// rejecting the batch (schema §11: store unknown values, do not coerce).
+pub const DETECTION_CPU_STARVATION: &str = "cpu_starvation";
+pub const DETECTION_BLKIO_STALL: &str = "blkio_stall";
+pub const DETECTION_CGROUP_PRESSURE: &str = "cgroup_pressure";
+pub const DETECTION_OOM_KILL: &str = "oom_kill";
+
+/// Map a local incident `event_type` to a cloud `detection_type`.
+/// Returns `None` for incident kinds the v1 contract cannot describe —
+/// callers skip those rather than shipping an event the edge can't validate.
+pub fn detection_type_for(incident_event_type: &str) -> Option<&'static str> {
+    match incident_event_type {
+        "fork_storm" => Some(DETECTION_FORK_STORM),
+        "memory_leak" => Some(DETECTION_MEMORY_LEAK),
+        "circuit_breaker" => Some(DETECTION_CIRCUIT_BREAKER),
+        "cpu_starvation" => Some(DETECTION_CPU_STARVATION),
+        "blkio_stall" => Some(DETECTION_BLKIO_STALL),
+        "cgroup_pressure" => Some(DETECTION_CGROUP_PRESSURE),
+        "oom_kill" => Some(DETECTION_OOM_KILL),
+        _ => None,
+    }
+}
+
+/// Severity of a detection event.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Severity {
+    Info,
+    Warning,
+    Critical,
+}
+
+/// Inclusive-start, exclusive-end evidence window (RFC 3339 UTC).
+#[derive(Debug, Clone, Serialize)]
+pub struct TimeRange {
+    pub start: String,
+    pub end: String,
+}
+
+/// Workload identity. `None` (v1) — resolving incidents to pod/namespace is
+/// a follow-up; we don't ship process names as workload identity.
+#[derive(Debug, Clone, Serialize)]
+pub struct WorkloadRef {
+    pub namespace: String,
+    pub pod: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub container_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct HeartbeatPayload {
+    pub interval_seconds: u32,
+    pub uptime_seconds: u64,
+    pub agent_status: AgentStatus,
+    pub transport: Transport,
+    pub ebpf_attached: bool,
+    pub btf_available: bool,
+    pub active_node: bool,
+    pub events_buffered: u64,
+    pub events_dropped_total: u64,
+    pub blame_series_active: u32,
+    pub blame_series_evicted_total: u64,
+    pub blame_series_evicted_delta: u64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentStatus {
+    Healthy,
+    Degraded,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Transport {
+    Perf,
+    Userspace,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct DetectionPayload {
+    pub detection_type: String,
+    pub severity: Severity,
+    pub subject: Option<WorkloadRef>,
+    pub window: TimeRange,
+    pub rule_name: String,
+    pub action: DetectionAction,
+    pub details: serde_json::Value,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DetectionAction {
+    Observe,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct DegradationStatePayload {
+    pub attribution_quality: AttributionQuality,
+    pub ebpf_attached: bool,
+    pub fallback_mode: FallbackMode,
+    pub transport: Transport,
+    pub btf_available: bool,
+    pub rss_probe: String,
+    pub lost_capabilities: Vec<String>,
+    pub reason_code: String,
+    pub reason: String,
+    pub state_since: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FallbackMode {
+    None,
+    ProcPressureOnly,
+}
+
+/// Event payload, serialized untagged so the JSON shape matches the schema
+/// (no extra discriminator object around the payload).
+#[derive(Debug, Clone, Serialize)]
+#[serde(untagged)]
+pub enum EventPayload {
+    Heartbeat(HeartbeatPayload),
+    Detection(DetectionPayload),
+    DegradationState(DegradationStatePayload),
+}
+
+impl EventPayload {
+    pub fn event_type(&self) -> EventType {
+        match self {
+            EventPayload::Heartbeat(_) => EventType::Heartbeat,
+            EventPayload::Detection(_) => EventType::Detection,
+            EventPayload::DegradationState(_) => EventType::DegradationState,
+        }
+    }
+}
+
+/// One event in a batch: the schema's EVENTBASE.
+#[derive(Debug, Clone, Serialize)]
+pub struct Event {
+    pub event_id: String,
+    pub event_idempotency_key: String,
+    pub event_type: EventType,
+    pub occurred_at: String,
+    pub detail_level: DetailLevel,
+    pub payload: EventPayload,
+}
+
+/// The batch envelope (schema §2).
+#[derive(Debug, Clone, Serialize)]
+pub struct BatchEnvelope {
+    pub schema_version: String,
+    pub tenant_id: String,
+    pub cluster_id: String,
+    pub node_id: String,
+    pub agent_version: String,
+    pub sent_at: String,
+    pub batch_idempotency_key: String,
+    pub sequence: u64,
+    pub agent_instance_id: String,
+    pub attribution_quality: AttributionQuality,
+    pub events: Vec<Event>,
+}
+
+impl BatchEnvelope {
+    /// `b:{node_id}:{sequence}` — stable across retries (schema §2).
+    pub fn idempotency_key(node_id: &str, sequence: u64) -> String {
+        format!("b:{node_id}:{sequence}")
+    }
+}
+
+/// Format a Unix timestamp as RFC 3339 UTC (`occurred_at`/`sent_at`).
+pub fn rfc3339(unix_secs: i64) -> String {
+    chrono::DateTime::<chrono::Utc>::from_timestamp(unix_secs, 0)
+        .map(|dt| dt.to_rfc3339_opts(chrono::SecondsFormat::Millis, true))
+        .unwrap_or_else(|| "1970-01-01T00:00:00.000Z".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn quality_serializes_as_schema_values() {
+        assert_eq!(
+            serde_json::to_string(&AttributionQuality::Full).unwrap(),
+            "\"full\""
+        );
+        assert_eq!(
+            serde_json::to_string(&AttributionQuality::PsiOnly).unwrap(),
+            "\"psi_only\""
+        );
+    }
+
+    #[test]
+    fn event_type_serializes_as_schema_values() {
+        assert_eq!(
+            serde_json::to_string(&EventType::DegradationState).unwrap(),
+            "\"degradation_state\""
+        );
+        assert_eq!(
+            serde_json::to_string(&EventType::Heartbeat).unwrap(),
+            "\"heartbeat\""
+        );
+    }
+
+    #[test]
+    fn detection_type_mapping_covers_all_six_incident_types() {
+        for t in [
+            "fork_storm",
+            "memory_leak",
+            "cpu_starvation",
+            "blkio_stall",
+            "cgroup_pressure",
+            "oom_kill",
+        ] {
+            assert!(detection_type_for(t).is_some(), "{t} must map");
+        }
+        assert_eq!(
+            detection_type_for("circuit_breaker"),
+            Some("circuit_breaker")
+        );
+        assert_eq!(detection_type_for("bogus"), None);
+    }
+
+    #[test]
+    fn payload_is_untagged() {
+        let event = Event {
+            event_id: "e1".to_string(),
+            event_idempotency_key: "k1".to_string(),
+            event_type: EventType::Heartbeat,
+            occurred_at: rfc3339(0),
+            detail_level: DetailLevel::Summary,
+            payload: EventPayload::Heartbeat(HeartbeatPayload {
+                interval_seconds: 60,
+                uptime_seconds: 1,
+                agent_status: AgentStatus::Healthy,
+                transport: Transport::Perf,
+                ebpf_attached: true,
+                btf_available: true,
+                active_node: true,
+                events_buffered: 0,
+                events_dropped_total: 0,
+                blame_series_active: 0,
+                blame_series_evicted_total: 0,
+                blame_series_evicted_delta: 0,
+            }),
+        };
+        let v: serde_json::Value = serde_json::to_value(&event).unwrap();
+        // No wrapper object: heartbeat fields sit directly under "payload".
+        assert_eq!(v["payload"]["interval_seconds"], 60);
+        assert!(v["payload"].get("heartbeat").is_none());
+    }
+
+    #[test]
+    fn batch_idempotency_key_format_matches_schema_example() {
+        assert_eq!(
+            BatchEnvelope::idempotency_key("node_7f89b0", 18421),
+            "b:node_7f89b0:18421"
+        );
+    }
+}

--- a/cognitod/src/cloud/scrub.rs
+++ b/cognitod/src/cloud/scrub.rs
@@ -1,0 +1,212 @@
+//! Privacy enforcement for cloud export.
+//!
+//! The schema's data-minimization classes are hard rules here, not config:
+//!
+//! - **NEVER export** (removed unconditionally): tokens, secrets, passwords,
+//!   authorization headers, environment blocks, cookies/sessions.
+//! - **OPT-IN only** (removed unless `[cloud] export_process_identity =
+//!   true`): process identity — comm, PIDs, cmdline, exe paths, raw cgroup
+//!   paths, and the incident's `target_pid`/`target_name`.
+//! - **Default allow** (kept): pod namespace/name, PSI values, stall pairs,
+//!   fork counts, thresholds, verdicts, evidence labels, probe health.
+//!
+//! Blocked keys are dropped from the JSON (not replaced with a marker), so
+//! the edge never sees either the value or its shape.
+
+use serde_json::Value;
+
+/// Process-identity keys: opt-in only. Matched exactly (case-insensitive);
+/// nested objects are walked, so `{"parent": {"pid": 1}}` is scrubbed too.
+const IDENTITY_KEYS: &[&str] = &[
+    "comm",
+    "parent_comm",
+    "target_name",
+    "process_name",
+    "pid",
+    "tid",
+    "ppid",
+    "parent_pid",
+    "target_pid",
+    "cmdline",
+    "cmd_line",
+    "exe",
+    "executable",
+    "exec_path",
+    "cgroup",
+    "cgroup_path",
+];
+
+/// Secret keys: never exported. Matched as a case-insensitive substring so
+/// `api_auth_token`, `signing_secret`, `db_password` are all caught.
+const SECRET_FRAGMENTS: &[&str] = &[
+    "token",
+    "secret",
+    "password",
+    "passwd",
+    "api_key",
+    "apikey",
+    "authorization",
+    "bearer",
+    "private_key",
+    "cookie",
+    "sessionid",
+    "session_id",
+];
+
+/// Environment blocks: never exported. Exact match (case-insensitive) —
+/// a substring match would eat legitimate keys like `environment_score`.
+const ENV_KEYS: &[&str] = &["env", "environ", "environment", "env_vars"];
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ScrubPolicy {
+    /// When true, process-identity keys are kept. Secrets are still removed.
+    pub export_process_identity: bool,
+}
+
+impl ScrubPolicy {
+    pub fn from_opt_in(export_process_identity: bool) -> Self {
+        Self {
+            export_process_identity,
+        }
+    }
+}
+
+fn is_secret_key(lower_key: &str) -> bool {
+    SECRET_FRAGMENTS.iter().any(|frag| lower_key.contains(frag)) || ENV_KEYS.contains(&lower_key)
+}
+
+fn is_identity_key(lower_key: &str) -> bool {
+    IDENTITY_KEYS.contains(&lower_key)
+}
+
+/// Recursively drop blocked keys from a JSON value in place.
+pub fn scrub_value(value: &mut Value, policy: ScrubPolicy) {
+    match value {
+        Value::Object(map) => {
+            map.retain(|key, _| {
+                let lower = key.to_ascii_lowercase();
+                if is_secret_key(&lower) {
+                    return false;
+                }
+                if !policy.export_process_identity && is_identity_key(&lower) {
+                    return false;
+                }
+                true
+            });
+            for child in map.values_mut() {
+                scrub_value(child, policy);
+            }
+        }
+        Value::Array(items) => {
+            for item in items {
+                scrub_value(item, policy);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Scrub an incident's `system_snapshot` JSON for export. Returns the
+/// scrubbed value (an object), or `None` when there is no snapshot or it
+/// isn't valid JSON — the caller then ships an empty details object rather
+/// than inventing one.
+pub fn scrub_snapshot(snapshot: Option<&str>, policy: ScrubPolicy) -> Option<Value> {
+    let raw = snapshot?;
+    let mut value: Value = serde_json::from_str(raw).ok()?;
+    scrub_value(&mut value, policy);
+    Some(value)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    const STRICT: ScrubPolicy = ScrubPolicy {
+        export_process_identity: false,
+    };
+    const OPT_IN: ScrubPolicy = ScrubPolicy {
+        export_process_identity: true,
+    };
+
+    fn kitchen_sink() -> Value {
+        json!({
+            "verdict": "StormCritical",
+            "forks_per_sec": 87.5,
+            "threshold_per_sec": 30.0,
+            "window_secs": 10.0,
+            "parent_pid": 4242,
+            "parent_comm": "runaway.sh",
+            "cmdline": "/bin/bash runaway.sh",
+            "cgroup_path": "/sys/fs/cgroup/system.slice/evil.service",
+            "evidence": {"fork_rate": "measured", "offending_parent": "inferred"},
+            "nested": {"pid": 99, "exe": "/usr/bin/x", "keep_me": 1},
+            "api_token": "tok-123",
+            "signing_secret": "shh",
+            "environment": {"HOME": "/root"},
+            "list": [{"tid": 5, "v": 1}]
+        })
+    }
+
+    #[test]
+    fn strict_scrub_removes_identity_and_secrets_keeps_measurements() {
+        let mut v = kitchen_sink();
+        scrub_value(&mut v, STRICT);
+        // Identity gone.
+        for key in ["parent_pid", "parent_comm", "cmdline", "cgroup_path"] {
+            assert!(v.get(key).is_none(), "{key} must be scrubbed");
+        }
+        assert!(v["nested"].get("pid").is_none());
+        assert!(v["nested"].get("exe").is_none());
+        assert!(v["list"][0].get("tid").is_none());
+        // Secrets gone.
+        assert!(v.get("api_token").is_none());
+        assert!(v.get("signing_secret").is_none());
+        assert!(v.get("environment").is_none());
+        // Measurements and labels kept.
+        assert_eq!(v["verdict"], "StormCritical");
+        assert_eq!(v["forks_per_sec"], 87.5);
+        assert_eq!(v["threshold_per_sec"], 30.0);
+        assert_eq!(v["evidence"]["fork_rate"], "measured");
+        assert_eq!(v["nested"]["keep_me"], 1);
+        assert_eq!(v["list"][0]["v"], 1);
+    }
+
+    #[test]
+    fn opt_in_keeps_identity_but_never_secrets() {
+        let mut v = kitchen_sink();
+        scrub_value(&mut v, OPT_IN);
+        assert_eq!(v["parent_pid"], 4242);
+        assert_eq!(v["parent_comm"], "runaway.sh");
+        assert_eq!(v["cmdline"], "/bin/bash runaway.sh");
+        assert!(v.get("api_token").is_none());
+        assert!(v.get("signing_secret").is_none());
+        assert!(v.get("environment").is_none());
+    }
+
+    #[test]
+    fn key_matching_is_case_insensitive_and_exact_where_it_matters() {
+        let mut v = json!({
+            "Parent_PID": 1,
+            "COMM": "x",
+            "environment_score": 0.9,
+            "my_tokenizer": "keep?",
+        });
+        scrub_value(&mut v, STRICT);
+        assert!(v.get("Parent_PID").is_none());
+        assert!(v.get("COMM").is_none());
+        // Exact-match env keys don't eat `environment_score`...
+        assert_eq!(v["environment_score"], 0.9);
+        // ...but substring secret fragments do match `my_tokenizer`.
+        assert!(v.get("my_tokenizer").is_none());
+    }
+
+    #[test]
+    fn scrub_snapshot_returns_none_for_missing_or_invalid_json() {
+        assert!(scrub_snapshot(None, STRICT).is_none());
+        assert!(scrub_snapshot(Some("not json"), STRICT).is_none());
+        let v = scrub_snapshot(Some(r#"{"a": 1, "pid": 2}"#), STRICT).unwrap();
+        assert_eq!(v["a"], 1);
+        assert!(v.get("pid").is_none());
+    }
+}

--- a/cognitod/src/cloud/scrub.rs
+++ b/cognitod/src/cloud/scrub.rs
@@ -24,6 +24,7 @@ const IDENTITY_KEYS: &[&str] = &[
     "process_name",
     "pid",
     "tid",
+    "tgid",
     "ppid",
     "parent_pid",
     "target_pid",
@@ -199,6 +200,45 @@ mod tests {
         assert_eq!(v["environment_score"], 0.9);
         // ...but substring secret fragments do match `my_tokenizer`.
         assert!(v.get("my_tokenizer").is_none());
+    }
+
+    #[test]
+    fn strict_scrub_removes_tgid_from_cpu_starvation_snapshots() {
+        // Shape mirrors collectors/runqueue_starvation.rs: the subject's
+        // tgid plus one per top_waiters entry. All are process identity.
+        let mut v = json!({
+            "tid": 4321,
+            "tgid": 1234,
+            "comm": "victim",
+            "wait_ms": 6100.0,
+            "window_secs": 10.0,
+            "top_waiters": [
+                {"tid": 111, "tgid": 100, "comm": "hog-a", "wait_ms": 50.0},
+                {"tid": 222, "tgid": 200, "comm": "hog-b", "wait_ms": 40.0}
+            ],
+            "evidence": {"runqueue_wait": "measured", "offender": "unavailable"}
+        });
+        scrub_value(&mut v, STRICT);
+        assert!(v.get("tid").is_none());
+        assert!(v.get("tgid").is_none());
+        assert!(v.get("comm").is_none());
+        for w in v["top_waiters"].as_array().unwrap() {
+            assert!(w.get("tid").is_none());
+            assert!(w.get("tgid").is_none());
+            assert!(w.get("comm").is_none());
+            assert!(w.get("wait_ms").is_some());
+        }
+        // Measurements survive.
+        assert_eq!(v["wait_ms"], 6100.0);
+        assert_eq!(v["evidence"]["runqueue_wait"], "measured");
+    }
+
+    #[test]
+    fn opt_in_preserves_tgid() {
+        let mut v = json!({"tgid": 1234, "top_waiters": [{"tgid": 100}]});
+        scrub_value(&mut v, OPT_IN);
+        assert_eq!(v["tgid"], 1234);
+        assert_eq!(v["top_waiters"][0]["tgid"], 100);
     }
 
     #[test]

--- a/cognitod/src/cloud/seal.rs
+++ b/cognitod/src/cloud/seal.rs
@@ -1,0 +1,254 @@
+//! Batch assembly with the schema's seal triggers.
+//!
+//! Events are serialized once, at push time, to measure them; the sealed
+//! batch bytes are then immutable — retries resend the exact same bytes with
+//! the same idempotency key (schema §10: "Retries preserve bytes and
+//! identity").
+//!
+//! Seal triggers (schema §10): 500 events, 1 MiB uncompressed, or 5 seconds
+//! since the first buffered event. A change in attribution quality seals
+//! immediately too, but that's handled by the exporter (seal the old batch,
+//! rotate to a new sealer) because a batch must never mix quality states.
+
+use std::time::Instant;
+
+use sha2::{Digest, Sha256};
+
+use super::model::{AttributionQuality, BatchEnvelope, Event, SCHEMA_VERSION};
+use super::{MAX_BATCH_BYTES, MAX_EVENTS_PER_BATCH, SEAL_INTERVAL_SECS};
+
+/// Fixed overhead fudge for the envelope around the events when deciding
+/// whether the next push would breach the 1 MiB cap. The real envelope is a
+/// few hundred bytes; overestimating slightly is safe.
+const ENVELOPE_OVERHEAD: usize = 512;
+
+/// Context needed once per sealed batch.
+pub struct SealContext<'a> {
+    pub tenant_id: &'a str,
+    pub cluster_id: &'a str,
+    pub node_id: &'a str,
+    pub agent_instance_id: &'a str,
+    pub sequence: u64,
+}
+
+/// A sealed, immutable batch: the exact bytes to POST, with their digest.
+pub struct SealedBatch {
+    pub sequence: u64,
+    pub quality: AttributionQuality,
+    pub event_count: usize,
+    pub bytes: Vec<u8>,
+    /// sha256 hex of `bytes`, recorded so the spool can verify integrity.
+    pub digest: String,
+}
+
+pub struct BatchSealer {
+    quality: AttributionQuality,
+    events: Vec<Event>,
+    event_bytes: usize,
+    first_push: Option<Instant>,
+}
+
+impl BatchSealer {
+    pub fn new(quality: AttributionQuality) -> Self {
+        Self {
+            quality,
+            events: Vec::new(),
+            event_bytes: 0,
+            first_push: None,
+        }
+    }
+
+    pub fn quality(&self) -> AttributionQuality {
+        self.quality
+    }
+
+    pub fn len(&self) -> usize {
+        self.events.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.events.is_empty()
+    }
+
+    /// Buffer an event. The caller must only push events whose batch-level
+    /// attribution quality matches this sealer's — a batch never mixes
+    /// quality states (schema §2).
+    pub fn push(&mut self, event: Event) {
+        // Size is best-effort: serialization of our own types can't fail.
+        let size = serde_json::to_vec(&event).map(|b| b.len()).unwrap_or(0);
+        if self.first_push.is_none() {
+            self.first_push = Some(Instant::now());
+        }
+        self.event_bytes += size;
+        self.events.push(event);
+    }
+
+    /// True when any seal trigger has fired.
+    pub fn seal_due(&self, now: Instant) -> bool {
+        if self.events.is_empty() {
+            return false;
+        }
+        if self.events.len() >= MAX_EVENTS_PER_BATCH {
+            return true;
+        }
+        if self.event_bytes + ENVELOPE_OVERHEAD >= MAX_BATCH_BYTES {
+            return true;
+        }
+        if let Some(first) = self.first_push
+            && now.duration_since(first).as_secs() >= SEAL_INTERVAL_SECS
+        {
+            return true;
+        }
+        false
+    }
+
+    /// Test hook: inspect the currently buffered events.
+    #[cfg(test)]
+    pub fn buffered_events(&self) -> &[Event] {
+        &self.events
+    }
+
+    /// Seal the buffered events into an immutable batch. Returns `None`
+    /// when there's nothing to seal (the schema requires 1–500 events).
+    pub fn seal(&mut self, ctx: &SealContext<'_>) -> Option<SealedBatch> {
+        if self.events.is_empty() {
+            return None;
+        }
+        let events = std::mem::take(&mut self.events);
+        self.event_bytes = 0;
+        self.first_push = None;
+        let event_count = events.len();
+
+        let envelope = BatchEnvelope {
+            schema_version: SCHEMA_VERSION.to_string(),
+            tenant_id: ctx.tenant_id.to_string(),
+            cluster_id: ctx.cluster_id.to_string(),
+            node_id: ctx.node_id.to_string(),
+            agent_version: env!("CARGO_PKG_VERSION").to_string(),
+            sent_at: super::model::rfc3339(chrono::Utc::now().timestamp()),
+            batch_idempotency_key: BatchEnvelope::idempotency_key(ctx.node_id, ctx.sequence),
+            sequence: ctx.sequence,
+            agent_instance_id: ctx.agent_instance_id.to_string(),
+            attribution_quality: self.quality,
+            events,
+        };
+        // Same inputs → same bytes: idempotency keys are stable across retries.
+        let bytes = serde_json::to_vec(&envelope).expect("envelope serialization cannot fail");
+        let digest = hex::encode(Sha256::digest(&bytes));
+        Some(SealedBatch {
+            sequence: ctx.sequence,
+            quality: self.quality,
+            event_count,
+            bytes,
+            digest,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::model::*;
+    use super::*;
+
+    fn heartbeat_event(id: &str) -> Event {
+        Event {
+            event_id: id.to_string(),
+            event_idempotency_key: format!("k:{id}"),
+            event_type: EventType::Heartbeat,
+            occurred_at: rfc3339(1_700_000_000),
+            detail_level: DetailLevel::Summary,
+            payload: EventPayload::Heartbeat(HeartbeatPayload {
+                interval_seconds: 60,
+                uptime_seconds: 1,
+                agent_status: AgentStatus::Healthy,
+                transport: Transport::Perf,
+                ebpf_attached: true,
+                btf_available: true,
+                active_node: true,
+                events_buffered: 0,
+                events_dropped_total: 0,
+                blame_series_active: 0,
+                blame_series_evicted_total: 0,
+                blame_series_evicted_delta: 0,
+            }),
+        }
+    }
+
+    fn ctx<'a>() -> SealContext<'a> {
+        SealContext {
+            tenant_id: "tn_1",
+            cluster_id: "clu_1",
+            node_id: "node_1",
+            agent_instance_id: "instance-1",
+            sequence: 7,
+        }
+    }
+
+    #[test]
+    fn seals_on_event_count() {
+        let mut sealer = BatchSealer::new(AttributionQuality::Full);
+        for i in 0..MAX_EVENTS_PER_BATCH {
+            sealer.push(heartbeat_event(&format!("e{i}")));
+            assert_eq!(
+                sealer.seal_due(Instant::now()),
+                i + 1 >= MAX_EVENTS_PER_BATCH
+            );
+        }
+        let batch = sealer.seal(&ctx()).unwrap();
+        assert_eq!(batch.event_count, MAX_EVENTS_PER_BATCH);
+        assert_eq!(batch.sequence, 7);
+        assert!(sealer.is_empty());
+    }
+
+    #[test]
+    fn seals_on_time() {
+        let mut sealer = BatchSealer::new(AttributionQuality::PsiOnly);
+        sealer.push(heartbeat_event("e1"));
+        assert!(!sealer.seal_due(Instant::now()));
+        let later = Instant::now() + std::time::Duration::from_secs(SEAL_INTERVAL_SECS);
+        assert!(sealer.seal_due(later));
+        let batch = sealer.seal(&ctx()).unwrap();
+        assert_eq!(batch.quality, AttributionQuality::PsiOnly);
+        // Empty sealer seals to nothing: the schema requires ≥1 event.
+        assert!(sealer.seal(&ctx()).is_none());
+    }
+
+    #[test]
+    fn idempotency_inputs_are_stable_across_retries() {
+        // sent_at varies per seal, but everything the edge dedupes on —
+        // idempotency key, sequence, event payloads — is stable, so a retry
+        // of the same logical batch is recognized as the same batch.
+        let build = || {
+            let mut sealer = BatchSealer::new(AttributionQuality::Full);
+            sealer.push(heartbeat_event("e1"));
+            sealer.seal(&ctx()).unwrap()
+        };
+        let a = build();
+        let b = build();
+        let va: serde_json::Value = serde_json::from_slice(&a.bytes).unwrap();
+        let vb: serde_json::Value = serde_json::from_slice(&b.bytes).unwrap();
+        assert_eq!(va["batch_idempotency_key"], "b:node_1:7");
+        assert_eq!(va["batch_idempotency_key"], vb["batch_idempotency_key"]);
+        assert_eq!(va["events"], vb["events"]);
+        // Digest is sha256 over the sealed bytes.
+        use sha2::Digest as _;
+        assert_eq!(a.digest, hex::encode(sha2::Sha256::digest(&a.bytes)));
+    }
+
+    #[test]
+    fn envelope_shape_matches_schema() {
+        let mut sealer = BatchSealer::new(AttributionQuality::Full);
+        sealer.push(heartbeat_event("e1"));
+        let batch = sealer.seal(&ctx()).unwrap();
+        let v: serde_json::Value = serde_json::from_slice(&batch.bytes).unwrap();
+        assert_eq!(v["schema_version"], "1.0.0");
+        assert_eq!(v["tenant_id"], "tn_1");
+        assert_eq!(v["cluster_id"], "clu_1");
+        assert_eq!(v["node_id"], "node_1");
+        assert_eq!(v["sequence"], 7);
+        assert_eq!(v["agent_instance_id"], "instance-1");
+        assert_eq!(v["attribution_quality"], "full");
+        assert_eq!(v["events"].as_array().unwrap().len(), 1);
+        assert_eq!(v["events"][0]["event_type"], "heartbeat");
+    }
+}

--- a/cognitod/src/cloud/seal.rs
+++ b/cognitod/src/cloud/seal.rs
@@ -12,6 +12,7 @@
 
 use std::time::Instant;
 
+use log::warn;
 use sha2::{Digest, Sha256};
 
 use super::model::{AttributionQuality, BatchEnvelope, Event, SCHEMA_VERSION};
@@ -48,6 +49,24 @@ pub struct BatchSealer {
     first_push: Option<Instant>,
 }
 
+/// Outcome of attempting to buffer an event. The byte cap is enforced
+/// *before* appending, so a sealed batch can never exceed the edge's body
+/// limit: the caller seals the current batch first when the next event
+/// doesn't fit.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PushOutcome {
+    /// The event was buffered.
+    Accepted,
+    /// The event doesn't fit in this batch: the caller should seal the
+    /// current batch, then push the event into a fresh sealer.
+    BatchFull,
+    /// The event alone exceeds the byte cap, so it was dropped (with a
+    /// warning). The edge would quarantine an oversized batch anyway;
+    /// dropping keeps one pathological snapshot from blocking the pipeline.
+    /// Callers should count these in their dropped-events total.
+    DroppedOversize { bytes: usize },
+}
+
 impl BatchSealer {
     pub fn new(quality: AttributionQuality) -> Self {
         Self {
@@ -70,17 +89,36 @@ impl BatchSealer {
         self.events.is_empty()
     }
 
-    /// Buffer an event. The caller must only push events whose batch-level
+    /// Buffer an event, enforcing the count and byte caps *before* the
+    /// append. The caller must only push events whose batch-level
     /// attribution quality matches this sealer's — a batch never mixes
     /// quality states (schema §2).
-    pub fn push(&mut self, event: Event) {
+    pub fn try_push(&mut self, event: Event) -> PushOutcome {
         // Size is best-effort: serialization of our own types can't fail.
         let size = serde_json::to_vec(&event).map(|b| b.len()).unwrap_or(0);
+        if size + ENVELOPE_OVERHEAD > MAX_BATCH_BYTES {
+            warn!(
+                "[cloud] dropping oversized event ({} bytes > {} byte batch cap); \
+                 the edge would quarantine an oversized batch",
+                size, MAX_BATCH_BYTES
+            );
+            return PushOutcome::DroppedOversize { bytes: size };
+        }
+        if !self.events.is_empty() && self.would_breach(size) {
+            return PushOutcome::BatchFull;
+        }
         if self.first_push.is_none() {
             self.first_push = Some(Instant::now());
         }
         self.event_bytes += size;
         self.events.push(event);
+        PushOutcome::Accepted
+    }
+
+    /// True if buffering an event of `size` bytes would breach a cap.
+    fn would_breach(&self, size: usize) -> bool {
+        self.events.len() + 1 > MAX_EVENTS_PER_BATCH
+            || self.event_bytes + size + ENVELOPE_OVERHEAD > MAX_BATCH_BYTES
     }
 
     /// True when any seal trigger has fired.
@@ -184,11 +222,104 @@ mod tests {
         }
     }
 
+    fn big_event(id: &str, blob_len: usize) -> Event {
+        Event {
+            event_id: id.to_string(),
+            event_idempotency_key: format!("k:{id}"),
+            event_type: EventType::Detection,
+            occurred_at: rfc3339(1_700_000_000),
+            detail_level: DetailLevel::Evidence,
+            payload: EventPayload::Detection(DetectionPayload {
+                detection_type: "fork_storm".to_string(),
+                severity: Severity::Warning,
+                subject: None,
+                window: TimeRange {
+                    start: rfc3339(1_700_000_000 - 10),
+                    end: rfc3339(1_700_000_000),
+                },
+                rule_name: "fork_storm".to_string(),
+                action: DetectionAction::Observe,
+                details: serde_json::json!({"blob": "x".repeat(blob_len)}),
+            }),
+        }
+    }
+
+    #[test]
+    fn try_push_reports_batch_full_before_breaching_caps() {
+        let mut sealer = BatchSealer::new(AttributionQuality::Full);
+        for i in 0..MAX_EVENTS_PER_BATCH {
+            assert_eq!(
+                sealer.try_push(heartbeat_event(&format!("e{i}"))),
+                PushOutcome::Accepted
+            );
+        }
+        // The next event would breach the 500-event cap: seal first.
+        assert_eq!(
+            sealer.try_push(heartbeat_event("overflow")),
+            PushOutcome::BatchFull
+        );
+        // Nothing was appended by the refused push.
+        assert_eq!(sealer.len(), MAX_EVENTS_PER_BATCH);
+
+        // A fresh sealer accepts it.
+        let mut fresh = BatchSealer::new(AttributionQuality::Full);
+        assert_eq!(
+            fresh.try_push(heartbeat_event("overflow")),
+            PushOutcome::Accepted
+        );
+    }
+
+    #[test]
+    fn try_push_never_lets_a_batch_exceed_the_byte_cap() {
+        let mut sealer = BatchSealer::new(AttributionQuality::Full);
+        assert_eq!(
+            sealer.try_push(big_event("fill", 512 * 1024)),
+            PushOutcome::Accepted
+        );
+        // Keep pushing until the cap trips; the refused event must not be
+        // appended, and the sealed batch must respect the cap.
+        let mut pushed = 1usize;
+        let refused_at = loop {
+            match sealer.try_push(heartbeat_event(&format!("e{pushed}"))) {
+                PushOutcome::Accepted => pushed += 1,
+                PushOutcome::BatchFull => break pushed,
+                PushOutcome::DroppedOversize { .. } => panic!("a heartbeat is tiny"),
+            }
+        };
+        assert!(refused_at > 1, "the cap should trip before seal_due alone");
+        assert_eq!(sealer.len(), refused_at);
+        let batch = sealer.seal(&ctx()).unwrap();
+        assert!(
+            batch.bytes.len() < MAX_BATCH_BYTES,
+            "sealed batch ({} bytes) must respect the cap",
+            batch.bytes.len()
+        );
+        // The refused event goes into a fresh batch cleanly.
+        let mut fresh = BatchSealer::new(AttributionQuality::Full);
+        assert_eq!(
+            fresh.try_push(heartbeat_event("next")),
+            PushOutcome::Accepted
+        );
+    }
+
+    #[test]
+    fn oversized_single_event_is_dropped_with_outcome() {
+        let mut sealer = BatchSealer::new(AttributionQuality::Full);
+        let outcome = sealer.try_push(big_event("huge", MAX_BATCH_BYTES));
+        assert!(matches!(
+            outcome,
+            PushOutcome::DroppedOversize { bytes } if bytes > MAX_BATCH_BYTES
+        ));
+        // The sealer is untouched: the drop can't poison the batch.
+        assert!(sealer.is_empty());
+        assert!(!sealer.seal_due(Instant::now()));
+    }
+
     #[test]
     fn seals_on_event_count() {
         let mut sealer = BatchSealer::new(AttributionQuality::Full);
         for i in 0..MAX_EVENTS_PER_BATCH {
-            sealer.push(heartbeat_event(&format!("e{i}")));
+            sealer.try_push(heartbeat_event(&format!("e{i}")));
             assert_eq!(
                 sealer.seal_due(Instant::now()),
                 i + 1 >= MAX_EVENTS_PER_BATCH
@@ -203,7 +334,7 @@ mod tests {
     #[test]
     fn seals_on_time() {
         let mut sealer = BatchSealer::new(AttributionQuality::PsiOnly);
-        sealer.push(heartbeat_event("e1"));
+        sealer.try_push(heartbeat_event("e1"));
         assert!(!sealer.seal_due(Instant::now()));
         let later = Instant::now() + std::time::Duration::from_secs(SEAL_INTERVAL_SECS);
         assert!(sealer.seal_due(later));
@@ -220,7 +351,7 @@ mod tests {
         // of the same logical batch is recognized as the same batch.
         let build = || {
             let mut sealer = BatchSealer::new(AttributionQuality::Full);
-            sealer.push(heartbeat_event("e1"));
+            sealer.try_push(heartbeat_event("e1"));
             sealer.seal(&ctx()).unwrap()
         };
         let a = build();
@@ -238,7 +369,7 @@ mod tests {
     #[test]
     fn envelope_shape_matches_schema() {
         let mut sealer = BatchSealer::new(AttributionQuality::Full);
-        sealer.push(heartbeat_event("e1"));
+        sealer.try_push(heartbeat_event("e1"));
         let batch = sealer.seal(&ctx()).unwrap();
         let v: serde_json::Value = serde_json::from_slice(&batch.bytes).unwrap();
         assert_eq!(v["schema_version"], "1.0.0");

--- a/cognitod/src/cloud/seal.rs
+++ b/cognitod/src/cloud/seal.rs
@@ -9,6 +9,13 @@
 //! since the first buffered event. A change in attribution quality seals
 //! immediately too, but that's handled by the exporter (seal the old batch,
 //! rotate to a new sealer) because a batch must never mix quality states.
+//!
+//! Byte accounting is exact, not estimated: the sealer is built with the
+//! identity fields that go into every envelope and precomputes the
+//! serialized size of the envelope around the events. A fixed overhead fudge
+//! can't account for variable-length identity strings, JSON escaping, or
+//! the commas between events — underestimating lets sealed batches exceed
+//! the 1 MiB cap the edge enforces (and then quarantines).
 
 use std::time::Instant;
 
@@ -18,10 +25,21 @@ use sha2::{Digest, Sha256};
 use super::model::{AttributionQuality, BatchEnvelope, Event, SCHEMA_VERSION};
 use super::{MAX_BATCH_BYTES, MAX_EVENTS_PER_BATCH, SEAL_INTERVAL_SECS};
 
-/// Fixed overhead fudge for the envelope around the events when deciding
-/// whether the next push would breach the 1 MiB cap. The real envelope is a
-/// few hundred bytes; overestimating slightly is safe.
-const ENVELOPE_OVERHEAD: usize = 512;
+/// Identity fields baked into every batch envelope. The sealer needs them at
+/// construction time (not just at seal time) so the prospective size check
+/// in [`try_push`] measures the real envelope instead of guessing.
+#[derive(Debug, Clone)]
+pub struct SealIdentity {
+    pub tenant_id: String,
+    pub cluster_id: String,
+    pub node_id: String,
+    pub agent_instance_id: String,
+}
+
+/// `sent_at` always serializes to exactly 24 bytes (`YYYY-MM-DDTHH:MM:SS.sssZ`
+/// via [`rfc3339`]); the size template uses a placeholder of the same length
+/// so its math stays exact. A test pins this length.
+const SENT_AT_PLACEHOLDER: &str = "1970-01-01T00:00:00.000Z";
 
 /// Context needed once per sealed batch.
 pub struct SealContext<'a> {
@@ -44,6 +62,14 @@ pub struct SealedBatch {
 
 pub struct BatchSealer {
     quality: AttributionQuality,
+    identity: SealIdentity,
+    /// Serialized length of the envelope with zero events, built with
+    /// `sequence = u64::MAX` (20 digits) and a 24-byte `sent_at`. The real
+    /// sequence is always shorter, so this can only *over*estimate — by at
+    /// most 2 × (20 − digits) bytes across `sequence` and the idempotency
+    /// key — which fails safe: a batch may seal a few bytes early, but never
+    /// over the cap.
+    empty_envelope_len: usize,
     events: Vec<Event>,
     event_bytes: usize,
     first_push: Option<Instant>,
@@ -53,13 +79,14 @@ pub struct BatchSealer {
 /// *before* appending, so a sealed batch can never exceed the edge's body
 /// limit: the caller seals the current batch first when the next event
 /// doesn't fit.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone)]
 pub enum PushOutcome {
     /// The event was buffered.
     Accepted,
-    /// The event doesn't fit in this batch: the caller should seal the
-    /// current batch, then push the event into a fresh sealer.
-    BatchFull,
+    /// The event doesn't fit in this batch. The event is handed back (not
+    /// consumed) so the caller can seal the current batch and push it into
+    /// a fresh sealer without cloning beforehand.
+    BatchFull(Box<Event>),
     /// The event alone exceeds the byte cap, so it was dropped (with a
     /// warning). The edge would quarantine an oversized batch anyway;
     /// dropping keeps one pathological snapshot from blocking the pipeline.
@@ -68,9 +95,40 @@ pub enum PushOutcome {
 }
 
 impl BatchSealer {
-    pub fn new(quality: AttributionQuality) -> Self {
+    pub fn new(quality: AttributionQuality, identity: SealIdentity) -> Self {
+        debug_assert_eq!(
+            SENT_AT_PLACEHOLDER.len(),
+            24,
+            "sent_at placeholder must match the 24-byte rfc3339 format"
+        );
+        // Serialize the envelope with zero events: the exact fixed cost of
+        // every batch this sealer produces. `events` serializes last (struct
+        // field order), so the template ends with `"events":[]` and the
+        // prospective size of n events is
+        // `empty_envelope_len + sum(event_bytes) + (n - 1)` commas.
+        let template = BatchEnvelope {
+            schema_version: SCHEMA_VERSION.to_string(),
+            tenant_id: identity.tenant_id.clone(),
+            cluster_id: identity.cluster_id.clone(),
+            node_id: identity.node_id.clone(),
+            agent_version: env!("CARGO_PKG_VERSION").to_string(),
+            sent_at: SENT_AT_PLACEHOLDER.to_string(),
+            batch_idempotency_key: BatchEnvelope::idempotency_key(&identity.node_id, u64::MAX),
+            sequence: u64::MAX,
+            agent_instance_id: identity.agent_instance_id.clone(),
+            attribution_quality: quality,
+            events: Vec::new(),
+        };
+        let template_bytes =
+            serde_json::to_vec(&template).expect("template envelope serialization cannot fail");
+        debug_assert!(
+            template_bytes.ends_with(br#""events":[]}"#),
+            "size math assumes `events` serializes last; BatchEnvelope field order changed?"
+        );
         Self {
             quality,
+            identity,
+            empty_envelope_len: template_bytes.len(),
             events: Vec::new(),
             event_bytes: 0,
             first_push: None,
@@ -89,6 +147,14 @@ impl BatchSealer {
         self.events.is_empty()
     }
 
+    /// Exact serialized size of the batch if `event_bytes_total` event bytes
+    /// were spread over `event_count` events. Derivation: the template is
+    /// `{...,"events":[]}`; replacing `[]` with `[e1,…,en]` adds the event
+    /// bytes plus (n−1) comma separators.
+    fn prospective_len(&self, event_bytes_total: usize, event_count: usize) -> usize {
+        self.empty_envelope_len + event_bytes_total + event_count.saturating_sub(1)
+    }
+
     /// Buffer an event, enforcing the count and byte caps *before* the
     /// append. The caller must only push events whose batch-level
     /// attribution quality matches this sealer's — a batch never mixes
@@ -96,7 +162,9 @@ impl BatchSealer {
     pub fn try_push(&mut self, event: Event) -> PushOutcome {
         // Size is best-effort: serialization of our own types can't fail.
         let size = serde_json::to_vec(&event).map(|b| b.len()).unwrap_or(0);
-        if size + ENVELOPE_OVERHEAD > MAX_BATCH_BYTES {
+        // An event that doesn't fit even alone is dropped, not batched:
+        // the edge would quarantine the oversized batch.
+        if self.prospective_len(size, 1) > MAX_BATCH_BYTES {
             warn!(
                 "[cloud] dropping oversized event ({} bytes > {} byte batch cap); \
                  the edge would quarantine an oversized batch",
@@ -105,7 +173,7 @@ impl BatchSealer {
             return PushOutcome::DroppedOversize { bytes: size };
         }
         if !self.events.is_empty() && self.would_breach(size) {
-            return PushOutcome::BatchFull;
+            return PushOutcome::BatchFull(Box::new(event));
         }
         if self.first_push.is_none() {
             self.first_push = Some(Instant::now());
@@ -118,7 +186,8 @@ impl BatchSealer {
     /// True if buffering an event of `size` bytes would breach a cap.
     fn would_breach(&self, size: usize) -> bool {
         self.events.len() + 1 > MAX_EVENTS_PER_BATCH
-            || self.event_bytes + size + ENVELOPE_OVERHEAD > MAX_BATCH_BYTES
+            || self.prospective_len(self.event_bytes + size, self.events.len() + 1)
+                > MAX_BATCH_BYTES
     }
 
     /// True when any seal trigger has fired.
@@ -129,7 +198,10 @@ impl BatchSealer {
         if self.events.len() >= MAX_EVENTS_PER_BATCH {
             return true;
         }
-        if self.event_bytes + ENVELOPE_OVERHEAD >= MAX_BATCH_BYTES {
+        // Backstop: try_push already refuses anything that would breach, so
+        // this should never fire — but if the accounting ever drifts, seal
+        // rather than emit an oversized batch.
+        if self.prospective_len(self.event_bytes, self.events.len()) >= MAX_BATCH_BYTES {
             return true;
         }
         if let Some(first) = self.first_push
@@ -152,6 +224,12 @@ impl BatchSealer {
         if self.events.is_empty() {
             return None;
         }
+        // The size accounting was computed from this identity; a caller
+        // sealing with different identity fields would invalidate it.
+        debug_assert_eq!(ctx.tenant_id, self.identity.tenant_id);
+        debug_assert_eq!(ctx.cluster_id, self.identity.cluster_id);
+        debug_assert_eq!(ctx.node_id, self.identity.node_id);
+        debug_assert_eq!(ctx.agent_instance_id, self.identity.agent_instance_id);
         let events = std::mem::take(&mut self.events);
         self.event_bytes = 0;
         self.first_push = None;
@@ -172,6 +250,15 @@ impl BatchSealer {
         };
         // Same inputs → same bytes: idempotency keys are stable across retries.
         let bytes = serde_json::to_vec(&envelope).expect("envelope serialization cannot fail");
+        // Backstop for the prospective accounting: a sealed batch must never
+        // exceed the cap. (The template overestimates via u64::MAX digits,
+        // so this holds with room to spare.)
+        debug_assert!(
+            bytes.len() <= MAX_BATCH_BYTES,
+            "sealed batch ({} bytes) exceeds the {MAX_BATCH_BYTES} byte cap: \
+             prospective size accounting is wrong",
+            bytes.len(),
+        );
         let digest = hex::encode(Sha256::digest(&bytes));
         Some(SealedBatch {
             sequence: ctx.sequence,
@@ -187,6 +274,26 @@ impl BatchSealer {
 mod tests {
     use super::super::model::*;
     use super::*;
+
+    fn test_identity() -> SealIdentity {
+        SealIdentity {
+            tenant_id: "tn_1".to_string(),
+            cluster_id: "clu_1".to_string(),
+            node_id: "node_1".to_string(),
+            agent_instance_id: "instance-1".to_string(),
+        }
+    }
+
+    /// Production-shaped identity: UUID-length fields, the case the fixed
+    /// fudge factor got wrong (commas + escaping + long IDs).
+    fn uuid_identity() -> SealIdentity {
+        SealIdentity {
+            tenant_id: "123e4567-e89b-12d3-a456-426614174000".to_string(),
+            cluster_id: "123e4567-e89b-12d3-a456-426614174001".to_string(),
+            node_id: "123e4567-e89b-12d3-a456-426614174002".to_string(),
+            agent_instance_id: "123e4567-e89b-12d3-a456-426614174003".to_string(),
+        }
+    }
 
     fn heartbeat_event(id: &str) -> Event {
         Event {
@@ -245,66 +352,151 @@ mod tests {
     }
 
     #[test]
-    fn try_push_reports_batch_full_before_breaching_caps() {
-        let mut sealer = BatchSealer::new(AttributionQuality::Full);
+    fn sent_at_is_always_24_bytes() {
+        // The template's size math depends on this; rfc3339 with millis is
+        // fixed-width by construction.
+        assert_eq!(SENT_AT_PLACEHOLDER.len(), 24);
+        assert_eq!(rfc3339(1_700_000_000).len(), 24);
+        assert_eq!(rfc3339(0).len(), 24);
+    }
+
+    #[test]
+    fn batch_full_hands_the_event_back() {
+        let mut sealer = BatchSealer::new(AttributionQuality::Full, test_identity());
         for i in 0..MAX_EVENTS_PER_BATCH {
-            assert_eq!(
+            assert!(matches!(
                 sealer.try_push(heartbeat_event(&format!("e{i}"))),
                 PushOutcome::Accepted
-            );
+            ));
         }
-        // The next event would breach the 500-event cap: seal first.
-        assert_eq!(
-            sealer.try_push(heartbeat_event("overflow")),
-            PushOutcome::BatchFull
-        );
+        // The next event would breach the 500-event cap: it comes back in
+        // the outcome — no clone needed before pushing.
+        let returned = match sealer.try_push(heartbeat_event("overflow")) {
+            PushOutcome::BatchFull(event) => event,
+            other => panic!("expected BatchFull, got {other:?}"),
+        };
+        assert_eq!(returned.event_id, "overflow");
         // Nothing was appended by the refused push.
         assert_eq!(sealer.len(), MAX_EVENTS_PER_BATCH);
 
-        // A fresh sealer accepts it.
-        let mut fresh = BatchSealer::new(AttributionQuality::Full);
-        assert_eq!(
-            fresh.try_push(heartbeat_event("overflow")),
-            PushOutcome::Accepted
-        );
+        // The returned event goes into a fresh sealer cleanly.
+        let mut fresh = BatchSealer::new(AttributionQuality::Full, test_identity());
+        assert!(matches!(fresh.try_push(*returned), PushOutcome::Accepted));
+        assert_eq!(fresh.len(), 1);
     }
 
     #[test]
     fn try_push_never_lets_a_batch_exceed_the_byte_cap() {
-        let mut sealer = BatchSealer::new(AttributionQuality::Full);
-        assert_eq!(
+        let mut sealer = BatchSealer::new(AttributionQuality::Full, test_identity());
+        assert!(matches!(
             sealer.try_push(big_event("fill", 512 * 1024)),
             PushOutcome::Accepted
-        );
+        ));
         // Keep pushing until the cap trips; the refused event must not be
         // appended, and the sealed batch must respect the cap.
         let mut pushed = 1usize;
-        let refused_at = loop {
+        let refused_event = loop {
             match sealer.try_push(heartbeat_event(&format!("e{pushed}"))) {
                 PushOutcome::Accepted => pushed += 1,
-                PushOutcome::BatchFull => break pushed,
+                PushOutcome::BatchFull(event) => break event,
                 PushOutcome::DroppedOversize { .. } => panic!("a heartbeat is tiny"),
             }
         };
-        assert!(refused_at > 1, "the cap should trip before seal_due alone");
-        assert_eq!(sealer.len(), refused_at);
+        assert!(pushed > 1, "the cap should trip before seal_due alone");
+        assert_eq!(sealer.len(), pushed);
         let batch = sealer.seal(&ctx()).unwrap();
         assert!(
-            batch.bytes.len() < MAX_BATCH_BYTES,
+            batch.bytes.len() <= MAX_BATCH_BYTES,
             "sealed batch ({} bytes) must respect the cap",
             batch.bytes.len()
         );
-        // The refused event goes into a fresh batch cleanly.
-        let mut fresh = BatchSealer::new(AttributionQuality::Full);
-        assert_eq!(
-            fresh.try_push(heartbeat_event("next")),
+        // The refused event is reusable without cloning.
+        let mut fresh = BatchSealer::new(AttributionQuality::Full, test_identity());
+        assert!(matches!(
+            fresh.try_push(*refused_event),
             PushOutcome::Accepted
+        ));
+        assert_eq!(fresh.len(), 1);
+    }
+
+    #[test]
+    fn byte_accounting_is_exact_at_the_boundary() {
+        // Fill a batch with ~100 KiB events until the byte cap (not the
+        // count cap) trips, then assert the sealed batch lands just under
+        // the cap: exact accounting fills close to the boundary instead of
+        // leaving a fudge-sized gap.
+        let mut sealer = BatchSealer::new(AttributionQuality::Full, uuid_identity());
+        let mut count = 0usize;
+        loop {
+            match sealer.try_push(big_event(&format!("b{count}"), 100 * 1024)) {
+                PushOutcome::Accepted => count += 1,
+                PushOutcome::BatchFull(_) => break,
+                PushOutcome::DroppedOversize { .. } => panic!("100 KiB fits alone"),
+            }
+        }
+        assert!(count >= 9, "expected ~10 events near the cap, got {count}");
+        let batch = sealer
+            .seal(&SealContext {
+                tenant_id: "123e4567-e89b-12d3-a456-426614174000",
+                cluster_id: "123e4567-e89b-12d3-a456-426614174001",
+                node_id: "123e4567-e89b-12d3-a456-426614174002",
+                agent_instance_id: "123e4567-e89b-12d3-a456-426614174003",
+                sequence: 3,
+            })
+            .unwrap();
+        assert!(
+            batch.bytes.len() <= MAX_BATCH_BYTES,
+            "sealed batch ({} bytes) must respect the cap",
+            batch.bytes.len()
+        );
+        // Near-boundary fill: the next ~100 KiB event didn't fit, so the
+        // batch must be within one event of the cap (plus the tiny
+        // sequence-digit overestimate) — not a fudge-factor short.
+        let event_size = serde_json::to_vec(&big_event("probe", 100 * 1024))
+            .unwrap()
+            .len();
+        assert!(
+            batch.bytes.len() + event_size > MAX_BATCH_BYTES,
+            "batch ({} bytes) should be within one event ({event_size} bytes) of the cap",
+            batch.bytes.len()
+        );
+    }
+
+    #[test]
+    fn full_event_count_batch_with_uuid_identity_stays_under_cap() {
+        // 500 events with production-length identity strings: the old
+        // fixed-fudge accounting could overshoot here (499 commas alone
+        // nearly exhaust a 512-byte fudge).
+        let mut sealer = BatchSealer::new(AttributionQuality::Full, uuid_identity());
+        let mut accepted = 0;
+        for i in 0..MAX_EVENTS_PER_BATCH {
+            match sealer.try_push(heartbeat_event(&format!("e{i}"))) {
+                PushOutcome::Accepted => accepted += 1,
+                PushOutcome::BatchFull(_) => break,
+                PushOutcome::DroppedOversize { .. } => panic!("heartbeat is tiny"),
+            }
+        }
+        assert_eq!(accepted, MAX_EVENTS_PER_BATCH);
+        let batch = sealer
+            .seal(&SealContext {
+                tenant_id: "123e4567-e89b-12d3-a456-426614174000",
+                cluster_id: "123e4567-e89b-12d3-a456-426614174001",
+                node_id: "123e4567-e89b-12d3-a456-426614174002",
+                agent_instance_id: "123e4567-e89b-12d3-a456-426614174003",
+                sequence: 3,
+            })
+            .unwrap();
+        assert_eq!(batch.event_count, MAX_EVENTS_PER_BATCH);
+        assert!(
+            batch.bytes.len() <= MAX_BATCH_BYTES,
+            "500-event batch ({} bytes) must respect the cap",
+            batch.bytes.len()
         );
     }
 
     #[test]
     fn oversized_single_event_is_dropped_with_outcome() {
-        let mut sealer = BatchSealer::new(AttributionQuality::Full);
+        let mut sealer = BatchSealer::new(AttributionQuality::Full, test_identity());
         let outcome = sealer.try_push(big_event("huge", MAX_BATCH_BYTES));
         assert!(matches!(
             outcome,
@@ -317,7 +509,7 @@ mod tests {
 
     #[test]
     fn seals_on_event_count() {
-        let mut sealer = BatchSealer::new(AttributionQuality::Full);
+        let mut sealer = BatchSealer::new(AttributionQuality::Full, test_identity());
         for i in 0..MAX_EVENTS_PER_BATCH {
             sealer.try_push(heartbeat_event(&format!("e{i}")));
             assert_eq!(
@@ -333,7 +525,7 @@ mod tests {
 
     #[test]
     fn seals_on_time() {
-        let mut sealer = BatchSealer::new(AttributionQuality::PsiOnly);
+        let mut sealer = BatchSealer::new(AttributionQuality::PsiOnly, test_identity());
         sealer.try_push(heartbeat_event("e1"));
         assert!(!sealer.seal_due(Instant::now()));
         let later = Instant::now() + std::time::Duration::from_secs(SEAL_INTERVAL_SECS);
@@ -350,7 +542,7 @@ mod tests {
         // idempotency key, sequence, event payloads — is stable, so a retry
         // of the same logical batch is recognized as the same batch.
         let build = || {
-            let mut sealer = BatchSealer::new(AttributionQuality::Full);
+            let mut sealer = BatchSealer::new(AttributionQuality::Full, test_identity());
             sealer.try_push(heartbeat_event("e1"));
             sealer.seal(&ctx()).unwrap()
         };
@@ -368,7 +560,7 @@ mod tests {
 
     #[test]
     fn envelope_shape_matches_schema() {
-        let mut sealer = BatchSealer::new(AttributionQuality::Full);
+        let mut sealer = BatchSealer::new(AttributionQuality::Full, test_identity());
         sealer.try_push(heartbeat_event("e1"));
         let batch = sealer.seal(&ctx()).unwrap();
         let v: serde_json::Value = serde_json::from_slice(&batch.bytes).unwrap();

--- a/cognitod/src/cloud/spool.rs
+++ b/cognitod/src/cloud/spool.rs
@@ -1,0 +1,426 @@
+//! Crash-safe on-disk spool for sealed batches.
+//!
+//! Layout inside the state directory (`cloud_spool/`):
+//! - `{sequence}.json` — the immutable sealed batch bytes.
+//! - `spool.json` — manifest: entries (sequence, priority, digest, bytes,
+//!   event count, sealed-at) plus the cumulative `dropped_total`.
+//! - `quarantine/` — batches the edge refused (409/413/422) with a `.note`
+//!   explaining why; never retried, kept for operator inspection.
+//!
+//! Caps (schema §10): 256 MiB total or 24h age, whichever first. When a cap
+//! is hit the oldest lowest-priority batches are dropped first:
+//! heartbeat, then detection. `degradation_state` is never dropped —
+//! losing the quality signal would let the cloud mistake silence for health.
+//! Every drop increments `dropped_total`, which the heartbeat reports.
+
+use std::collections::VecDeque;
+use std::io;
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use serde::{Deserialize, Serialize};
+
+use super::seal::SealedBatch;
+use super::{SPOOL_MAX_AGE_SECS, SPOOL_MAX_BYTES};
+
+pub const SPOOL_DIR_NAME: &str = "cloud_spool";
+const MANIFEST_NAME: &str = "spool.json";
+const QUARANTINE_DIR: &str = "quarantine";
+
+/// Drop priority: lower value = more important = dropped later.
+/// Mirrors schema §10 ("Never drop degradation_state, then retain
+/// stall_attribution and detection, then heartbeat, and drop oldest
+/// pressure_sample first" — pressure_sample isn't emitted in v1).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub enum SpoolPriority {
+    DegradationState = 0,
+    Detection = 1,
+    Heartbeat = 2,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct SpoolEntry {
+    sequence: u64,
+    priority: SpoolPriority,
+    digest: String,
+    bytes: u64,
+    events: usize,
+    sealed_at_unix: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+struct Manifest {
+    entries: Vec<SpoolEntry>,
+    dropped_total: u64,
+}
+
+pub struct Spool {
+    dir: PathBuf,
+    manifest_path: PathBuf,
+    quarantine_dir: PathBuf,
+    entries: VecDeque<SpoolEntry>,
+    total_bytes: u64,
+    dropped_total: u64,
+}
+
+impl Spool {
+    /// Open (or create) the spool in `state_dir/cloud_spool`, rebuilding the
+    /// index from the manifest and dropping entries whose batch file is
+    /// missing (e.g. torn write before the manifest fsync).
+    pub fn open(state_dir: &Path) -> io::Result<Self> {
+        let dir = state_dir.join(SPOOL_DIR_NAME);
+        std::fs::create_dir_all(&dir)?;
+        let quarantine_dir = dir.join(QUARANTINE_DIR);
+        std::fs::create_dir_all(&quarantine_dir)?;
+        let manifest_path = dir.join(MANIFEST_NAME);
+
+        let mut manifest: Manifest = match std::fs::read_to_string(&manifest_path) {
+            Ok(contents) => serde_json::from_str(&contents).unwrap_or_default(),
+            Err(e) if e.kind() == io::ErrorKind::NotFound => Manifest::default(),
+            Err(e) => return Err(e),
+        };
+        // Drop index entries whose payload didn't survive.
+        manifest
+            .entries
+            .retain(|e| dir.join(batch_file_name(e.sequence)).exists());
+
+        let total_bytes = manifest.entries.iter().map(|e| e.bytes).sum();
+        let entries = manifest.entries.into_iter().collect();
+        Ok(Self {
+            dir,
+            manifest_path,
+            quarantine_dir,
+            entries,
+            total_bytes,
+            dropped_total: manifest.dropped_total,
+        })
+    }
+
+    fn persist(&self) -> io::Result<()> {
+        let manifest = Manifest {
+            entries: self.entries.iter().cloned().collect(),
+            dropped_total: self.dropped_total,
+        };
+        let tmp = self.manifest_path.with_extension("json.tmp");
+        std::fs::write(&tmp, serde_json::to_string_pretty(&manifest).unwrap())?;
+        std::fs::rename(&tmp, &self.manifest_path)?;
+        Ok(())
+    }
+
+    fn batch_path(&self, sequence: u64) -> PathBuf {
+        self.dir.join(batch_file_name(sequence))
+    }
+
+    /// Durably store a sealed batch, then enforce the caps.
+    pub fn store(&mut self, batch: &SealedBatch, priority: SpoolPriority) -> io::Result<()> {
+        let path = self.batch_path(batch.sequence);
+        // create_new: a sequence is never reused, so an existing file means
+        // a bug — fail loudly rather than silently overwriting evidence.
+        let mut opts = std::fs::OpenOptions::new();
+        opts.write(true).create_new(true);
+        let mut file = opts.open(&path)?;
+        use std::io::Write as _;
+        file.write_all(&batch.bytes)?;
+        file.sync_all()?;
+
+        // Keep newest-first ordering simple: entries are appended in
+        // sequence order; the drain end is the front.
+        self.entries.push_back(SpoolEntry {
+            sequence: batch.sequence,
+            priority,
+            digest: batch.digest.clone(),
+            bytes: batch.bytes.len() as u64,
+            events: batch.event_count,
+            sealed_at_unix: now_unix(),
+        });
+        self.total_bytes += batch.bytes.len() as u64;
+        self.enforce_caps()?;
+        self.persist()
+    }
+
+    /// Drop oldest-lowest-priority batches until both caps hold.
+    /// Degradation-state batches are never dropped.
+    fn enforce_caps(&mut self) -> io::Result<()> {
+        while let Some(i) = select_victim(&self.entries, self.total_bytes, now_unix()) {
+            let entry = self.entries.remove(i).expect("index from live iter");
+            let _ = std::fs::remove_file(self.batch_path(entry.sequence));
+            self.total_bytes = self.total_bytes.saturating_sub(entry.bytes);
+            self.dropped_total = self.dropped_total.saturating_add(entry.events as u64);
+            log::warn!(
+                "[cloud] spool cap hit: dropped {} event(s) from batch {} (priority {:?})",
+                entry.events,
+                entry.sequence,
+                entry.priority
+            );
+        }
+        Ok(())
+    }
+
+    /// Oldest batch first (FIFO within the spool).
+    pub fn oldest(&self) -> Option<SpoolEntryView<'_>> {
+        self.entries.front().map(|e| SpoolEntryView {
+            entry: e,
+            path: self.batch_path(e.sequence),
+        })
+    }
+
+    /// Remove a batch after the edge acknowledged it (200/202).
+    pub fn remove(&mut self, sequence: u64) -> io::Result<()> {
+        if let Some(i) = self.entries.iter().position(|e| e.sequence == sequence) {
+            let entry = self.entries.remove(i).expect("position from live iter");
+            let _ = std::fs::remove_file(self.batch_path(entry.sequence));
+            self.total_bytes = self.total_bytes.saturating_sub(entry.bytes);
+            self.persist()?;
+        }
+        Ok(())
+    }
+
+    /// Move a refused batch to quarantine with a note. Never retried.
+    pub fn quarantine(&mut self, sequence: u64, reason: &str) -> io::Result<()> {
+        let Some(i) = self.entries.iter().position(|e| e.sequence == sequence) else {
+            return Ok(());
+        };
+        let entry = self.entries.remove(i).expect("position from live iter");
+        let dest = self.quarantine_dir.join(batch_file_name(entry.sequence));
+        let _ = std::fs::rename(self.batch_path(entry.sequence), &dest);
+        let _ = std::fs::write(
+            self.quarantine_dir.join(format!("{}.note", entry.sequence)),
+            format!(
+                "sequence: {}\ndigest: {}\nquarantined_at_unix: {}\nreason: {reason}\n",
+                entry.sequence,
+                entry.digest,
+                now_unix()
+            ),
+        );
+        self.total_bytes = self.total_bytes.saturating_sub(entry.bytes);
+        self.persist()?;
+        log::error!(
+            "[cloud] batch {} quarantined ({} event(s)): {reason}; kept at {}",
+            entry.sequence,
+            entry.events,
+            dest.display()
+        );
+        Ok(())
+    }
+
+    /// Pending event count across all spooled batches (heartbeat field).
+    pub fn pending_events(&self) -> u64 {
+        self.entries.iter().map(|e| e.events as u64).sum()
+    }
+
+    /// Cumulative locally-dropped events (heartbeat field).
+    pub fn dropped_total(&self) -> u64 {
+        self.dropped_total
+    }
+
+    pub fn batch_count(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// Read a spooled batch's bytes, verifying the digest.
+    pub fn read(&self, sequence: u64) -> io::Result<Vec<u8>> {
+        let entry = self
+            .entries
+            .iter()
+            .find(|e| e.sequence == sequence)
+            .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "batch not spooled"))?;
+        let bytes = std::fs::read(self.batch_path(sequence))?;
+        use sha2::Digest as _;
+        let digest = hex::encode(sha2::Sha256::digest(&bytes));
+        if digest != entry.digest {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("batch {sequence} failed digest check"),
+            ));
+        }
+        Ok(bytes)
+    }
+}
+
+/// A borrowed view of the oldest spooled batch for the sender.
+pub struct SpoolEntryView<'a> {
+    entry: &'a SpoolEntry,
+    path: PathBuf,
+}
+
+impl SpoolEntryView<'_> {
+    pub fn sequence(&self) -> u64 {
+        self.entry.sequence
+    }
+
+    pub fn priority(&self) -> SpoolPriority {
+        self.entry.priority
+    }
+
+    pub fn bytes_path(&self) -> &Path {
+        &self.path
+    }
+}
+
+fn batch_file_name(sequence: u64) -> String {
+    format!("{sequence}.json")
+}
+
+/// Pick the next batch to drop when a cap is hit: lowest priority (highest
+/// discriminant) first, then oldest — with the monotonic sequence as the
+/// final tie-break so same-second seals are still deterministic.
+/// Degradation-state batches are never candidates. Pure for testing.
+fn select_victim(
+    entries: &VecDeque<SpoolEntry>,
+    total_bytes: u64,
+    now_unix_secs: u64,
+) -> Option<usize> {
+    entries
+        .iter()
+        .enumerate()
+        .filter(|(_, e)| {
+            e.priority != SpoolPriority::DegradationState
+                && (total_bytes > SPOOL_MAX_BYTES
+                    || now_unix_secs.saturating_sub(e.sealed_at_unix) > SPOOL_MAX_AGE_SECS)
+        })
+        .max_by(|(_, a), (_, b)| {
+            a.priority
+                .cmp(&b.priority)
+                .then(b.sealed_at_unix.cmp(&a.sealed_at_unix))
+                .then(b.sequence.cmp(&a.sequence))
+        })
+        .map(|(i, _)| i)
+}
+
+fn now_unix() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::model::{AttributionQuality, BatchEnvelope};
+    use super::*;
+
+    fn sealed(sequence: u64, event_count: usize) -> SealedBatch {
+        let bytes = vec![b'x'; 64];
+        SealedBatch {
+            sequence,
+            quality: AttributionQuality::Full,
+            event_count,
+            bytes,
+            digest: {
+                use sha2::Digest as _;
+                hex::encode(sha2::Sha256::digest(vec![b'x'; 64]))
+            },
+        }
+    }
+
+    #[test]
+    fn round_trip_and_digest_check() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut spool = Spool::open(dir.path()).unwrap();
+        let batch = sealed(3, 10);
+        spool.store(&batch, SpoolPriority::Detection).unwrap();
+        assert_eq!(spool.batch_count(), 1);
+        assert_eq!(spool.pending_events(), 10);
+        let read = spool.read(3).unwrap();
+        assert_eq!(read, batch.bytes);
+        spool.remove(3).unwrap();
+        assert_eq!(spool.batch_count(), 0);
+        assert_eq!(spool.pending_events(), 0);
+    }
+
+    #[test]
+    fn spool_survives_reopen() {
+        let dir = tempfile::tempdir().unwrap();
+        {
+            let mut spool = Spool::open(dir.path()).unwrap();
+            spool
+                .store(&sealed(1, 5), SpoolPriority::Heartbeat)
+                .unwrap();
+            spool
+                .store(&sealed(2, 7), SpoolPriority::Detection)
+                .unwrap();
+        }
+        let spool = Spool::open(dir.path()).unwrap();
+        assert_eq!(spool.batch_count(), 2);
+        assert_eq!(spool.pending_events(), 12);
+        assert_eq!(spool.oldest().unwrap().sequence(), 1);
+    }
+
+    fn entry(sequence: u64, priority: SpoolPriority, sealed_at_unix: u64) -> SpoolEntry {
+        SpoolEntry {
+            sequence,
+            priority,
+            digest: "d".to_string(),
+            bytes: 64,
+            events: 1,
+            sealed_at_unix,
+        }
+    }
+
+    #[test]
+    fn victim_selection_prefers_low_priority_then_oldest() {
+        let now = 1_700_000_000;
+        let entries: VecDeque<SpoolEntry> = [
+            entry(0, SpoolPriority::DegradationState, now),
+            entry(1, SpoolPriority::Detection, now),
+            entry(2, SpoolPriority::Heartbeat, now),
+            entry(3, SpoolPriority::Heartbeat, now),
+        ]
+        .into_iter()
+        .collect();
+        // Over the size cap: oldest heartbeat first, never degradation.
+        let over = SPOOL_MAX_BYTES + 1;
+        assert_eq!(select_victim(&entries, over, now), Some(2));
+        let mut without_oldest: VecDeque<SpoolEntry> = entries.clone().into_iter().collect();
+        without_oldest.remove(2);
+        // Detection outranks the remaining heartbeat... no: heartbeat is
+        // lower priority, so the newer heartbeat still goes first.
+        assert_eq!(select_victim(&without_oldest, over, now), Some(2)); // seq 3 now at index 2
+        // Under the size cap but with an aged-out heartbeat: age cap fires.
+        let aged: VecDeque<SpoolEntry> = [
+            entry(0, SpoolPriority::DegradationState, now),
+            entry(1, SpoolPriority::Detection, now),
+            entry(2, SpoolPriority::Heartbeat, now - SPOOL_MAX_AGE_SECS - 1),
+        ]
+        .into_iter()
+        .collect();
+        assert_eq!(select_victim(&aged, 100, now), Some(2));
+        // Nothing over any cap: no victim.
+        let fresh: VecDeque<SpoolEntry> = [
+            entry(
+                0,
+                SpoolPriority::DegradationState,
+                now - SPOOL_MAX_AGE_SECS - 1,
+            ),
+            entry(1, SpoolPriority::Detection, now),
+        ]
+        .into_iter()
+        .collect();
+        assert_eq!(select_victim(&fresh, 100, now), None);
+    }
+
+    #[test]
+    fn quarantine_moves_batch_out_of_the_drain_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut spool = Spool::open(dir.path()).unwrap();
+        spool
+            .store(&sealed(9, 4), SpoolPriority::Detection)
+            .unwrap();
+        spool.quarantine(9, "409 conflict").unwrap();
+        assert_eq!(spool.batch_count(), 0);
+        assert!(spool.oldest().is_none());
+        let note = std::fs::read_to_string(
+            dir.path()
+                .join(SPOOL_DIR_NAME)
+                .join(QUARANTINE_DIR)
+                .join("9.note"),
+        )
+        .unwrap();
+        assert!(note.contains("409 conflict"));
+    }
+
+    #[test]
+    fn batch_envelope_idempotency_key_uses_node_and_sequence() {
+        assert_eq!(BatchEnvelope::idempotency_key("node_1", 42), "b:node_1:42");
+    }
+}

--- a/cognitod/src/cloud/spool.rs
+++ b/cognitod/src/cloud/spool.rs
@@ -12,6 +12,18 @@
 //! heartbeat, then detection. `degradation_state` is never dropped —
 //! losing the quality signal would let the cloud mistake silence for health.
 //! Every drop increments `dropped_total`, which the heartbeat reports.
+//!
+//! Quarantine is bounded by the same envelope: quarantined bytes count
+//! toward the 256 MiB cap, and quarantined batches older than 24h are
+//! evicted oldest-first (with a diagnostic log; their `.note` is the
+//! operator's record and is never deleted while the batch exists). Spool
+//! batches are always evicted before quarantined ones — refused evidence is
+//! more valuable for debugging than unsent heartbeats.
+//!
+//! A corrupt `spool.json` doesn't silently orphan evidence: the manifest is
+//! rebuilt from the batch files on disk (each payload verified before
+//! re-admission; files that fail verification are moved to quarantine with
+//! a note explaining why).
 
 use std::collections::VecDeque;
 use std::io;
@@ -19,6 +31,7 @@ use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 
 use super::seal::SealedBatch;
 use super::{SPOOL_MAX_AGE_SECS, SPOOL_MAX_BYTES};
@@ -54,6 +67,17 @@ struct Manifest {
     dropped_total: u64,
 }
 
+/// A quarantined batch, indexed from the files on disk at open (the
+/// quarantine directory itself is the source of truth, so a crash between
+/// the file move and the manifest write can't lose the index).
+#[derive(Debug, Clone)]
+struct QuarantineEntry {
+    sequence: u64,
+    bytes: u64,
+    events: usize,
+    quarantined_at_unix: u64,
+}
+
 pub struct Spool {
     dir: PathBuf,
     manifest_path: PathBuf,
@@ -61,12 +85,17 @@ pub struct Spool {
     entries: VecDeque<SpoolEntry>,
     total_bytes: u64,
     dropped_total: u64,
+    quarantine_entries: VecDeque<QuarantineEntry>,
+    quarantine_bytes: u64,
 }
 
 impl Spool {
     /// Open (or create) the spool in `state_dir/cloud_spool`, rebuilding the
     /// index from the manifest and dropping entries whose batch file is
-    /// missing (e.g. torn write before the manifest fsync).
+    /// missing (e.g. torn write before the manifest fsync). A corrupt
+    /// manifest is rebuilt from the batch files on disk instead of silently
+    /// opening empty (which would orphan evidence the watermark may already
+    /// have advanced past).
     pub fn open(state_dir: &Path) -> io::Result<Self> {
         let dir = state_dir.join(SPOOL_DIR_NAME);
         std::fs::create_dir_all(&dir)?;
@@ -74,8 +103,18 @@ impl Spool {
         std::fs::create_dir_all(&quarantine_dir)?;
         let manifest_path = dir.join(MANIFEST_NAME);
 
+        let mut rebuilt = false;
         let mut manifest: Manifest = match std::fs::read_to_string(&manifest_path) {
-            Ok(contents) => serde_json::from_str(&contents).unwrap_or_default(),
+            Ok(contents) => match serde_json::from_str(&contents) {
+                Ok(m) => m,
+                Err(e) => {
+                    log::error!(
+                        "[cloud] spool manifest is corrupt ({e}); rebuilding from batch files on disk"
+                    );
+                    rebuilt = true;
+                    Self::rebuild_from_disk(&dir, &quarantine_dir)?
+                }
+            },
             Err(e) if e.kind() == io::ErrorKind::NotFound => Manifest::default(),
             Err(e) => return Err(e),
         };
@@ -84,16 +123,132 @@ impl Spool {
             .entries
             .retain(|e| dir.join(batch_file_name(e.sequence)).exists());
 
+        let quarantine_entries = Self::scan_quarantine(&quarantine_dir)?;
+        let quarantine_bytes = quarantine_entries.iter().map(|e| e.bytes).sum();
+
         let total_bytes = manifest.entries.iter().map(|e| e.bytes).sum();
         let entries = manifest.entries.into_iter().collect();
-        Ok(Self {
+        let spool = Self {
             dir,
             manifest_path,
             quarantine_dir,
             entries,
             total_bytes,
             dropped_total: manifest.dropped_total,
-        })
+            quarantine_entries,
+            quarantine_bytes,
+        };
+        if rebuilt {
+            // Persist the rebuilt manifest so the next open takes the fast
+            // path; the quarantine index is always re-scanned from disk.
+            spool.persist()?;
+        }
+        Ok(spool)
+    }
+
+    /// Rebuild the manifest from `{sequence}.json` files on disk. Every
+    /// payload is verified before re-admission; files that fail verification
+    /// are moved to quarantine with a note (skip-and-note) rather than being
+    /// silently dropped or blindly trusted.
+    fn rebuild_from_disk(dir: &Path, quarantine_dir: &Path) -> io::Result<Manifest> {
+        let mut sequences: Vec<(u64, PathBuf)> = std::fs::read_dir(dir)?
+            .filter_map(|e| e.ok())
+            .filter(|e| e.file_type().map(|t| t.is_file()).unwrap_or(false))
+            .filter_map(|e| {
+                let name = e.file_name().to_string_lossy().into_owned();
+                let seq: u64 = name.strip_suffix(".json")?.parse().ok()?;
+                Some((seq, e.path()))
+            })
+            .collect();
+        sequences.sort_by_key(|(seq, _)| *seq);
+
+        let mut manifest = Manifest::default();
+        for (seq, path) in sequences {
+            let bytes = std::fs::read(&path)?;
+            match verify_batch_bytes(&bytes) {
+                Ok(info) => {
+                    manifest.entries.push(SpoolEntry {
+                        sequence: seq,
+                        priority: info.priority,
+                        digest: info.digest,
+                        bytes: bytes.len() as u64,
+                        events: info.events,
+                        sealed_at_unix: file_mtime_unix(&path),
+                    });
+                }
+                Err(reason) => {
+                    let dest = quarantine_dir.join(batch_file_name(seq));
+                    let _ = std::fs::rename(&path, &dest);
+                    let _ = std::fs::write(
+                        quarantine_dir.join(format!("{seq}.note")),
+                        format!(
+                            "sequence: {seq}\nquarantined_at_unix: {}\n\
+                             reason: skipped during spool rebuild: {reason}\n",
+                            now_unix()
+                        ),
+                    );
+                    log::warn!(
+                        "[cloud] spool rebuild: quarantined unreadable batch file {seq} ({reason})"
+                    );
+                }
+            }
+        }
+        log::warn!(
+            "[cloud] spool rebuild complete: re-admitted {} batch(es); dropped_total reset",
+            manifest.entries.len()
+        );
+        Ok(manifest)
+    }
+
+    /// Index the quarantine directory from disk. Every batch gets a note if
+    /// it lacks one — a quarantined batch is never deleted un-noted.
+    fn scan_quarantine(quarantine_dir: &Path) -> io::Result<VecDeque<QuarantineEntry>> {
+        let mut out: Vec<QuarantineEntry> = Vec::new();
+        for entry in std::fs::read_dir(quarantine_dir)? {
+            let entry = match entry {
+                Ok(e) => e,
+                Err(_) => continue,
+            };
+            let name = entry.file_name().to_string_lossy().into_owned();
+            let Some(seq) = name
+                .strip_suffix(".json")
+                .and_then(|s| s.parse::<u64>().ok())
+            else {
+                continue;
+            };
+            let bytes = entry.metadata().map(|m| m.len()).unwrap_or(0);
+            let note_path = quarantine_dir.join(format!("{seq}.note"));
+            let quarantined_at = std::fs::read_to_string(&note_path)
+                .ok()
+                .and_then(|note| parse_note_field(&note, "quarantined_at_unix"))
+                .unwrap_or_else(|| file_mtime_unix(&entry.path()));
+            if !note_path.exists() {
+                let _ = std::fs::write(
+                    &note_path,
+                    format!(
+                        "sequence: {seq}\nquarantined_at_unix: {quarantined_at}\n\
+                         reason: recovered at startup; original refusal reason unknown\n"
+                    ),
+                );
+            }
+            let events = std::fs::read(entry.path())
+                .ok()
+                .and_then(|b| verify_batch_bytes(&b).ok())
+                .map(|info| info.events)
+                .unwrap_or(0);
+            out.push(QuarantineEntry {
+                sequence: seq,
+                bytes,
+                events,
+                quarantined_at_unix: quarantined_at,
+            });
+        }
+        out.sort_by(|a, b| {
+            a.quarantined_at_unix
+                .cmp(&b.quarantined_at_unix)
+                .then(a.sequence.cmp(&b.sequence))
+        });
+        Ok(out.into())
     }
 
     fn persist(&self) -> io::Result<()> {
@@ -139,9 +294,12 @@ impl Spool {
     }
 
     /// Drop oldest-lowest-priority batches until both caps hold.
-    /// Degradation-state batches are never dropped.
+    /// Degradation-state batches are never dropped. Quarantined batches
+    /// count toward the byte cap and are evicted oldest-first when they age
+    /// out or when the spool alone can't get back under the cap.
     fn enforce_caps(&mut self) -> io::Result<()> {
-        while let Some(i) = select_victim(&self.entries, self.total_bytes, now_unix()) {
+        let now = now_unix();
+        while let Some(i) = select_victim(&self.entries, self.total_bytes_used(), now) {
             let entry = self.entries.remove(i).expect("index from live iter");
             let _ = std::fs::remove_file(self.batch_path(entry.sequence));
             self.total_bytes = self.total_bytes.saturating_sub(entry.bytes);
@@ -151,6 +309,49 @@ impl Spool {
                 entry.events,
                 entry.sequence,
                 entry.priority
+            );
+        }
+        self.enforce_quarantine_caps_at(now)
+    }
+
+    /// Spool + quarantine bytes: the cap both share.
+    fn total_bytes_used(&self) -> u64 {
+        self.total_bytes.saturating_add(self.quarantine_bytes)
+    }
+
+    /// Evict quarantined batches oldest-first when one is older than 24h or
+    /// the shared byte cap is still exceeded. Every evicted batch is noted
+    /// (its `.note` was written at quarantine/scan time) and the eviction
+    /// is logged as the diagnostic trail.
+    fn enforce_quarantine_caps_at(&mut self, now: u64) -> io::Result<()> {
+        while let Some(i) =
+            select_quarantine_victim(&self.quarantine_entries, self.total_bytes_used(), now)
+        {
+            let q = self
+                .quarantine_entries
+                .remove(i)
+                .expect("index from live iter");
+            let note_path = self.quarantine_dir.join(format!("{}.note", q.sequence));
+            if !note_path.exists() {
+                let _ = std::fs::write(
+                    &note_path,
+                    format!(
+                        "sequence: {}\nquarantined_at_unix: {}\n\
+                         reason: recovered at eviction; original refusal reason unknown\n",
+                        q.sequence, q.quarantined_at_unix
+                    ),
+                );
+            }
+            let _ = std::fs::remove_file(self.quarantine_dir.join(batch_file_name(q.sequence)));
+            let _ = std::fs::remove_file(&note_path);
+            self.quarantine_bytes = self.quarantine_bytes.saturating_sub(q.bytes);
+            self.dropped_total = self.dropped_total.saturating_add(q.events as u64);
+            log::error!(
+                "[cloud] quarantine retention: evicted quarantined batch {} \
+                 ({} event(s), {} bytes) — age/size cap",
+                q.sequence,
+                q.events,
+                q.bytes
             );
         }
         Ok(())
@@ -175,7 +376,9 @@ impl Spool {
         Ok(())
     }
 
-    /// Move a refused batch to quarantine with a note. Never retried.
+    /// Move a refused batch to quarantine with a note. Never retried; the
+    /// quarantine directory is bounded by the same retention envelope as
+    /// the spool (see [`Spool::enforce_quarantine_caps_at`]).
     pub fn quarantine(&mut self, sequence: u64, reason: &str) -> io::Result<()> {
         let Some(i) = self.entries.iter().position(|e| e.sequence == sequence) else {
             return Ok(());
@@ -193,6 +396,14 @@ impl Spool {
             ),
         );
         self.total_bytes = self.total_bytes.saturating_sub(entry.bytes);
+        self.quarantine_bytes = self.quarantine_bytes.saturating_add(entry.bytes);
+        self.quarantine_entries.push_back(QuarantineEntry {
+            sequence: entry.sequence,
+            bytes: entry.bytes,
+            events: entry.events,
+            quarantined_at_unix: now_unix(),
+        });
+        self.enforce_quarantine_caps_at(now_unix())?;
         self.persist()?;
         log::error!(
             "[cloud] batch {} quarantined ({} event(s)): {reason}; kept at {}",
@@ -215,6 +426,22 @@ impl Spool {
 
     pub fn batch_count(&self) -> usize {
         self.entries.len()
+    }
+
+    /// Test hooks: quarantine observability.
+    #[cfg(test)]
+    pub fn quarantine_batch_count(&self) -> usize {
+        self.quarantine_entries.len()
+    }
+
+    #[cfg(test)]
+    pub fn quarantine_bytes_used(&self) -> u64 {
+        self.quarantine_bytes
+    }
+
+    #[cfg(test)]
+    pub fn total_bytes_used_for_test(&self) -> u64 {
+        self.total_bytes_used()
     }
 
     /// Read a spooled batch's bytes, verifying the digest.
@@ -261,6 +488,74 @@ fn batch_file_name(sequence: u64) -> String {
     format!("{sequence}.json")
 }
 
+/// What `verify_batch_bytes` recovers from a payload on disk.
+struct BatchInfo {
+    digest: String,
+    events: usize,
+    priority: SpoolPriority,
+}
+
+/// Verify a batch payload well enough to re-admit it after a corrupt
+/// manifest: valid JSON, the envelope's idempotency key, and an events
+/// array. Priority is inferred from the event types present (a batch that
+/// carried a degradation_state keeps its never-drop protection).
+fn verify_batch_bytes(bytes: &[u8]) -> Result<BatchInfo, String> {
+    let v: serde_json::Value =
+        serde_json::from_slice(bytes).map_err(|e| format!("invalid JSON: {e}"))?;
+    if v.get("batch_idempotency_key")
+        .and_then(|k| k.as_str())
+        .is_none()
+    {
+        return Err("missing batch_idempotency_key".to_string());
+    }
+    let events = v
+        .get("events")
+        .and_then(|e| e.as_array())
+        .ok_or_else(|| "missing events array".to_string())?;
+    let mut has_detection = false;
+    let mut has_degradation = false;
+    for e in events {
+        match e.get("event_type").and_then(|t| t.as_str()) {
+            Some("degradation_state") => has_degradation = true,
+            Some("detection") => has_detection = true,
+            _ => {}
+        }
+    }
+    let priority = if has_degradation {
+        SpoolPriority::DegradationState
+    } else if has_detection {
+        SpoolPriority::Detection
+    } else {
+        SpoolPriority::Heartbeat
+    };
+    Ok(BatchInfo {
+        digest: hex::encode(Sha256::digest(bytes)),
+        events: events.len(),
+        priority,
+    })
+}
+
+/// Parse a `key: value` line out of a quarantine `.note` file.
+fn parse_note_field(note: &str, key: &str) -> Option<u64> {
+    note.lines().find_map(|line| {
+        let (k, v) = line.split_once(':')?;
+        if k.trim() == key {
+            v.trim().parse::<u64>().ok()
+        } else {
+            None
+        }
+    })
+}
+
+fn file_mtime_unix(path: &Path) -> u64 {
+    std::fs::metadata(path)
+        .and_then(|m| m.modified())
+        .ok()
+        .and_then(|t| t.duration_since(UNIX_EPOCH).ok())
+        .map(|d| d.as_secs())
+        .unwrap_or_else(now_unix)
+}
+
 /// Pick the next batch to drop when a cap is hit: lowest priority (highest
 /// discriminant) first, then oldest — with the monotonic sequence as the
 /// final tie-break so same-second seals are still deterministic.
@@ -283,6 +578,29 @@ fn select_victim(
                 .cmp(&b.priority)
                 .then(b.sealed_at_unix.cmp(&a.sealed_at_unix))
                 .then(b.sequence.cmp(&a.sequence))
+        })
+        .map(|(i, _)| i)
+}
+
+/// Pick the next quarantined batch to evict: oldest first (by quarantine
+/// time, then sequence), but only when it's older than 24h or the shared
+/// byte cap is exceeded. Pure for testing.
+fn select_quarantine_victim(
+    entries: &VecDeque<QuarantineEntry>,
+    total_bytes_used: u64,
+    now_unix_secs: u64,
+) -> Option<usize> {
+    entries
+        .iter()
+        .enumerate()
+        .filter(|(_, e)| {
+            total_bytes_used > SPOOL_MAX_BYTES
+                || now_unix_secs.saturating_sub(e.quarantined_at_unix) > SPOOL_MAX_AGE_SECS
+        })
+        .min_by(|(_, a), (_, b)| {
+            a.quarantined_at_unix
+                .cmp(&b.quarantined_at_unix)
+                .then(a.sequence.cmp(&b.sequence))
         })
         .map(|(i, _)| i)
 }
@@ -422,5 +740,133 @@ mod tests {
     #[test]
     fn batch_envelope_idempotency_key_uses_node_and_sequence() {
         assert_eq!(BatchEnvelope::idempotency_key("node_1", 42), "b:node_1:42");
+    }
+
+    fn qentry(sequence: u64, quarantined_at_unix: u64) -> QuarantineEntry {
+        QuarantineEntry {
+            sequence,
+            bytes: 64,
+            events: 2,
+            quarantined_at_unix,
+        }
+    }
+
+    #[test]
+    fn quarantine_victim_selection_is_oldest_first() {
+        let now = 1_700_000_000;
+        let entries: VecDeque<QuarantineEntry> =
+            [qentry(5, now), qentry(3, now - 10), qentry(7, now - 10)]
+                .into_iter()
+                .collect();
+        // Over the shared size cap: oldest first, sequence breaks ties.
+        assert_eq!(
+            select_quarantine_victim(&entries, SPOOL_MAX_BYTES + 1, now),
+            Some(1)
+        );
+        // Aged-out entry evicted even under the size cap.
+        let aged: VecDeque<QuarantineEntry> =
+            [qentry(5, now), qentry(6, now - SPOOL_MAX_AGE_SECS - 1)]
+                .into_iter()
+                .collect();
+        assert_eq!(select_quarantine_victim(&aged, 100, now), Some(1));
+        // Fresh and under the cap: no victim.
+        let fresh: VecDeque<QuarantineEntry> =
+            [qentry(5, now), qentry(6, now)].into_iter().collect();
+        assert_eq!(select_quarantine_victim(&fresh, 100, now), None);
+    }
+
+    #[test]
+    fn quarantine_bytes_count_toward_the_shared_cap() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut spool = Spool::open(dir.path()).unwrap();
+        spool
+            .store(&sealed(11, 4), SpoolPriority::Detection)
+            .unwrap();
+        assert_eq!(spool.total_bytes_used_for_test(), 64);
+        spool.quarantine(11, "409 conflict").unwrap();
+        assert_eq!(spool.batch_count(), 0);
+        assert_eq!(spool.quarantine_batch_count(), 1);
+        // The bytes moved with the batch: the cap still sees them.
+        assert_eq!(spool.quarantine_bytes_used(), 64);
+        assert_eq!(spool.total_bytes_used_for_test(), 64);
+        // The batch file and its note survived the move.
+        let qdir = dir.path().join(SPOOL_DIR_NAME).join(QUARANTINE_DIR);
+        assert!(qdir.join("11.json").exists());
+        assert!(qdir.join("11.note").exists());
+    }
+
+    #[test]
+    fn quarantine_index_rebuilt_from_disk() {
+        let dir = tempfile::tempdir().unwrap();
+        let qdir = dir.path().join(SPOOL_DIR_NAME).join(QUARANTINE_DIR);
+        std::fs::create_dir_all(&qdir).unwrap();
+        // A quarantined batch with a note, as quarantine() would leave it.
+        let bytes = br#"{"batch_idempotency_key":"b:n:21","events":[{"event_type":"detection"}]}"#;
+        std::fs::write(qdir.join("21.json"), bytes).unwrap();
+        std::fs::write(
+            qdir.join("21.note"),
+            "sequence: 21\ndigest: d\nquarantined_at_unix: 1700000000\nreason: 409\n",
+        )
+        .unwrap();
+        // And one without a note: open must note it (never delete un-noted).
+        std::fs::write(qdir.join("22.json"), bytes).unwrap();
+
+        let spool = Spool::open(dir.path()).unwrap();
+        assert_eq!(spool.quarantine_batch_count(), 2);
+        assert_eq!(spool.quarantine_bytes_used(), bytes.len() as u64 * 2);
+        assert!(
+            qdir.join("22.note").exists(),
+            "recovered batch must be noted"
+        );
+    }
+
+    #[test]
+    fn corrupt_manifest_rebuilds_from_disk() {
+        let dir = tempfile::tempdir().unwrap();
+        let spool_dir = dir.path().join(SPOOL_DIR_NAME);
+        std::fs::create_dir_all(&spool_dir).unwrap();
+        // A valid sealed batch on disk...
+        let good = serde_json::json!({
+            "schema_version": "1.0.0",
+            "batch_idempotency_key": "b:n:5",
+            "events": [
+                {"event_id": "e1", "event_type": "detection"},
+                {"event_id": "e2", "event_type": "heartbeat"}
+            ]
+        });
+        std::fs::write(spool_dir.join("5.json"), serde_json::to_vec(&good).unwrap()).unwrap();
+        // ...a corrupt one...
+        std::fs::write(spool_dir.join("6.json"), b"not json at all").unwrap();
+        // ...and a corrupt manifest.
+        std::fs::write(spool_dir.join(MANIFEST_NAME), b"{truncated").unwrap();
+
+        let spool = Spool::open(dir.path()).unwrap();
+        // The valid batch was re-admitted with its digest recomputed; the
+        // corrupt file was skip-and-noted into quarantine.
+        assert_eq!(spool.batch_count(), 1);
+        let read = spool.read(5).unwrap();
+        let v: serde_json::Value = serde_json::from_slice(&read).unwrap();
+        assert_eq!(v["batch_idempotency_key"], "b:n:5");
+        assert_eq!(spool.quarantine_batch_count(), 1);
+        let qdir = spool_dir.join(QUARANTINE_DIR);
+        assert!(qdir.join("6.json").exists());
+        let note = std::fs::read_to_string(qdir.join("6.note")).unwrap();
+        assert!(note.contains("spool rebuild"), "note explains why: {note}");
+        // The rebuilt manifest is valid: a second open takes the fast path.
+        drop(spool);
+        let reopened = Spool::open(dir.path()).unwrap();
+        assert_eq!(reopened.batch_count(), 1);
+        assert_eq!(reopened.quarantine_batch_count(), 1);
+    }
+
+    #[test]
+    fn corrupt_manifest_with_no_batch_files_opens_empty() {
+        let dir = tempfile::tempdir().unwrap();
+        let spool_dir = dir.path().join(SPOOL_DIR_NAME);
+        std::fs::create_dir_all(&spool_dir).unwrap();
+        std::fs::write(spool_dir.join(MANIFEST_NAME), b"\x00\x01 garbage").unwrap();
+        let spool = Spool::open(dir.path()).unwrap();
+        assert_eq!(spool.batch_count(), 0);
+        assert_eq!(spool.quarantine_batch_count(), 0);
     }
 }

--- a/cognitod/src/cloud/spool.rs
+++ b/cognitod/src/cloud/spool.rs
@@ -1,5 +1,15 @@
 //! Crash-safe on-disk spool for sealed batches.
 //!
+//! Durability model: every metadata write (manifest, quarantine notes) goes
+//! through [`super::persist_durable`] — temp file, `sync_all`, atomic
+//! rename, parent-directory fsync — so it survives process crashes *and*
+//! host/power loss on filesystems that honor sync. Payload files are
+//! written with `create_new` + `sync_all`, plus a directory fsync so the
+//! directory entry is durable too. A crash between syncing a payload and
+//! persisting the manifest can't strand evidence: every open reconciles
+//! the manifest against the batch files on disk (orphans are re-admitted
+//! after verification).
+//!
 //! Layout inside the state directory (`cloud_spool/`):
 //! - `{sequence}.json` — the immutable sealed batch bytes.
 //! - `spool.json` — manifest: entries (sequence, priority, digest, bytes,
@@ -25,7 +35,7 @@
 //! re-admission; files that fail verification are moved to quarantine with
 //! a note explaining why).
 
-use std::collections::VecDeque;
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::io;
 use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -103,7 +113,6 @@ impl Spool {
         std::fs::create_dir_all(&quarantine_dir)?;
         let manifest_path = dir.join(MANIFEST_NAME);
 
-        let mut rebuilt = false;
         let mut manifest: Manifest = match std::fs::read_to_string(&manifest_path) {
             Ok(contents) => match serde_json::from_str(&contents) {
                 Ok(m) => m,
@@ -111,24 +120,26 @@ impl Spool {
                     log::error!(
                         "[cloud] spool manifest is corrupt ({e}); rebuilding from batch files on disk"
                     );
-                    rebuilt = true;
                     Self::rebuild_from_disk(&dir, &quarantine_dir)?
                 }
             },
             Err(e) if e.kind() == io::ErrorKind::NotFound => Manifest::default(),
             Err(e) => return Err(e),
         };
-        // Drop index entries whose payload didn't survive.
-        manifest
-            .entries
-            .retain(|e| dir.join(batch_file_name(e.sequence)).exists());
+        // Reconcile the manifest against the batch files on disk on *every*
+        // open, not just after a corrupt manifest: a crash between syncing
+        // a payload and persisting the manifest leaves a valid manifest
+        // plus an orphaned batch that would otherwise never be uploaded,
+        // removed, or counted. Listed entries whose file is missing,
+        // resized, or digest-drifted are dropped, repaired, or quarantined.
+        Self::reconcile_with_disk(&mut manifest, &dir, &quarantine_dir)?;
 
         let quarantine_entries = Self::scan_quarantine(&quarantine_dir)?;
         let quarantine_bytes = quarantine_entries.iter().map(|e| e.bytes).sum();
 
         let total_bytes = manifest.entries.iter().map(|e| e.bytes).sum();
         let entries = manifest.entries.into_iter().collect();
-        let spool = Self {
+        let mut spool = Self {
             dir,
             manifest_path,
             quarantine_dir,
@@ -138,12 +149,183 @@ impl Spool {
             quarantine_entries,
             quarantine_bytes,
         };
-        if rebuilt {
-            // Persist the rebuilt manifest so the next open takes the fast
-            // path; the quarantine index is always re-scanned from disk.
-            spool.persist()?;
-        }
+        // Enforce the caps on recovered state before the sender ever drains
+        // it: an over-age or over-size spool from a previous run must be
+        // evicted, not served. Then persist the reconciled, cap-enforced
+        // manifest so the next open takes the fast path.
+        spool.enforce_caps()?;
+        spool.persist()?;
         Ok(spool)
+    }
+
+    /// Move an unverifiable batch file into quarantine with a note. A
+    /// missing source is already-done (idempotent); anything else
+    /// propagates — the caller must not index a file whose disposition is
+    /// unknown.
+    fn quarantine_file(
+        path: &Path,
+        quarantine_dir: &Path,
+        seq: u64,
+        reason: &str,
+    ) -> io::Result<()> {
+        let dest = quarantine_dir.join(batch_file_name(seq));
+        match std::fs::rename(path, &dest) {
+            Ok(()) => {}
+            Err(e) if e.kind() == io::ErrorKind::NotFound => {
+                log::warn!("[cloud] spool: batch file {seq} vanished before quarantine; skipping");
+                return Ok(());
+            }
+            Err(e) => return Err(e),
+        }
+        // The rename already succeeded, so the batch IS quarantined on
+        // disk; a note-write failure propagates, but the next open's scan
+        // recreates the note — the batch is never left un-noted.
+        let note = format!(
+            "sequence: {seq}\nquarantined_at_unix: {}\nreason: {reason}\n",
+            now_unix()
+        );
+        super::persist_durable(&quarantine_dir.join(format!("{seq}.note")), note.as_bytes())?;
+        log::warn!("[cloud] spool: quarantined batch file {seq} ({reason})");
+        Ok(())
+    }
+
+    /// Reconcile a manifest against the batch files on disk.
+    ///
+    /// - Payload files not listed in the manifest (the crash window: payload
+    ///   synced, manifest never persisted) are verified and re-admitted, or
+    ///   quarantined with a note when they fail verification.
+    /// - Listed entries whose file is missing are dropped.
+    /// - Listed entries whose size or digest no longer matches the file are
+    ///   re-verified: repaired from disk when the file is a valid batch,
+    ///   quarantined with a note when it isn't.
+    fn reconcile_with_disk(
+        manifest: &mut Manifest,
+        dir: &Path,
+        quarantine_dir: &Path,
+    ) -> io::Result<()> {
+        let mut indexed: HashMap<u64, usize> = HashMap::new();
+        for (i, e) in manifest.entries.iter().enumerate() {
+            indexed.entry(e.sequence).or_insert(i);
+        }
+        let mut on_disk: Vec<(u64, PathBuf)> = std::fs::read_dir(dir)?
+            .filter_map(|e| e.ok())
+            .filter(|e| e.file_type().map(|t| t.is_file()).unwrap_or(false))
+            .filter_map(|e| {
+                let name = e.file_name().to_string_lossy().into_owned();
+                let seq: u64 = name.strip_suffix(".json")?.parse().ok()?;
+                Some((seq, e.path()))
+            })
+            .collect();
+        on_disk.sort_by_key(|(seq, _)| *seq);
+
+        // Sequences whose manifest entry survives this pass.
+        let mut confirmed: HashSet<u64> = HashSet::new();
+        for (seq, path) in on_disk {
+            let survives = match indexed.get(&seq) {
+                Some(&i) => {
+                    let entry = &manifest.entries[i];
+                    // Read once: size and digest are both checked against
+                    // the manifest. Any drift means the file changed under
+                    // us — re-verify before trusting it.
+                    let disk = std::fs::read(&path);
+                    let matches = match &disk {
+                        Ok(bytes) => {
+                            bytes.len() as u64 == entry.bytes
+                                && hex::encode(Sha256::digest(bytes)) == entry.digest
+                        }
+                        Err(_) => false,
+                    };
+                    if matches {
+                        true
+                    } else {
+                        match disk.map_err(|e| e.to_string()).and_then(|bytes| {
+                            verify_batch_bytes(&bytes).map(|info| {
+                                let digest = hex::encode(Sha256::digest(&bytes));
+                                (bytes.len() as u64, digest, info)
+                            })
+                        }) {
+                            Ok((actual_bytes, actual_digest, info)) => {
+                                log::warn!(
+                                    "[cloud] spool reconcile: repaired manifest entry for batch \
+                                     {seq} (size/digest drifted on disk)"
+                                );
+                                let e = &mut manifest.entries[i];
+                                e.bytes = actual_bytes;
+                                e.digest = actual_digest;
+                                e.events = info.events;
+                                e.priority = info.priority;
+                                true
+                            }
+                            Err(reason) => {
+                                let claimed_events = manifest.entries[i].events;
+                                Self::quarantine_file(
+                                    &path,
+                                    quarantine_dir,
+                                    seq,
+                                    &format!(
+                                        "spool reconcile: listed batch failed re-verification: {reason}"
+                                    ),
+                                )?;
+                                manifest.dropped_total =
+                                    manifest.dropped_total.saturating_add(claimed_events as u64);
+                                false
+                            }
+                        }
+                    }
+                }
+                None => {
+                    // Orphaned batch: the payload was synced but the
+                    // manifest persist never landed.
+                    match std::fs::read(&path)
+                        .map_err(|e| e.to_string())
+                        .and_then(|bytes| {
+                            verify_batch_bytes(&bytes).map(|info| (bytes.len() as u64, info))
+                        }) {
+                        Ok((actual_bytes, info)) => {
+                            log::warn!(
+                                "[cloud] spool reconcile: re-admitting orphaned batch {seq} \
+                                 ({} event(s))",
+                                info.events
+                            );
+                            indexed.insert(seq, manifest.entries.len());
+                            manifest.entries.push(SpoolEntry {
+                                sequence: seq,
+                                priority: info.priority,
+                                digest: info.digest,
+                                bytes: actual_bytes,
+                                events: info.events,
+                                sealed_at_unix: file_mtime_unix(&path),
+                            });
+                            true
+                        }
+                        Err(reason) => {
+                            Self::quarantine_file(
+                                &path,
+                                quarantine_dir,
+                                seq,
+                                &format!(
+                                    "spool reconcile: orphaned batch failed verification: {reason}"
+                                ),
+                            )?;
+                            false
+                        }
+                    }
+                }
+            };
+            if survives {
+                confirmed.insert(seq);
+            }
+        }
+        let before = manifest.entries.len();
+        manifest.entries.retain(|e| confirmed.contains(&e.sequence));
+        let dropped = before - manifest.entries.len();
+        if dropped > 0 {
+            log::warn!(
+                "[cloud] spool reconcile: dropped {dropped} manifest entr(ies) with no surviving file"
+            );
+        }
+        manifest.entries.sort_by_key(|e| e.sequence);
+        Ok(())
     }
 
     /// Rebuild the manifest from `{sequence}.json` files on disk. Every
@@ -177,19 +359,12 @@ impl Spool {
                     });
                 }
                 Err(reason) => {
-                    let dest = quarantine_dir.join(batch_file_name(seq));
-                    let _ = std::fs::rename(&path, &dest);
-                    let _ = std::fs::write(
-                        quarantine_dir.join(format!("{seq}.note")),
-                        format!(
-                            "sequence: {seq}\nquarantined_at_unix: {}\n\
-                             reason: skipped during spool rebuild: {reason}\n",
-                            now_unix()
-                        ),
-                    );
-                    log::warn!(
-                        "[cloud] spool rebuild: quarantined unreadable batch file {seq} ({reason})"
-                    );
+                    Self::quarantine_file(
+                        &path,
+                        quarantine_dir,
+                        seq,
+                        &format!("spool rebuild: skipped unreadable batch: {reason}"),
+                    )?;
                 }
             }
         }
@@ -223,13 +398,16 @@ impl Spool {
                 .and_then(|note| parse_note_field(&note, "quarantined_at_unix"))
                 .unwrap_or_else(|| file_mtime_unix(&entry.path()));
             if !note_path.exists() {
-                let _ = std::fs::write(
+                // A quarantined batch is never left un-noted; the write
+                // propagates — without the note we can't prove the
+                // quarantine later.
+                std::fs::write(
                     &note_path,
                     format!(
                         "sequence: {seq}\nquarantined_at_unix: {quarantined_at}\n\
                          reason: recovered at startup; original refusal reason unknown\n"
                     ),
-                );
+                )?;
             }
             let events = std::fs::read(entry.path())
                 .ok()
@@ -251,15 +429,16 @@ impl Spool {
         Ok(out.into())
     }
 
+    /// Durable manifest persist: temp file + file sync + atomic rename +
+    /// parent-directory fsync (see [`super::persist_durable`]), so a host or
+    /// power loss can't roll the manifest back or leave it torn.
     fn persist(&self) -> io::Result<()> {
         let manifest = Manifest {
             entries: self.entries.iter().cloned().collect(),
             dropped_total: self.dropped_total,
         };
-        let tmp = self.manifest_path.with_extension("json.tmp");
-        std::fs::write(&tmp, serde_json::to_string_pretty(&manifest).unwrap())?;
-        std::fs::rename(&tmp, &self.manifest_path)?;
-        Ok(())
+        let bytes = serde_json::to_string_pretty(&manifest).unwrap();
+        super::persist_durable(&self.manifest_path, bytes.as_bytes())
     }
 
     fn batch_path(&self, sequence: u64) -> PathBuf {
@@ -277,6 +456,11 @@ impl Spool {
         use std::io::Write as _;
         file.write_all(&batch.bytes)?;
         file.sync_all()?;
+        drop(file);
+        // Sync the directory entry too: without this a power loss can lose
+        // the payload file itself, which the manifest (persisted later)
+        // would then reference.
+        super::sync_dir(&self.dir)?;
 
         // Keep newest-first ordering simple: entries are appended in
         // sequence order; the drain end is the front.
@@ -300,8 +484,14 @@ impl Spool {
     fn enforce_caps(&mut self) -> io::Result<()> {
         let now = now_unix();
         while let Some(i) = select_victim(&self.entries, self.total_bytes_used(), now) {
+            // The file goes first: only after the filesystem confirms the
+            // deletion does the index stop describing the batch. A missing
+            // file is already-done (idempotent); anything else aborts the
+            // eviction so the index never claims a deletion that didn't
+            // happen — the batch stays queued and is retried next pass.
+            let sequence = self.entries[i].sequence;
+            remove_file_if_exists(&self.batch_path(sequence))?;
             let entry = self.entries.remove(i).expect("index from live iter");
-            let _ = std::fs::remove_file(self.batch_path(entry.sequence));
             self.total_bytes = self.total_bytes.saturating_sub(entry.bytes);
             self.dropped_total = self.dropped_total.saturating_add(entry.events as u64);
             log::warn!(
@@ -327,23 +517,30 @@ impl Spool {
         while let Some(i) =
             select_quarantine_victim(&self.quarantine_entries, self.total_bytes_used(), now)
         {
-            let q = self
-                .quarantine_entries
-                .remove(i)
-                .expect("index from live iter");
-            let note_path = self.quarantine_dir.join(format!("{}.note", q.sequence));
+            // Ensure the note exists *before* deleting anything: a
+            // quarantined batch is never deleted un-noted. The write
+            // propagates — without the note we can't prove the eviction
+            // later, so the batch stays.
+            let note_path = self
+                .quarantine_dir
+                .join(format!("{}.note", self.quarantine_entries[i].sequence));
             if !note_path.exists() {
-                let _ = std::fs::write(
+                std::fs::write(
                     &note_path,
                     format!(
                         "sequence: {}\nquarantined_at_unix: {}\n\
                          reason: recovered at eviction; original refusal reason unknown\n",
-                        q.sequence, q.quarantined_at_unix
+                        self.quarantine_entries[i].sequence,
+                        self.quarantine_entries[i].quarantined_at_unix,
                     ),
-                );
+                )?;
             }
-            let _ = std::fs::remove_file(self.quarantine_dir.join(batch_file_name(q.sequence)));
-            let _ = std::fs::remove_file(&note_path);
+            let q = self
+                .quarantine_entries
+                .remove(i)
+                .expect("index from live iter");
+            remove_file_if_exists(&self.quarantine_dir.join(batch_file_name(q.sequence)))?;
+            remove_file_if_exists(&note_path)?;
             self.quarantine_bytes = self.quarantine_bytes.saturating_sub(q.bytes);
             self.dropped_total = self.dropped_total.saturating_add(q.events as u64);
             log::error!(
@@ -365,11 +562,13 @@ impl Spool {
         })
     }
 
-    /// Remove a batch after the edge acknowledged it (200/202).
+    /// Remove a batch after the edge acknowledged it (200/202). The file is
+    /// deleted first; the index and manifest follow only once the filesystem
+    /// confirms it. A delete failure propagates and the batch stays queued.
     pub fn remove(&mut self, sequence: u64) -> io::Result<()> {
         if let Some(i) = self.entries.iter().position(|e| e.sequence == sequence) {
+            remove_file_if_exists(&self.batch_path(sequence))?;
             let entry = self.entries.remove(i).expect("position from live iter");
-            let _ = std::fs::remove_file(self.batch_path(entry.sequence));
             self.total_bytes = self.total_bytes.saturating_sub(entry.bytes);
             self.persist()?;
         }
@@ -379,22 +578,45 @@ impl Spool {
     /// Move a refused batch to quarantine with a note. Never retried; the
     /// quarantine directory is bounded by the same retention envelope as
     /// the spool (see [`Spool::enforce_quarantine_caps_at`]).
+    ///
+    /// The rename happens before any in-memory change: only after the
+    /// filesystem confirms the move does the index follow. A rename failure
+    /// propagates and the batch stays queued for retry; a missing source is
+    /// already-done (the entry is dropped, since the batch can't be read
+    /// anyway).
     pub fn quarantine(&mut self, sequence: u64, reason: &str) -> io::Result<()> {
         let Some(i) = self.entries.iter().position(|e| e.sequence == sequence) else {
             return Ok(());
         };
+        let src = self.batch_path(sequence);
+        let dest = self.quarantine_dir.join(batch_file_name(sequence));
+        match std::fs::rename(&src, &dest) {
+            Ok(()) => {}
+            Err(e) if e.kind() == io::ErrorKind::NotFound => {
+                log::warn!(
+                    "[cloud] batch {sequence} already gone from spool; dropping its index entry"
+                );
+                let entry = self.entries.remove(i).expect("position from live iter");
+                self.total_bytes = self.total_bytes.saturating_sub(entry.bytes);
+                self.persist()?;
+                return Ok(());
+            }
+            Err(e) => return Err(e),
+        }
+        // The rename succeeded: on disk the batch IS quarantined, so the
+        // index follows. A note-write failure propagates, but the next
+        // open's scan recreates the note — the batch is never lost un-noted.
         let entry = self.entries.remove(i).expect("position from live iter");
-        let dest = self.quarantine_dir.join(batch_file_name(entry.sequence));
-        let _ = std::fs::rename(self.batch_path(entry.sequence), &dest);
-        let _ = std::fs::write(
-            self.quarantine_dir.join(format!("{}.note", entry.sequence)),
+        super::persist_durable(
+            &self.quarantine_dir.join(format!("{}.note", entry.sequence)),
             format!(
                 "sequence: {}\ndigest: {}\nquarantined_at_unix: {}\nreason: {reason}\n",
                 entry.sequence,
                 entry.digest,
                 now_unix()
-            ),
-        );
+            )
+            .as_bytes(),
+        )?;
         self.total_bytes = self.total_bytes.saturating_sub(entry.bytes);
         self.quarantine_bytes = self.quarantine_bytes.saturating_add(entry.bytes);
         self.quarantine_entries.push_back(QuarantineEntry {
@@ -486,6 +708,17 @@ impl SpoolEntryView<'_> {
 
 fn batch_file_name(sequence: u64) -> String {
     format!("{sequence}.json")
+}
+
+/// Delete a file that should be gone. A missing file is already-done
+/// (idempotent); any other error propagates so the caller can't update its
+/// index as if the deletion had happened.
+fn remove_file_if_exists(path: &Path) -> io::Result<()> {
+    match std::fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(e),
+    }
 }
 
 /// What `verify_batch_bytes` recovers from a payload on disk.
@@ -801,11 +1034,16 @@ mod tests {
         let qdir = dir.path().join(SPOOL_DIR_NAME).join(QUARANTINE_DIR);
         std::fs::create_dir_all(&qdir).unwrap();
         // A quarantined batch with a note, as quarantine() would leave it.
+        // (The note's timestamp must be fresh: open() now enforces the 24h
+        // quarantine age cap, so an ancient fixture would be evicted.)
         let bytes = br#"{"batch_idempotency_key":"b:n:21","events":[{"event_type":"detection"}]}"#;
         std::fs::write(qdir.join("21.json"), bytes).unwrap();
         std::fs::write(
             qdir.join("21.note"),
-            "sequence: 21\ndigest: d\nquarantined_at_unix: 1700000000\nreason: 409\n",
+            format!(
+                "sequence: 21\ndigest: d\nquarantined_at_unix: {}\nreason: 409\n",
+                now_unix()
+            ),
         )
         .unwrap();
         // And one without a note: open must note it (never delete un-noted).
@@ -866,6 +1104,182 @@ mod tests {
         std::fs::create_dir_all(&spool_dir).unwrap();
         std::fs::write(spool_dir.join(MANIFEST_NAME), b"\x00\x01 garbage").unwrap();
         let spool = Spool::open(dir.path()).unwrap();
+        assert_eq!(spool.batch_count(), 0);
+        assert_eq!(spool.quarantine_batch_count(), 0);
+    }
+
+    fn valid_batch_bytes(seq: u64, event_count: usize) -> Vec<u8> {
+        let events: Vec<_> = (0..event_count)
+            .map(|i| serde_json::json!({"event_id": format!("e{i}"), "event_type": "detection"}))
+            .collect();
+        serde_json::to_vec(&serde_json::json!({
+            "schema_version": "1.0.0",
+            "batch_idempotency_key": format!("b:n:{seq}"),
+            "events": events,
+        }))
+        .unwrap()
+    }
+
+    #[test]
+    fn reconcile_readmits_orphan_batch_with_valid_manifest() {
+        // The crash window: payload synced, manifest persist never landed.
+        let dir = tempfile::tempdir().unwrap();
+        {
+            let mut spool = Spool::open(dir.path()).unwrap();
+            spool
+                .store(&sealed(1, 5), SpoolPriority::Heartbeat)
+                .unwrap();
+        }
+        // An orphaned payload appears on disk with the manifest untouched.
+        let orphan = valid_batch_bytes(2, 3);
+        std::fs::write(dir.path().join(SPOOL_DIR_NAME).join("2.json"), &orphan).unwrap();
+
+        let spool = Spool::open(dir.path()).unwrap();
+        assert_eq!(spool.batch_count(), 2, "orphan must be re-admitted");
+        assert_eq!(spool.read(2).unwrap(), orphan);
+        // The reconciled manifest was persisted: a second open agrees.
+        drop(spool);
+        let reopened = Spool::open(dir.path()).unwrap();
+        assert_eq!(reopened.batch_count(), 2);
+    }
+
+    #[test]
+    fn reconcile_repairs_drifted_but_valid_batch() {
+        let dir = tempfile::tempdir().unwrap();
+        {
+            let mut spool = Spool::open(dir.path()).unwrap();
+            spool
+                .store(&sealed(1, 5), SpoolPriority::Heartbeat)
+                .unwrap();
+        }
+        // The file on disk is replaced by different-but-valid batch bytes
+        // (size and digest drift from the manifest).
+        let replacement = valid_batch_bytes(1, 4);
+        std::fs::write(dir.path().join(SPOOL_DIR_NAME).join("1.json"), &replacement).unwrap();
+
+        let spool = Spool::open(dir.path()).unwrap();
+        assert_eq!(spool.batch_count(), 1);
+        // The manifest entry was repaired: the digest check passes on the
+        // new bytes.
+        assert_eq!(spool.read(1).unwrap(), replacement);
+        assert_eq!(spool.pending_events(), 4);
+    }
+
+    #[test]
+    fn reconcile_quarantines_listed_batch_that_fails_reverification() {
+        let dir = tempfile::tempdir().unwrap();
+        {
+            let mut spool = Spool::open(dir.path()).unwrap();
+            spool
+                .store(&sealed(1, 5), SpoolPriority::Heartbeat)
+                .unwrap();
+        }
+        // Torn write: the file no longer parses.
+        std::fs::write(dir.path().join(SPOOL_DIR_NAME).join("1.json"), b"{torn").unwrap();
+
+        let spool = Spool::open(dir.path()).unwrap();
+        assert_eq!(
+            spool.batch_count(),
+            0,
+            "unverifiable batch leaves the index"
+        );
+        assert_eq!(spool.quarantine_batch_count(), 1);
+        let note = std::fs::read_to_string(
+            dir.path()
+                .join(SPOOL_DIR_NAME)
+                .join(QUARANTINE_DIR)
+                .join("1.note"),
+        )
+        .unwrap();
+        assert!(note.contains("reconcile"), "note explains why: {note}");
+    }
+
+    #[test]
+    fn reopen_enforces_age_cap_on_recovered_state() {
+        let dir = tempfile::tempdir().unwrap();
+        {
+            let mut spool = Spool::open(dir.path()).unwrap();
+            spool
+                .store(&sealed(1, 5), SpoolPriority::Heartbeat)
+                .unwrap();
+        }
+        // Age the manifest entry to the epoch: a recovered spool older than
+        // 24h must be evicted at open, not served to the sender.
+        let manifest_path = dir.path().join(SPOOL_DIR_NAME).join(MANIFEST_NAME);
+        let mut manifest: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(&manifest_path).unwrap()).unwrap();
+        manifest["entries"][0]["sealed_at_unix"] = serde_json::json!(0);
+        std::fs::write(&manifest_path, serde_json::to_vec(&manifest).unwrap()).unwrap();
+
+        let spool = Spool::open(dir.path()).unwrap();
+        assert_eq!(
+            spool.batch_count(),
+            0,
+            "over-age batch must be evicted at open"
+        );
+        assert_eq!(spool.dropped_total(), 5);
+        assert!(
+            !dir.path().join(SPOOL_DIR_NAME).join("1.json").exists(),
+            "evicted batch file must be gone"
+        );
+    }
+
+    #[test]
+    fn remove_propagates_fs_errors_without_desync() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut spool = Spool::open(dir.path()).unwrap();
+        spool
+            .store(&sealed(1, 5), SpoolPriority::Heartbeat)
+            .unwrap();
+        // Failure injection that works even as root: a directory where the
+        // batch file should be makes remove_file fail with a non-NotFound
+        // error.
+        let batch_path = dir.path().join(SPOOL_DIR_NAME).join("1.json");
+        std::fs::remove_file(&batch_path).unwrap();
+        std::fs::create_dir(&batch_path).unwrap();
+
+        let err = spool.remove(1).unwrap_err();
+        assert_ne!(err.kind(), io::ErrorKind::NotFound);
+        // The failure must not desync the index: the batch is still queued
+        // with its accounting intact, so a later retry can finish the ack.
+        assert_eq!(spool.batch_count(), 1);
+        assert_eq!(spool.total_bytes_used_for_test(), 64);
+    }
+
+    #[test]
+    fn quarantine_propagates_rename_collision() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut spool = Spool::open(dir.path()).unwrap();
+        spool
+            .store(&sealed(1, 5), SpoolPriority::Heartbeat)
+            .unwrap();
+        // Block the rename target with a directory: rename fails, the error
+        // propagates, and the batch stays queued (never half-moved).
+        let qdir = dir.path().join(SPOOL_DIR_NAME).join(QUARANTINE_DIR);
+        std::fs::create_dir(qdir.join("1.json")).unwrap();
+
+        let err = spool.quarantine(1, "409 conflict").unwrap_err();
+        assert_ne!(err.kind(), io::ErrorKind::NotFound);
+        assert_eq!(
+            spool.batch_count(),
+            1,
+            "failed quarantine must not drop the batch"
+        );
+        assert_eq!(spool.quarantine_batch_count(), 0);
+        assert_eq!(spool.total_bytes_used_for_test(), 64);
+    }
+
+    #[test]
+    fn quarantine_with_vanished_source_drops_the_index_entry() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut spool = Spool::open(dir.path()).unwrap();
+        spool
+            .store(&sealed(1, 5), SpoolPriority::Heartbeat)
+            .unwrap();
+        // The payload vanished between oldest() and quarantine(): NotFound
+        // is already-done — drop the entry rather than wedging the drain.
+        std::fs::remove_file(dir.path().join(SPOOL_DIR_NAME).join("1.json")).unwrap();
+        spool.quarantine(1, "409 conflict").unwrap();
         assert_eq!(spool.batch_count(), 0);
         assert_eq!(spool.quarantine_batch_count(), 0);
     }

--- a/cognitod/src/config.rs
+++ b/cognitod/src/config.rs
@@ -218,6 +218,11 @@ pub struct Config {
     pub incidents: IncidentsConfig,
     #[serde(default)]
     pub telemetry: TelemetrySettings,
+    /// Opt-in shipment of evidence batches to the Linnix Cloud edge.
+    /// Disabled by default: with `enabled = false` (or the section absent)
+    /// no cloud code runs and no network traffic occurs.
+    #[serde(default)]
+    pub cloud: CloudConfig,
     /// Top-level sections/keys no field matches. Captured so `--check-config`
     /// can name them; a typo'd `[reasner]` is otherwise indistinguishable from
     /// having configured nothing.
@@ -360,6 +365,11 @@ impl Config {
                 "unrecognised key `{key}` in [incidents] (not read by the daemon)"
             ));
         }
+        for key in config.cloud.unknown.keys() {
+            problems.push(format!(
+                "unrecognised key `{key}` in [cloud] (not read by the daemon)"
+            ));
+        }
         problems.extend(config.telemetry.range_problems());
         problems
     }
@@ -406,6 +416,15 @@ impl Config {
                 "[config] ignoring unrecognised key(s) in [incidents]: {}. \
                  These are not read by the daemon and have no effect — a \
                  typo'd `retention_day` leaves pruning disabled. \
+                 Run `cognitod --check-config` to validate.",
+                keys.join(", ")
+            );
+        }
+        if !self.cloud.unknown.is_empty() {
+            let keys: Vec<&str> = self.cloud.unknown.keys().map(String::as_str).collect();
+            log::warn!(
+                "[config] ignoring unrecognised key(s) in [cloud]: {}. \
+                 These are not read by the daemon and have no effect. \
                  Run `cognitod --check-config` to validate.",
                 keys.join(", ")
             );
@@ -708,6 +727,137 @@ fn default_episode_capture_output_dir() -> String {
     "/var/lib/linnix/episodes".to_string()
 }
 
+/// `[cloud]` — opt-in shipment of evidence batches to the Linnix Cloud edge.
+///
+/// Everything here is inert unless `enabled = true`: with the default
+/// `enabled = false` no cloud code runs and no network traffic occurs.
+/// Enabling requires an `endpoint` and a bearer token; the token should come
+/// from the `LINNIX_CLOUD_TOKEN` environment variable (e.g. populated from a
+/// Kubernetes Secret) rather than the config file, mirroring how
+/// `LINNIX_API_TOKEN` overrides `api.auth_token`. A token placed in the
+/// config file is readable by anyone who can read the file, so keep the
+/// file's permissions tight if you do.
+#[derive(Deserialize, Clone, Default)]
+pub struct CloudConfig {
+    /// Master switch. Default false — cloud export is strictly opt-in.
+    #[serde(default)]
+    pub enabled: bool,
+    /// Edge ingest URL, e.g. `https://ingest.linnix.example/v1/event-batches`.
+    /// No default: it must be explicitly configured. Plain `http://` is
+    /// rejected unless the host is loopback (tests), so a bearer token can
+    /// never be sent in cleartext to a remote host by misconfiguration.
+    #[serde(default)]
+    pub endpoint: Option<String>,
+    /// Opaque cloud organization ID. Required when enabled; the edge also
+    /// derives the tenant from the token and rejects a mismatched body.
+    #[serde(default)]
+    pub tenant_id: Option<String>,
+    /// Stable installation ID for the cluster. Optional: when absent the
+    /// daemon generates one once and persists it — but every node then gets
+    /// its own, so set this explicitly (e.g. via Helm) for real clusters.
+    #[serde(default)]
+    pub cluster_id: Option<String>,
+    /// Stable node identity. Optional override; otherwise `NODE_NAME`, then
+    /// `HOSTNAME`, then the OS hostname — the same order `k8s.rs` uses.
+    /// The first resolved value is persisted, so later renames don't fork
+    /// the node's identity.
+    #[serde(default)]
+    pub node_id: Option<String>,
+    /// Bearer token for the edge. `LINNIX_CLOUD_TOKEN` (env) takes precedence
+    /// when both are set; empty values are ignored.
+    #[serde(default)]
+    pub bearer_token: Option<String>,
+    /// Opt-in to exporting process identity (comm, PIDs, cmdline, cgroup
+    /// paths). Default false: the exporter scrubs those fields and the edge
+    /// never sees them.
+    #[serde(default)]
+    pub export_process_identity: bool,
+    /// Keys present in `[cloud]` that no field matches. Captured rather
+    /// than discarded so `warn_unknown_keys` and `Config::check` can name
+    /// them — the same idiom as `[incidents]`.
+    #[serde(flatten)]
+    pub unknown: std::collections::BTreeMap<String, toml::Value>,
+}
+
+impl CloudConfig {
+    /// True when the exporter may start: explicitly enabled with an endpoint,
+    /// a tenant, and a usable token from either source.
+    pub fn usable(&self, env_token: Option<&str>) -> bool {
+        self.enabled
+            && self
+                .endpoint
+                .as_deref()
+                .is_some_and(|e| !e.trim().is_empty())
+            && self
+                .tenant_id
+                .as_deref()
+                .is_some_and(|t| !t.trim().is_empty())
+            && effective_cloud_token(env_token, self.bearer_token.as_deref()).is_some()
+    }
+
+    /// Refuse cleartext `http://` to non-loopback hosts: the bearer token
+    /// must not travel unencrypted because of a typo'd scheme.
+    pub fn endpoint_allows_plaintext(&self) -> bool {
+        match self.endpoint.as_deref() {
+            Some(url) => {
+                let lower = url.trim_start().to_ascii_lowercase();
+                if lower.starts_with("https://") {
+                    return true;
+                }
+                if lower.starts_with("http://") {
+                    let Some(after_scheme) = lower.strip_prefix("http://") else {
+                        return false;
+                    };
+                    let host = after_scheme.split(['/', '?', '#']).next().unwrap_or("");
+                    let host = host.rsplit('@').next().unwrap_or(host);
+                    // Strip a :port suffix without mangling bracketed IPv6.
+                    if let Some(rest) = host.strip_prefix('[') {
+                        return rest.split(']').next().is_some_and(|ip| ip == "::1");
+                    }
+                    if host.matches(':').count() > 1 {
+                        return host == "::1";
+                    }
+                    let host = host.split(':').next().unwrap_or(host);
+                    return host == "localhost" || host == "127.0.0.1";
+                }
+                false
+            }
+            None => false,
+        }
+    }
+}
+
+/// Resolve the cloud bearer token: `LINNIX_CLOUD_TOKEN` wins over the config
+/// file, mirroring `configured_auth_token` for the API token. Empty values
+/// are treated as absent.
+pub fn effective_cloud_token(
+    env_token: Option<&str>,
+    config_token: Option<&str>,
+) -> Option<String> {
+    env_token
+        .filter(|t| !t.trim().is_empty())
+        .or_else(|| config_token.filter(|t| !t.trim().is_empty()))
+        .map(str::to_string)
+}
+
+impl std::fmt::Debug for CloudConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CloudConfig")
+            .field("enabled", &self.enabled)
+            .field("endpoint", &self.endpoint)
+            .field("tenant_id", &self.tenant_id)
+            .field("cluster_id", &self.cluster_id)
+            .field("node_id", &self.node_id)
+            .field(
+                "bearer_token",
+                &self.bearer_token.as_deref().map(|_| "<redacted>"),
+            )
+            .field("export_process_identity", &self.export_process_identity)
+            .field("unknown", &self.unknown)
+            .finish()
+    }
+}
+
 /// `[incidents]` — incident store retention.
 ///
 /// The incident store would otherwise grow for the lifetime of the daemon.
@@ -885,6 +1035,106 @@ retention_days = 0
 "#;
         let cfg: Config = toml::from_str(toml).unwrap();
         assert_eq!(cfg.incidents.retention_days, Some(0));
+    }
+
+    #[test]
+    fn cloud_is_disabled_by_default() {
+        // Absent means no cloud code runs and no network traffic occurs.
+        let toml = r#"[runtime]
+offline = true
+"#;
+        let cfg: Config = toml::from_str(toml).unwrap();
+        assert!(!cfg.cloud.enabled);
+        assert!(cfg.cloud.endpoint.is_none());
+        assert!(cfg.cloud.tenant_id.is_none());
+        assert!(cfg.cloud.bearer_token.is_none());
+        assert!(!cfg.cloud.export_process_identity);
+        assert!(!cfg.cloud.usable(None));
+    }
+
+    #[test]
+    fn cloud_config_parses() {
+        let toml = r#"[cloud]
+enabled = true
+endpoint = "https://ingest.example/v1/event-batches"
+tenant_id = "tn_123"
+bearer_token = "tok"
+export_process_identity = true
+"#;
+        let cfg: Config = toml::from_str(toml).unwrap();
+        assert!(cfg.cloud.enabled);
+        assert_eq!(
+            cfg.cloud.endpoint.as_deref(),
+            Some("https://ingest.example/v1/event-batches")
+        );
+        assert_eq!(cfg.cloud.tenant_id.as_deref(), Some("tn_123"));
+        assert!(cfg.cloud.usable(None));
+        assert!(cfg.cloud.export_process_identity);
+    }
+
+    #[test]
+    fn cloud_needs_endpoint_tenant_and_token() {
+        let toml = r#"[cloud]
+enabled = true
+"#;
+        let cfg: Config = toml::from_str(toml).unwrap();
+        assert!(!cfg.cloud.usable(None));
+        assert!(!cfg.cloud.usable(Some("tok")));
+    }
+
+    #[test]
+    fn cloud_token_env_beats_config() {
+        assert_eq!(
+            effective_cloud_token(Some("env-tok"), Some("cfg-tok")).as_deref(),
+            Some("env-tok")
+        );
+        assert_eq!(
+            effective_cloud_token(None, Some("cfg-tok")).as_deref(),
+            Some("cfg-tok")
+        );
+        assert_eq!(
+            effective_cloud_token(Some("  "), Some("cfg-tok")).as_deref(),
+            Some("cfg-tok")
+        );
+        assert!(effective_cloud_token(None, None).is_none());
+    }
+
+    #[test]
+    fn cloud_rejects_cleartext_to_remote_hosts() {
+        let allows = |endpoint: Option<&str>| {
+            let cfg = CloudConfig {
+                endpoint: endpoint.map(str::to_string),
+                ..Default::default()
+            };
+            cfg.endpoint_allows_plaintext()
+        };
+        assert!(allows(Some("https://ingest.example/v1")));
+        assert!(allows(Some("http://127.0.0.1:8080/v1")));
+        assert!(allows(Some("http://localhost:8080/v1")));
+        assert!(!allows(Some("http://ingest.example/v1")));
+        assert!(!allows(Some("ftp://ingest.example/v1")));
+        assert!(!allows(None));
+    }
+
+    #[test]
+    fn cloud_bearer_token_is_redacted_in_debug() {
+        let cfg = CloudConfig {
+            bearer_token: Some("super-secret".to_string()),
+            ..Default::default()
+        };
+        let rendered = format!("{cfg:?}");
+        assert!(!rendered.contains("super-secret"));
+        assert!(rendered.contains("<redacted>"));
+    }
+
+    #[test]
+    fn cloud_unknown_keys_are_flagged() {
+        let toml = r#"[cloud]
+enabled = true
+endpooint = "https://ingest.example/v1"
+"#;
+        let cfg: Config = toml::from_str(toml).unwrap();
+        assert!(cfg.cloud.unknown.contains_key("endpooint"));
     }
 
     #[test]

--- a/cognitod/src/config.rs
+++ b/cognitod/src/config.rs
@@ -795,34 +795,43 @@ impl CloudConfig {
             && effective_cloud_token(env_token, self.bearer_token.as_deref()).is_some()
     }
 
-    /// Refuse cleartext `http://` to non-loopback hosts: the bearer token
-    /// must not travel unencrypted because of a typo'd scheme.
+    /// Whether the configured endpoint may be contacted over plaintext HTTP.
+    ///
+    /// This parses with the `url` crate — the same WHATWG URL library
+    /// reqwest uses — so the host we check is exactly the host the request
+    /// goes to. A hand-rolled string parser can be fooled: e.g.
+    /// `http://evil.example\@localhost` looks like `localhost` to naive
+    /// string splitting (the last `@` wins), but WHATWG normalizes the
+    /// backslash to a `/`, making the real host `evil.example` — which
+    /// would send the bearer token over cleartext to a remote host.
+    ///
+    /// Rules: `https` is always allowed; `http` only to `localhost` or a
+    /// loopback IP (`127.0.0.0/8`, `::1`) *without* embedded credentials;
+    /// anything else (parse failure, other schemes, non-loopback hosts) is
+    /// denied.
     pub fn endpoint_allows_plaintext(&self) -> bool {
-        match self.endpoint.as_deref() {
-            Some(url) => {
-                let lower = url.trim_start().to_ascii_lowercase();
-                if lower.starts_with("https://") {
-                    return true;
+        let Some(raw) = self.endpoint.as_deref() else {
+            return false;
+        };
+        let Ok(parsed) = url::Url::parse(raw) else {
+            return false;
+        };
+        match parsed.scheme() {
+            "https" => true,
+            "http" => {
+                // Credentials in the URL are never acceptable: they'd be
+                // sent in cleartext regardless of the host.
+                if !parsed.username().is_empty() || parsed.password().is_some() {
+                    return false;
                 }
-                if lower.starts_with("http://") {
-                    let Some(after_scheme) = lower.strip_prefix("http://") else {
-                        return false;
-                    };
-                    let host = after_scheme.split(['/', '?', '#']).next().unwrap_or("");
-                    let host = host.rsplit('@').next().unwrap_or(host);
-                    // Strip a :port suffix without mangling bracketed IPv6.
-                    if let Some(rest) = host.strip_prefix('[') {
-                        return rest.split(']').next().is_some_and(|ip| ip == "::1");
-                    }
-                    if host.matches(':').count() > 1 {
-                        return host == "::1";
-                    }
-                    let host = host.split(':').next().unwrap_or(host);
-                    return host == "localhost" || host == "127.0.0.1";
+                match parsed.host() {
+                    Some(url::Host::Domain(domain)) => domain.eq_ignore_ascii_case("localhost"),
+                    Some(url::Host::Ipv4(ip)) => ip.is_loopback(),
+                    Some(url::Host::Ipv6(ip)) => ip.is_loopback(),
+                    None => false,
                 }
-                false
             }
-            None => false,
+            _ => false,
         }
     }
 }
@@ -1109,10 +1118,25 @@ enabled = true
             cfg.endpoint_allows_plaintext()
         };
         assert!(allows(Some("https://ingest.example/v1")));
-        assert!(allows(Some("http://127.0.0.1:8080/v1")));
         assert!(allows(Some("http://localhost:8080/v1")));
+        assert!(allows(Some("http://127.0.0.1:8080/v1")));
+        assert!(allows(Some("http://127.0.0.2:8080/v1")));
+        assert!(allows(Some("http://[::1]:8080/v1")));
         assert!(!allows(Some("http://ingest.example/v1")));
         assert!(!allows(Some("ftp://ingest.example/v1")));
+        assert!(!allows(Some("http://localhost.evil.example/")));
+        // The reviewer's bypass: WHATWG normalizes the backslash to `/`,
+        // so the real host is evil.example — naive string splitting sees
+        // "localhost" after the last '@'.
+        assert!(!allows(Some("http://evil.example\\@localhost:8080/v1")));
+        assert!(!allows(Some("http://evil.example@127.0.0.1:8080/v1")));
+        // Credentials in the URL are never acceptable, even on loopback.
+        assert!(!allows(Some("http://user@localhost/")));
+        assert!(!allows(Some("http://user:pass@127.0.0.1/")));
+        // Malformed URLs fail closed.
+        assert!(!allows(Some("http://:8080")));
+        assert!(!allows(Some("not a url")));
+        assert!(!allows(Some("")));
         assert!(!allows(None));
     }
 

--- a/cognitod/src/incidents.rs
+++ b/cognitod/src/incidents.rs
@@ -140,6 +140,29 @@ pub fn retention_cutoff_unix(retention_days: Option<u64>, now_unix: i64) -> Opti
     Some(now_unix.saturating_sub(ttl_secs))
 }
 
+/// Map a full-column incident row onto [`Incident`]. Shared by `since` and
+/// the cloud exporter's watermark-ordered `export_batch`.
+fn incident_from_row(r: sqlx::sqlite::SqliteRow) -> Incident {
+    Incident {
+        id: Some(r.get(0)),
+        timestamp: r.get(1),
+        event_type: r.get(2),
+        psi_cpu: r.get(3),
+        psi_memory: r.get(4),
+        cpu_percent: r.get(5),
+        load_avg: r.get(6),
+        action: r.get(7),
+        target_pid: r.get(8),
+        target_name: r.get(9),
+        system_snapshot: r.get(10),
+        llm_analysis: r.get(11),
+        llm_analyzed_at: r.get(12),
+        recovery_time_ms: r.get(13),
+        psi_after: r.get(14),
+        investigation: r.get(15),
+    }
+}
+
 impl IncidentStore {
     /// Create a new incident store
     pub async fn new<P: AsRef<Path>>(db_path: P) -> Result<Self, sqlx::Error> {
@@ -826,27 +849,37 @@ impl IncidentStore {
             .await?
         };
 
-        Ok(rows
-            .into_iter()
-            .map(|r| Incident {
-                id: Some(r.get(0)),
-                timestamp: r.get(1),
-                event_type: r.get(2),
-                psi_cpu: r.get(3),
-                psi_memory: r.get(4),
-                cpu_percent: r.get(5),
-                load_avg: r.get(6),
-                action: r.get(7),
-                target_pid: r.get(8),
-                target_name: r.get(9),
-                system_snapshot: r.get(10),
-                llm_analysis: r.get(11),
-                llm_analyzed_at: r.get(12),
-                recovery_time_ms: r.get(13),
-                psi_after: r.get(14),
-                investigation: r.get(15),
-            })
-            .collect())
+        Ok(rows.into_iter().map(incident_from_row).collect())
+    }
+
+    /// Watermark-ordered read for the cloud exporter: incidents with
+    /// `id > after_id`, oldest row first, bounded by `limit`. The exporter
+    /// persists the highest seen id, so each incident is exported exactly
+    /// once (modulo crashes between spool and watermark commit, which the
+    /// idempotency key makes harmless).
+    pub async fn export_batch(
+        &self,
+        after_id: i64,
+        limit: i64,
+    ) -> Result<Vec<Incident>, sqlx::Error> {
+        let rows = sqlx::query(
+            r#"
+                SELECT id, timestamp, event_type, psi_cpu, psi_memory, cpu_percent, load_avg,
+                       action, target_pid, target_name, system_snapshot,
+                       llm_analysis, llm_analyzed_at, recovery_time_ms, psi_after,
+                   investigation
+                FROM incidents
+                WHERE id > ?
+                ORDER BY id ASC
+                LIMIT ?
+            "#,
+        )
+        .bind(after_id)
+        .bind(limit)
+        .fetch_all(&self.pool)
+        .await?;
+
+        Ok(rows.into_iter().map(incident_from_row).collect())
     }
 
     /// Get statistics about incidents

--- a/cognitod/src/lib.rs
+++ b/cognitod/src/lib.rs
@@ -5,6 +5,7 @@ pub mod alerts;
 pub mod attribution;
 pub mod bpf_config;
 pub mod cell;
+pub mod cloud;
 pub mod collectors;
 pub mod config;
 pub mod context;

--- a/configs/linnix.darwin.toml
+++ b/configs/linnix.darwin.toml
@@ -48,3 +48,30 @@ sustained_seconds = 15
 # this are pruned once a day (and once shortly after startup). 0 or unset
 # disables pruning and keeps incidents forever.
 retention_days = 30
+
+[cloud]
+# Opt-in shipment of evidence batches to the Linnix Cloud edge (v1 event
+# schema). Disabled by default: with `enabled = false` (or the section
+# absent) no cloud task starts and no network traffic occurs.
+enabled = false
+# Edge ingest URL. Required when enabled. Plain http:// is rejected for
+# non-loopback hosts so the bearer token never travels unencrypted.
+# endpoint = "https://ingest.example.com/v1/event-batches"
+# Opaque cloud organization/tenant ID. Required when enabled; the edge also
+# derives the tenant from the token and rejects a mismatched body.
+# tenant_id = "tn_123"
+# Stable cluster identity. Optional: when unset the daemon generates one and
+# persists it, but every node then gets its own — set this explicitly (e.g.
+# via Helm) for real clusters.
+# cluster_id = "prod-eu-west"
+# Stable node identity. Optional override; otherwise NODE_NAME, then
+# HOSTNAME, then the OS hostname. The first resolved value is persisted, so
+# later renames don't fork the node's identity.
+# node_id = "node-42"
+# Bearer token for the edge. Prefer the LINNIX_CLOUD_TOKEN environment
+# variable over writing it into this file; the env var wins when both are set.
+# bearer_token = "..."
+# Export process identity (comm, PIDs, cmdline, executable and cgroup paths)
+# inside detection details. Default false: those fields are scrubbed and the
+# edge never sees them. Secrets and environment blocks are always scrubbed.
+# export_process_identity = false

--- a/configs/linnix.toml
+++ b/configs/linnix.toml
@@ -68,3 +68,30 @@ attribution_cooldown_seconds = 300
 # this are pruned once a day (and once shortly after startup). 0 or unset
 # disables pruning and keeps incidents forever.
 retention_days = 30
+
+[cloud]
+# Opt-in shipment of evidence batches to the Linnix Cloud edge (v1 event
+# schema). Disabled by default: with `enabled = false` (or the section
+# absent) no cloud task starts and no network traffic occurs.
+enabled = false
+# Edge ingest URL. Required when enabled. Plain http:// is rejected for
+# non-loopback hosts so the bearer token never travels unencrypted.
+# endpoint = "https://ingest.example.com/v1/event-batches"
+# Opaque cloud organization/tenant ID. Required when enabled; the edge also
+# derives the tenant from the token and rejects a mismatched body.
+# tenant_id = "tn_123"
+# Stable cluster identity. Optional: when unset the daemon generates one and
+# persists it, but every node then gets its own — set this explicitly (e.g.
+# via Helm) for real clusters.
+# cluster_id = "prod-eu-west"
+# Stable node identity. Optional override; otherwise NODE_NAME, then
+# HOSTNAME, then the OS hostname. The first resolved value is persisted, so
+# later renames don't fork the node's identity.
+# node_id = "node-42"
+# Bearer token for the edge. Prefer the LINNIX_CLOUD_TOKEN environment
+# variable over writing it into this file; the env var wins when both are set.
+# bearer_token = "..."
+# Export process identity (comm, PIDs, cmdline, executable and cgroup paths)
+# inside detection details. Default false: those fields are scrubbed and the
+# edge never sees them. Secrets and environment blocks are always scrubbed.
+# export_process_identity = false

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -56,6 +56,34 @@ Linnix mounts:
 - `/sys/kernel/debug`: For debugfs (tracepoints).
 - `hostPID: true`: To correlate events with host processes.
 
+### State & Identity
+
+The DaemonSet mounts a `hostPath` volume at `/var/lib/linnix` and injects
+`NODE_NAME` from the downward API (`spec.nodeName`). Both are required for
+the agent's identity to survive pod restarts:
+
+- **Durable state**: `/var/lib/linnix` holds `incidents.db`, the cloud
+  exporter's `cloud_identity.json` (agent instance ID, batch sequence,
+  export watermark), and the `cloud_spool/` batch queue. Without the
+  hostPath mount, every pod restart would mint a new agent instance ID,
+  reset the batch sequence to 0, drop queued-but-unsent batches, and
+  re-export already-sent incidents — breaking the edge's gap detector and
+  batch idempotency keys.
+- **Stable node name**: the agent resolves its node ID as
+  `NODE_NAME` → `HOSTNAME` → OS hostname and persists the first value it
+  sees. `HOSTNAME` inside a pod is the pod name, which changes on every
+  restart; `spec.nodeName` is the actual Kubernetes node name and is
+  stable, so the persisted identity stays bound to the node.
+
+`hostPath` is the simplest correct choice for a DaemonSet: exactly one pod
+runs per node, so node-local storage is the right scope — no PVCs or
+storage classes needed. `DirectoryOrCreate` provisions the directory on
+fresh nodes automatically. Note the agent runs privileged and stores its
+operational state here; treat host access to `/var/lib/linnix` like host
+disk access generally. If you override the incident DB location with
+`LINNIX_INCIDENT_DB`, point the mount at that path's parent directory
+instead.
+
 ## Cloud Provider Notes
 
 ### AWS EKS

--- a/k8s/configmap.yaml
+++ b/k8s/configmap.yaml
@@ -47,3 +47,30 @@ data:
     # Days of incident history to retain; older rows are pruned once a day.
     # 0 (or the whole section absent) disables pruning entirely.
     retention_days = 30
+
+    [cloud]
+    # Opt-in shipment of evidence batches to the Linnix Cloud edge (v1 event
+    # schema). Disabled by default: with `enabled = false` (or the section
+    # absent) no cloud task starts and no network traffic occurs.
+    enabled = false
+    # Edge ingest URL. Required when enabled. Plain http:// is rejected for
+    # non-loopback hosts so the bearer token never travels unencrypted.
+    # endpoint = "https://ingest.example.com/v1/event-batches"
+    # Opaque cloud organization/tenant ID. Required when enabled; the edge
+    # also derives the tenant from the token and rejects a mismatched body.
+    # tenant_id = "tn_123"
+    # Stable cluster identity. Optional: when unset the daemon generates one
+    # and persists it, but every node then gets its own — set this explicitly
+    # (e.g. via Helm values) for real clusters.
+    # cluster_id = "prod-eu-west"
+    # Stable node identity. Optional override; otherwise NODE_NAME, then
+    # HOSTNAME, then the OS hostname. The first resolved value is persisted.
+    # node_id = "node-42"
+    # Bearer token for the edge. Prefer the LINNIX_CLOUD_TOKEN environment
+    # variable over writing it into this file; the env var wins when set.
+    # bearer_token = "..."
+    # Export process identity (comm, PIDs, cmdline, executable and cgroup
+    # paths) inside detection details. Default false: those fields are
+    # scrubbed and the edge never sees them. Secrets and environment blocks
+    # are always scrubbed.
+    # export_process_identity = false

--- a/k8s/daemonset.yaml
+++ b/k8s/daemonset.yaml
@@ -43,6 +43,15 @@ spec:
                 secretKeyRef:
                   name: linnix-api-token
                   key: token
+            # Downward API: the node's name. The agent prefers NODE_NAME over
+            # HOSTNAME when resolving its identity, so the persisted
+            # cloud_identity.json (and its batch sequence / export watermark)
+            # stays bound to the *node* across pod restarts instead of
+            # following the pod's hostname.
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
           volumeMounts:
             - name: config
               mountPath: /etc/linnix
@@ -52,6 +61,15 @@ spec:
               readOnly: true
             - name: debugfs
               mountPath: /sys/kernel/debug
+            # Durable per-node state: the incident DB, cloud_identity.json
+            # (agent instance ID, batch sequence, export watermark) and the
+            # cloud_spool/ batch queue all live under /var/lib/linnix (the
+            # daemon's default state dir; see LINNIX_INCIDENT_DB). Without
+            # this, every pod restart mints a new agent_instance_id, resets
+            # the batch sequence, and drops queued batches — breaking the
+            # edge's gap detector and idempotency keys.
+            - name: state
+              mountPath: /var/lib/linnix
             # Mount host /proc to monitor processes
             # Note: In container, this might be mounted at /host/proc if configured,
             # but standard hostPID: true makes /proc the host's /proc?
@@ -101,3 +119,14 @@ spec:
           hostPath:
             path: /sys/kernel/debug
             type: Directory
+        # hostPath is the simplest correct choice for a DaemonSet: one pod
+        # per node, so node-local storage is exactly the right scope — no
+        # PVC provisioning or storage class needed. DirectoryOrCreate so a
+        # fresh node comes up without manual provisioning. Security note:
+        # the agent runs privileged and writes its DB/spool here; restrict
+        # host access to /var/lib/linnix to the same administrators who can
+        # already read the node's disk.
+        - name: state
+          hostPath:
+            path: /var/lib/linnix
+            type: DirectoryOrCreate


### PR DESCRIPTION
Part 1 of 2 of the agent-side Linnix Cloud exporter ("close the hosted loop" milestone). Nothing here runs yet — no sender, no background task, no network. Part 2 (stacked) adds the sender, the export loop, and the daemon wiring.

## In scope

- `[cloud]` config (`cognitod/src/config.rs`): `enabled` (default false), `endpoint`, `tenant_id`, `cluster_id`/`node_id` overrides, `bearer_token`, `export_process_identity` (default false). Unknown keys are flagged like `[incidents]`; `LINNIX_CLOUD_TOKEN` wins over the config file; remote plain-`http://` endpoints are rejected (loopback allowed for tests).
- v1 event-schema wire types (`cloud/model.rs`): envelope, heartbeat, detection, degradation state. All six local incident types map; `cpu_starvation`/`blkio_stall`/`cgroup_pressure`/`oom_kill` are emitted as-is, a **proposed minor `detection_type` enum extension** (schema §11: store unknown values, do not coerce). `pressure_sample` is **omitted in v1** (permitted until the agent reads avg60/avg300 and cumulative PSI totals).
- Stable identity next to the incident DB (`cloud/identity.rs`): `cluster_id`, `node_id`, UUID-v4 `agent_instance_id`, monotonic batch sequence, row-ID export watermark. Corrupt identity files fail loudly rather than minting a new identity. Note: without an explicit `cluster_id`, each node generates its own — operators must set it for real clusters (documented in the shipped configs).
- Privacy scrubber (`cloud/scrub.rs`): secrets/env/auth material always removed; comm, PID/TID/PPID, cmdline, executable and raw cgroup paths removed unless `export_process_identity = true`.
- Batch sealer (`cloud/seal.rs`): 500 events / 1 MiB uncompressed / 5 s / quality transition; qualities never mixed. Sealed bytes are immutable from here on.
- On-disk spool (`cloud/spool.rs`): batch bytes + SHA-256, temp-write/rename manifest, 256 MiB / 24 h caps, drop oldest low-priority first, **never drop degradation_state**; drops counted for the heartbeat.
- `IncidentStore::export_batch`: watermark-ordered `id > ?` read, no schema change.
- Shipped configs (`configs/linnix.toml`, `configs/linnix.darwin.toml`, `k8s/configmap.yaml`) document `[cloud]` disabled by default.

## Out of scope (part 2)

Sender, export loop, heartbeat/degradation emission, daemon wiring.

## Validation

- `cargo test -p cognitod --lib` (295 tests on this branch, incl. 22 new cloud tests)
- `cargo test -p linnix-cli`
- `cargo +nightly fmt --all -- --check`
- `cargo clippy -p cognitod --all-targets -- -D warnings`
- `cargo clippy -p linnix-cli --all-targets -- -D warnings`

**Do not merge** — stacked PR follows.

## Review follow-ups (addressed)

- **Scrub TGIDs**: `tgid` added to the process-identity blocklist (cpu_starvation snapshots expose it on the subject and every `top_waiters` entry).
- **Byte-cap enforcement**: `BatchSealer::push` replaced by `try_push`, which checks the prospective serialized size *before* appending — a sealed batch can never exceed the 1 MiB cap. An individually oversized event is **dropped with a warning and counted** in the dropped-events total (policy choice: the edge would quarantine an oversized batch anyway, so one pathological snapshot must not wedge the pipeline; the watermark advances past it deliberately so it can't loop forever).
- **Bounded quarantine**: quarantined bytes count toward the shared 256 MiB cap; quarantined batches get 24h age eviction, oldest-first, with a diagnostic log. Spool batches are evicted before quarantined ones; a batch is never deleted without its `.note`.
- **Corrupt spool manifest**: rebuilds from verified `{sequence}.json` payloads on disk (skip-and-note to quarantine on verification failure) instead of silently opening empty.
- **`circuit_breaker_*` variants** normalize to the schema's `circuit_breaker` detection_type.

Validation after fixes: 305/305 `cognitod` lib tests, CLI tests, fmt, clippy clean (both packages).


## Review follow-ups, round 2 (addressed)

All 8 findings from the second review pass are fixed in `3c40350` (#117 rebased accordingly in `49e87b9`):

1. **BatchFull hands the event back** (`seal.rs`): `PushOutcome::BatchFull` now carries `Box<Event>` — #116 is correct standalone instead of relying on #117 to repair its public API. Tests: the refused event is returned at count and byte boundaries and retries exactly once into a fresh sealer.
2. **Exact byte accounting** (`seal.rs`): the 512-byte `ENVELOPE_OVERHEAD` fudge is gone. The sealer is constructed with the identity fields (`SealIdentity`) and precomputes the exact serialized envelope size from a zero-event template (sequence rendered as `u64::MAX`, a safe-direction overestimate of ≤38 bytes; commas and JSON escaping fully accounted for). `seal()` has a `debug_assert` backstop that sealed bytes never exceed the cap. Tests: a 500-event batch with UUID-length identities seals under the cap; a ~100 KiB-event batch fills to within one event of the boundary (proving the accounting is exact, not just conservative); the reviewer's long-identity failure shape is covered.
3. **Plaintext bypass closed** (`config.rs`): `endpoint_allows_plaintext` now parses with the `url` crate (the same WHATWG library reqwest uses) instead of hand-rolled string splitting. `http` is allowed only to `localhost`/loopback (`127.0.0.0/8`, `::1`) with no embedded credentials; everything else (parse failure, other schemes, non-loopback hosts) fails closed. Regression tests include the reviewer's `http://evil.example\@localhost:8080/v1` bypass plus userinfo, IPv6, trailing-dot, and malformed cases.
4. **K8s DaemonSet preserves state** (`k8s/daemonset.yaml`, `k8s/README.md`): `NODE_NAME` injected from the downward API (`spec.nodeName`), and a `hostPath` volume mounts durable per-node storage at `/var/lib/linnix` — the daemon's actual default state dir (incident DB, `cloud_identity.json`, `cloud_spool/`). The README documents why both are needed (identity stability, sequence/watermark/spool survival, idempotency-key uniqueness) and the hostPath security notes.
5. **Manifest reconciled against disk on every open** (`spool.rs`): `Spool::open` scans `{sequence}.json` files after loading a valid manifest — orphaned payloads (the crash window: payload synced, manifest never persisted) are verified and re-admitted; drifted entries are repaired from disk or quarantined with a note; missing entries are dropped. The reconciled manifest is persisted.
6. **Caps enforced during recovery** (`spool.rs`): `open()` calls `enforce_caps()` before returning, so over-age/over-size state recovered from disk is evicted rather than served to the sender.
7. **Filesystem errors propagate** (`spool.rs`): `remove_file`/`rename`/note-write sites no longer swallow errors — `NotFound` is treated as already-done (idempotent), anything else aborts the operation with the index and accounting untouched. The #117 exporter logs spool errors in its drain loop instead of discarding them. Tests inject failures via path collisions (a directory where a file is expected — works even as root) and assert the index stays consistent with disk.
8. **Power-loss durability** (`spool.rs`, `identity.rs`, `cloud/mod.rs`): new `persist_durable` helper — tmp file, `sync_all`, atomic rename, parent-directory fsync — used for `cloud_identity.json`, `spool.json`, and quarantine notes; payload creation also fsyncs the spool directory. Doc comments state the actual guarantee (process crash + host/power loss on filesystems that honor sync).

Validation after fixes: 318/318 `cognitod` lib tests (45 cloud tests, incl. 14 new), CLI tests, fmt, clippy clean (both packages).
