### PR TITLE
Cloud exporter: sender, export loop, daemon wiring

### DIFF
--- a/cognitod/src/cloud/exporter.rs
+++ b/cognitod/src/cloud/exporter.rs
@@ -29,7 +29,7 @@ use super::model::{
     TimeRange, Transport, detection_type_for, rfc3339,
 };
 use super::scrub::{ScrubPolicy, scrub_snapshot};
-use super::seal::{BatchSealer, SealContext, SealedBatch};
+use super::seal::{BatchSealer, PushOutcome, SealContext, SealIdentity, SealedBatch};
 use super::sender::{SendDecision, Sender, backoff_delay};
 use super::spool::{Spool, SpoolPriority};
 use super::{EXPORT_PULL_LIMIT, HEARTBEAT_INTERVAL_SECS, SEAL_INTERVAL_SECS};
@@ -85,6 +85,26 @@ pub fn spawn_exporter(
     })
 }
 
+/// Build a batch sealer bound to the exporter's identity. The sealer needs
+/// the identity fields at construction time for its exact prospective
+/// envelope-size accounting — it must see the same strings that
+/// [`SealContext`] will carry at seal time.
+fn new_sealer(
+    quality: AttributionQuality,
+    tenant_id: &str,
+    identity: &IdentityStore,
+) -> BatchSealer {
+    BatchSealer::new(
+        quality,
+        SealIdentity {
+            tenant_id: tenant_id.to_string(),
+            cluster_id: identity.cluster_id().to_string(),
+            node_id: identity.node_id().to_string(),
+            agent_instance_id: identity.agent_instance_id().to_string(),
+        },
+    )
+}
+
 pub struct Exporter {
     config: ExporterConfig,
     identity: IdentityStore,
@@ -103,10 +123,14 @@ pub struct Exporter {
     blame: Arc<BlameMetrics>,
     start: Instant,
     state_since: String,
-    heartbeat_count: u64,
     last_heartbeat: Instant,
     consecutive_failures: u32,
     last_evictions: u64,
+    /// Events deliberately dropped as individually oversized (the edge
+    /// would quarantine an oversized batch, so one pathological snapshot
+    /// must not wedge the pipeline). Counted in the heartbeat's dropped
+    /// total; the watermark advances past them on purpose.
+    oversize_dropped: u64,
     policy: ScrubPolicy,
     backoff: fn(u32) -> Duration,
 }
@@ -130,29 +154,32 @@ impl Exporter {
         let policy = ScrubPolicy::from_opt_in(config.export_process_identity);
         let watermark = identity.export_watermark();
         let last_evictions = blame.evictions();
+        let sealer = new_sealer(quality, &config.tenant_id, &identity);
         let mut exporter = Self {
             config,
             identity,
             spool,
             sender,
-            sealer: BatchSealer::new(quality),
+            sealer,
             pushed_watermark: watermark,
             pending_priority: SpoolPriority::Heartbeat,
             store,
             blame,
             start: Instant::now(),
             state_since: rfc3339(Utc::now().timestamp()),
-            heartbeat_count: 0,
             last_heartbeat: Instant::now() - Duration::from_secs(HEARTBEAT_INTERVAL_SECS),
             consecutive_failures: 0,
             last_evictions,
+            oversize_dropped: 0,
             policy,
             backoff: backoff_delay,
         };
         // The first batch always opens with the current degradation state so
         // the edge learns the quality before the first heartbeat arrives.
         let degradation = exporter.degradation_event();
-        exporter.push_event(degradation, SpoolPriority::DegradationState);
+        exporter
+            .push_event(degradation, SpoolPriority::DegradationState)
+            .await;
         info!(
             "[cloud] exporter initialized (node {}, cluster {}, quality {:?})",
             exporter.identity.node_id(),
@@ -169,9 +196,10 @@ impl Exporter {
         let quality = self.config.quality.quality();
         if quality != self.sealer.quality() {
             self.seal_and_spool().await;
-            self.sealer = BatchSealer::new(quality);
+            self.sealer = new_sealer(quality, &self.config.tenant_id, &self.identity);
             let degradation = self.degradation_event();
-            self.push_event(degradation, SpoolPriority::DegradationState);
+            self.push_event(degradation, SpoolPriority::DegradationState)
+                .await;
             info!("[cloud] attribution quality changed to {quality:?}; emitted degradation_state");
         }
 
@@ -182,25 +210,39 @@ impl Exporter {
         {
             Ok(incidents) => {
                 for incident in &incidents {
+                    let buffered = match self.detection_event(incident) {
+                        Some(event) => self.push_event(event, SpoolPriority::Detection).await,
+                        None => {
+                            debug!(
+                                "[cloud] skipping incident {:?} (unmapped type {:?})",
+                                incident.id, incident.event_type
+                            );
+                            // Deliberate skip: don't re-pull it forever.
+                            true
+                        }
+                    };
+                    if !buffered {
+                        // The batch is full and the spool is failing: stop
+                        // the pull with the watermark behind this incident so
+                        // it's retried next tick instead of being skipped.
+                        warn!(
+                            "[cloud] could not buffer incident {:?}; pausing pull until the spool recovers",
+                            incident.id
+                        );
+                        break;
+                    }
                     if let Some(id) = incident.id {
                         self.pushed_watermark = self.pushed_watermark.max(id);
-                    }
-                    match self.detection_event(incident) {
-                        Some(event) => self.push_event(event, SpoolPriority::Detection),
-                        None => debug!(
-                            "[cloud] skipping incident {:?} (unmapped type {:?})",
-                            incident.id, incident.event_type
-                        ),
                     }
                 }
             }
             Err(e) => warn!("[cloud] incident pull failed: {e}; will retry next tick"),
         }
 
-        if self.last_heartbeat.elapsed() >= Duration::from_secs(HEARTBEAT_INTERVAL_SECS) {
-            self.heartbeat_count += 1;
-            let heartbeat = self.heartbeat_event();
-            self.push_event(heartbeat, SpoolPriority::Heartbeat);
+        if self.last_heartbeat.elapsed() >= Duration::from_secs(HEARTBEAT_INTERVAL_SECS)
+            && let Some(heartbeat) = self.heartbeat_event()
+        {
+            self.push_event(heartbeat, SpoolPriority::Heartbeat).await;
             self.last_heartbeat = Instant::now();
         }
 
@@ -220,13 +262,55 @@ impl Exporter {
         }
     }
 
-    fn push_event(&mut self, event: Event, priority: SpoolPriority) {
-        self.pending_priority = self.pending_priority.min(priority);
-        self.sealer.push(event);
+    /// Buffer an event, sealing the current batch first when the next
+    /// event wouldn't fit. Returns `true` when the event was buffered or
+    /// deliberately dropped (oversize); `false` when the batch is full and
+    /// the spool is failing, in which case the caller must NOT advance the
+    /// watermark past the event.
+    async fn push_event(&mut self, event: Event, priority: SpoolPriority) -> bool {
+        match self.sealer.try_push(event) {
+            PushOutcome::Accepted => {
+                self.pending_priority = self.pending_priority.min(priority);
+                true
+            }
+            PushOutcome::BatchFull(event) => {
+                // Mid-pull seal: make the full batch durable, then buffer
+                // into a fresh batch and continue.
+                let was_empty = self.sealer.is_empty();
+                self.seal_and_spool().await;
+                if !was_empty && !self.sealer.is_empty() {
+                    // seal_and_spool failed and the buffer is still full.
+                    return false;
+                }
+                match self.sealer.try_push(*event) {
+                    PushOutcome::Accepted => {
+                        self.pending_priority = self.pending_priority.min(priority);
+                        true
+                    }
+                    // try_push filters oversize before the BatchFull check,
+                    // so a drained sealer always accepts — this is a bug.
+                    other => {
+                        error!("[cloud] event rejected by fresh sealer ({other:?}); dropping");
+                        self.oversize_dropped = self.oversize_dropped.saturating_add(1);
+                        true
+                    }
+                }
+            }
+            PushOutcome::DroppedOversize { bytes } => {
+                // Deliberate: the edge would quarantine an oversized batch,
+                // so one pathological snapshot must not wedge the pipeline.
+                // The watermark advances past it on purpose.
+                warn!("[cloud] dropping oversized event ({bytes} bytes > batch cap)");
+                self.oversize_dropped = self.oversize_dropped.saturating_add(1);
+                true
+            }
+        }
     }
 
-    /// Seal the buffered events and spool the batch. The watermark advances
-    /// only after the batch is durable on disk.
+    /// Seal the buffered events and spool the batch. The buffer is cleared
+    /// and the watermark advances only after the batch is durable on disk —
+    /// a failed spool leaves the events buffered for retry, so a later
+    /// successful batch can never advance the watermark past them.
     async fn seal_and_spool(&mut self) {
         if self.sealer.is_empty() {
             return;
@@ -250,12 +334,15 @@ impl Exporter {
         let priority = self.pending_priority;
         match self.spool.store(&batch, priority) {
             Ok(()) => {
+                self.sealer.clear();
                 if let Err(e) = self.identity.set_export_watermark(self.pushed_watermark) {
                     error!("[cloud] spooled batch {sequence} but failed to persist watermark: {e}");
                 }
                 self.pending_priority = SpoolPriority::Heartbeat;
             }
-            Err(e) => error!("[cloud] spool store failed for batch {sequence}: {e}"),
+            Err(e) => error!(
+                "[cloud] spool store failed for batch {sequence}: {e}; events stay buffered for retry"
+            ),
         }
     }
 
@@ -268,17 +355,32 @@ impl Exporter {
                 Ok(b) => b,
                 Err(e) => {
                     warn!("[cloud] spooled batch {sequence} unreadable ({e}); dropping");
-                    let _ = self.spool.remove(sequence);
+                    if let Err(remove_err) = self.spool.remove(sequence) {
+                        error!(
+                            "[cloud] failed to remove unreadable batch {sequence}: {remove_err}; \
+                             will retry next drain"
+                        );
+                    }
                     continue;
                 }
             };
             match self.sender.post_batch(&bytes).await {
                 SendDecision::Acked => {
-                    let _ = self.spool.remove(sequence);
+                    if let Err(e) = self.spool.remove(sequence) {
+                        error!(
+                            "[cloud] edge acked batch {sequence} but spool removal failed: {e}; \
+                             will retry the ack next drain"
+                        );
+                    }
                     self.consecutive_failures = 0;
                 }
                 SendDecision::Quarantine { reason } => {
-                    let _ = self.spool.quarantine(sequence, &reason);
+                    if let Err(e) = self.spool.quarantine(sequence, &reason) {
+                        error!(
+                            "[cloud] failed to quarantine refused batch {sequence}: {e}; \
+                             will retry next drain"
+                        );
+                    }
                     self.consecutive_failures = 0;
                 }
                 SendDecision::Retry { retry_after } => {
@@ -295,16 +397,28 @@ impl Exporter {
         }
     }
 
-    fn heartbeat_event(&mut self) -> Event {
-        let n = self.heartbeat_count;
+    fn heartbeat_event(&mut self) -> Option<Event> {
+        // The idempotency key must never repeat with a different body —
+        // including across daemon restarts, where in-memory counters reset.
+        // The counter is persisted in the identity file for exactly this.
+        let n = match self.identity.next_heartbeat_seq() {
+            Ok(n) => n,
+            Err(e) => {
+                error!(
+                    "[cloud] cannot persist heartbeat sequence: {e}; skipping heartbeat this tick"
+                );
+                return None;
+            }
+        };
         let node_id = self.identity.node_id();
+        let instance = self.identity.agent_instance_id();
         let quality = self.sealer.quality();
         let evicted_total = self.blame.evictions();
         let evicted_delta = evicted_total.saturating_sub(self.last_evictions);
         self.last_evictions = evicted_total;
-        Event {
+        Some(Event {
             event_id: format!("hb-{node_id}-{n}"),
-            event_idempotency_key: format!("e:hb:{node_id}:{n}"),
+            event_idempotency_key: format!("e:hb:{instance}:{n}"),
             event_type: EventType::Heartbeat,
             occurred_at: rfc3339(Utc::now().timestamp()),
             detail_level: DetailLevel::Summary,
@@ -323,7 +437,10 @@ impl Exporter {
                 btf_available: self.config.quality.btf_available,
                 active_node: true,
                 events_buffered: self.spool.pending_events(),
-                events_dropped_total: self.spool.dropped_total(),
+                events_dropped_total: self
+                    .spool
+                    .dropped_total()
+                    .saturating_add(self.oversize_dropped),
                 blame_series_active: self
                     .blame
                     .victim_series()
@@ -332,7 +449,7 @@ impl Exporter {
                 blame_series_evicted_total: evicted_total,
                 blame_series_evicted_delta: evicted_delta,
             }),
-        }
+        })
     }
 
     fn degradation_event(&self) -> Event {
@@ -481,13 +598,11 @@ mod tests {
         dir: tempfile::TempDir,
     }
 
-    async fn harness(endpoint: &str) -> TestHarness {
-        let dir = tempfile::tempdir().unwrap();
-        let store = Arc::new(
-            IncidentStore::new(dir.path().join("incidents.db"))
-                .await
-                .unwrap(),
-        );
+    async fn build_exporter(
+        state_dir: &std::path::Path,
+        endpoint: &str,
+        store: Arc<IncidentStore>,
+    ) -> Exporter {
         let blame = Arc::new(BlameMetrics::new("test-node"));
         let config = ExporterConfig {
             endpoint: endpoint.to_string(),
@@ -496,16 +611,27 @@ mod tests {
             cluster_id_override: Some("clu_test".to_string()),
             node_id_override: Some("node_test".to_string()),
             export_process_identity: false,
-            state_dir: dir.path().to_path_buf(),
+            state_dir: state_dir.to_path_buf(),
             quality: QualitySnapshot {
                 transport: "userspace".to_string(),
                 btf_available: false,
                 rss_probe: "unavailable".to_string(),
             },
         };
-        let mut exporter = Exporter::new(config, store.clone(), blame).await.unwrap();
+        let mut exporter = Exporter::new(config, store, blame).await.unwrap();
         // Keep retry-path tests fast; production uses exponential backoff.
         exporter.backoff = |_| Duration::from_millis(1);
+        exporter
+    }
+
+    async fn harness(endpoint: &str) -> TestHarness {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Arc::new(
+            IncidentStore::new(dir.path().join("incidents.db"))
+                .await
+                .unwrap(),
+        );
+        let exporter = build_exporter(dir.path(), endpoint, store.clone()).await;
         TestHarness {
             exporter,
             store,
@@ -532,6 +658,10 @@ mod tests {
             ("cgroup_pressure", "cgroup_pressure"),
             ("oom_kill", "oom_kill"),
             ("circuit_breaker", "circuit_breaker"),
+            // Recorded circuit-breaker variants normalize instead of
+            // skipping (their rows still advance the watermark).
+            ("circuit_breaker_cpu", "circuit_breaker"),
+            ("circuit_breaker_memory", "circuit_breaker"),
         ];
         for (local, cloud) in cases {
             let incident = sample_incident(
@@ -606,6 +736,145 @@ mod tests {
         // The next tick pulls nothing new — no duplicate events buffered.
         exporter.tick().await;
         assert_eq!(exporter.pushed_watermark, 2);
+    }
+
+    #[tokio::test]
+    async fn oversized_pull_seals_mid_tick_without_watermark_loss() {
+        let h = harness("http://127.0.0.1:9/unused").await;
+        for _ in 0..600 {
+            h.store
+                .insert(&sample_incident(None, "fork_storm", None))
+                .await
+                .unwrap();
+        }
+        let mut exporter = h.exporter;
+        // Tick 1 pulls 500 rows (EXPORT_PULL_LIMIT). The sealer already
+        // holds the startup degradation event, so the 500th detection
+        // doesn't fit: the batch seals mid-pull and the pull continues
+        // into a fresh batch.
+        exporter.tick().await;
+        assert_eq!(exporter.spool.batch_count(), 1);
+        // The mid-pull seal persisted the watermark for the 499 incidents
+        // in the sealed batch; the 500th is buffered but not yet sealed.
+        assert_eq!(exporter.identity.export_watermark(), 499);
+        assert_eq!(exporter.pushed_watermark, 500);
+
+        // Tick 2 pulls the remaining 100 rows. (Tick 1's drain backoff
+        // sleeps 5s, so the time-based seal fires here too — the point is
+        // the watermark accounting, not which tick sealed.)
+        exporter.tick().await;
+        assert_eq!(exporter.pushed_watermark, 600);
+        exporter.seal_and_spool().await; // no-op if tick 2 already sealed
+        assert_eq!(exporter.spool.batch_count(), 2);
+        assert_eq!(exporter.identity.export_watermark(), 600);
+
+        // All 600 detections made it into exactly two batches, in order,
+        // with no gaps and no duplicates.
+        let mut detection_ids: Vec<i64> = Vec::new();
+        let mut batch_sizes = Vec::new();
+        for seq in [0, 1] {
+            let bytes = exporter.spool.read(seq as u64).unwrap();
+            let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+            let events = v["events"].as_array().unwrap();
+            batch_sizes.push(events.len());
+            for e in events {
+                if e["event_type"] == "detection" {
+                    let id: i64 = e["event_id"]
+                        .as_str()
+                        .unwrap()
+                        .strip_prefix("incident-")
+                        .unwrap()
+                        .parse()
+                        .unwrap();
+                    detection_ids.push(id);
+                }
+            }
+        }
+        assert_eq!(batch_sizes, [500, 102]); // degradation + 499 detections, then 101 detections + heartbeat
+        detection_ids.sort_unstable();
+        assert_eq!(detection_ids, (1..=600).collect::<Vec<_>>());
+        // The next tick pulls nothing new.
+        exporter.tick().await;
+        assert_eq!(exporter.pushed_watermark, 600);
+    }
+
+    #[tokio::test]
+    async fn failed_spool_store_preserves_events_for_retry() {
+        let h = harness("http://127.0.0.1:9/unused").await;
+        h.store
+            .insert(&sample_incident(None, "fork_storm", None))
+            .await
+            .unwrap();
+        h.store
+            .insert(&sample_incident(None, "oom_kill", None))
+            .await
+            .unwrap();
+        let mut exporter = h.exporter;
+        exporter.tick().await;
+        assert_eq!(exporter.pushed_watermark, 2);
+
+        // Sabotage the next spool store: the batch file for sequence 0
+        // already exists, so create_new fails (disk-full/permission
+        // failures behave the same — store returns Err).
+        let spool_dir = h.dir.path().join(super::super::spool::SPOOL_DIR_NAME);
+        std::fs::write(spool_dir.join("0.json"), b"sabotage").unwrap();
+        exporter.seal_and_spool().await;
+        // The events are still buffered — not lost — and the watermark did
+        // not advance past them.
+        assert!(!exporter.sealer.is_empty());
+        assert_eq!(exporter.spool.batch_count(), 0);
+        assert_eq!(exporter.identity.export_watermark(), 0);
+
+        // Remove the sabotage: the retry spools everything (on the next
+        // sequence — claimed sequences are never reused), the watermark
+        // advances, and no incident is skipped or duplicated.
+        std::fs::remove_file(spool_dir.join("0.json")).unwrap();
+        exporter.seal_and_spool().await;
+        assert!(exporter.sealer.is_empty());
+        assert_eq!(exporter.spool.batch_count(), 1);
+        assert_eq!(exporter.identity.export_watermark(), 2);
+        let bytes = exporter.spool.read(1).unwrap();
+        let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        let detections = v["events"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter(|e| e["event_type"] == "detection")
+            .count();
+        assert_eq!(detections, 2);
+        exporter.tick().await;
+        assert_eq!(exporter.pushed_watermark, 2);
+    }
+
+    #[tokio::test]
+    async fn heartbeat_idempotency_keys_survive_restarts() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Arc::new(
+            IncidentStore::new(dir.path().join("incidents.db"))
+                .await
+                .unwrap(),
+        );
+        let key_before_restart =
+            build_exporter(dir.path(), "http://127.0.0.1:9/unused", store.clone())
+                .await
+                .heartbeat_event()
+                .unwrap()
+                .event_idempotency_key;
+        // Simulated restart: same state dir, fresh process state (the
+        // in-memory counter is gone, but the persisted one is not).
+        let mut restarted =
+            build_exporter(dir.path(), "http://127.0.0.1:9/unused", store.clone()).await;
+        let key_after_restart = restarted.heartbeat_event().unwrap().event_idempotency_key;
+        let key_next = restarted.heartbeat_event().unwrap().event_idempotency_key;
+        assert_ne!(
+            key_before_restart, key_after_restart,
+            "a restart must not reuse a heartbeat idempotency key with a different body"
+        );
+        assert_ne!(key_after_restart, key_next);
+        assert!(
+            key_after_restart.contains(restarted.identity.agent_instance_id()),
+            "key carries the stable instance id: {key_after_restart}"
+        );
     }
 
     #[tokio::test]

--- a/cognitod/src/cloud/exporter.rs
+++ b/cognitod/src/cloud/exporter.rs
@@ -1,0 +1,806 @@
+//! Cloud export loop.
+//!
+//! One tick (every [`SEAL_INTERVAL_SECS`]) pulls new incidents from the
+//! store in row-ID order behind a persisted watermark, converts them to
+//! schema-v1 detection events (scrubbed of secrets and, by default, process
+//! identity), adds heartbeats and degradation-state events, seals batches,
+//! spools them durably, and drains the spool through the sender.
+//!
+//! Failure isolation: every fallible step logs and continues. The exporter
+//! never panics, never blocks monitoring, and never touches the local API
+//! path.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use chrono::Utc;
+use log::{debug, error, info, warn};
+use serde_json::Value;
+use tokio::task::JoinHandle;
+
+use crate::attribution::BlameMetrics;
+use crate::incidents::{Incident, IncidentStore};
+
+use super::identity::IdentityStore;
+use super::model::{
+    AgentStatus, AttributionQuality, DegradationStatePayload, DetailLevel, DetectionAction,
+    DetectionPayload, Event, EventPayload, EventType, FallbackMode, HeartbeatPayload, Severity,
+    TimeRange, Transport, detection_type_for, rfc3339,
+};
+use super::scrub::{ScrubPolicy, scrub_snapshot};
+use super::seal::{BatchSealer, SealContext, SealedBatch};
+use super::sender::{SendDecision, Sender, backoff_delay};
+use super::spool::{Spool, SpoolPriority};
+use super::{EXPORT_PULL_LIMIT, HEARTBEAT_INTERVAL_SECS, SEAL_INTERVAL_SECS};
+
+/// Everything the exporter needs, with secrets already resolved from config
+/// and environment. Deliberately has no `Debug` impl: it carries the token.
+pub struct ExporterConfig {
+    pub endpoint: String,
+    pub token: String,
+    pub tenant_id: String,
+    pub cluster_id_override: Option<String>,
+    pub node_id_override: Option<String>,
+    pub export_process_identity: bool,
+    pub state_dir: PathBuf,
+    pub quality: QualitySnapshot,
+}
+
+/// Attribution-quality inputs captured at startup.
+#[derive(Debug, Clone)]
+pub struct QualitySnapshot {
+    /// `"perf"` when kernel instrumentation is live; anything else means the
+    /// userspace fallback.
+    pub transport: String,
+    pub btf_available: bool,
+    /// `"measured"` / `"inferred"` / `"unavailable"` — echoed in
+    /// degradation events.
+    pub rss_probe: String,
+}
+
+impl QualitySnapshot {
+    pub fn quality(&self) -> AttributionQuality {
+        if self.transport == "perf" {
+            AttributionQuality::Full
+        } else {
+            AttributionQuality::PsiOnly
+        }
+    }
+}
+
+/// Spawn the exporter on the current Tokio runtime. The task runs until the
+/// process exits; initialization failures are logged and the task ends, so
+/// cloud export can never take monitoring down with it.
+pub fn spawn_exporter(
+    config: ExporterConfig,
+    store: Arc<IncidentStore>,
+    blame: Arc<BlameMetrics>,
+) -> JoinHandle<()> {
+    tokio::spawn(async move {
+        match Exporter::new(config, store, blame).await {
+            Ok(exporter) => exporter.run().await,
+            Err(e) => error!("[cloud] exporter failed to initialize ({e}); cloud export disabled"),
+        }
+    })
+}
+
+pub struct Exporter {
+    config: ExporterConfig,
+    identity: IdentityStore,
+    spool: Spool,
+    sender: Sender,
+    sealer: BatchSealer,
+    /// Highest incident row ID converted into the in-memory sealer. Persisted
+    /// to the identity file only once the batch holding those events is
+    /// durably spooled, so a crash replays unsealed rows (the idempotency
+    /// key makes the replay harmless downstream).
+    pushed_watermark: i64,
+    /// Lowest drop priority among the events currently buffered; a batch is
+    /// spooled at its most important event's priority.
+    pending_priority: SpoolPriority,
+    store: Arc<IncidentStore>,
+    blame: Arc<BlameMetrics>,
+    start: Instant,
+    state_since: String,
+    heartbeat_count: u64,
+    last_heartbeat: Instant,
+    consecutive_failures: u32,
+    last_evictions: u64,
+    policy: ScrubPolicy,
+    backoff: fn(u32) -> Duration,
+}
+
+impl Exporter {
+    pub async fn new(
+        config: ExporterConfig,
+        store: Arc<IncidentStore>,
+        blame: Arc<BlameMetrics>,
+    ) -> Result<Self, String> {
+        let identity = IdentityStore::load_or_create(
+            &config.state_dir,
+            config.cluster_id_override.as_deref(),
+            config.node_id_override.as_deref(),
+        )
+        .map_err(|e| format!("identity: {e}"))?;
+        let spool = Spool::open(&config.state_dir).map_err(|e| format!("spool: {e}"))?;
+        let sender = Sender::new(config.endpoint.clone(), config.token.clone())
+            .map_err(|e| format!("sender: {e}"))?;
+        let quality = config.quality.quality();
+        let policy = ScrubPolicy::from_opt_in(config.export_process_identity);
+        let watermark = identity.export_watermark();
+        let last_evictions = blame.evictions();
+        let mut exporter = Self {
+            config,
+            identity,
+            spool,
+            sender,
+            sealer: BatchSealer::new(quality),
+            pushed_watermark: watermark,
+            pending_priority: SpoolPriority::Heartbeat,
+            store,
+            blame,
+            start: Instant::now(),
+            state_since: rfc3339(Utc::now().timestamp()),
+            heartbeat_count: 0,
+            last_heartbeat: Instant::now() - Duration::from_secs(HEARTBEAT_INTERVAL_SECS),
+            consecutive_failures: 0,
+            last_evictions,
+            policy,
+            backoff: backoff_delay,
+        };
+        // The first batch always opens with the current degradation state so
+        // the edge learns the quality before the first heartbeat arrives.
+        let degradation = exporter.degradation_event();
+        exporter.push_event(degradation, SpoolPriority::DegradationState);
+        info!(
+            "[cloud] exporter initialized (node {}, cluster {}, quality {:?})",
+            exporter.identity.node_id(),
+            exporter.identity.cluster_id(),
+            quality
+        );
+        Ok(exporter)
+    }
+
+    /// One export iteration: pull, heartbeat, seal, drain.
+    pub async fn tick(&mut self) {
+        // Quality transitions seal the old batch immediately and open a new
+        // one — a batch never mixes quality states (schema §2).
+        let quality = self.config.quality.quality();
+        if quality != self.sealer.quality() {
+            self.seal_and_spool().await;
+            self.sealer = BatchSealer::new(quality);
+            let degradation = self.degradation_event();
+            self.push_event(degradation, SpoolPriority::DegradationState);
+            info!("[cloud] attribution quality changed to {quality:?}; emitted degradation_state");
+        }
+
+        match self
+            .store
+            .export_batch(self.pushed_watermark, EXPORT_PULL_LIMIT)
+            .await
+        {
+            Ok(incidents) => {
+                for incident in &incidents {
+                    if let Some(id) = incident.id {
+                        self.pushed_watermark = self.pushed_watermark.max(id);
+                    }
+                    match self.detection_event(incident) {
+                        Some(event) => self.push_event(event, SpoolPriority::Detection),
+                        None => debug!(
+                            "[cloud] skipping incident {:?} (unmapped type {:?})",
+                            incident.id, incident.event_type
+                        ),
+                    }
+                }
+            }
+            Err(e) => warn!("[cloud] incident pull failed: {e}; will retry next tick"),
+        }
+
+        if self.last_heartbeat.elapsed() >= Duration::from_secs(HEARTBEAT_INTERVAL_SECS) {
+            self.heartbeat_count += 1;
+            let heartbeat = self.heartbeat_event();
+            self.push_event(heartbeat, SpoolPriority::Heartbeat);
+            self.last_heartbeat = Instant::now();
+        }
+
+        if self.sealer.seal_due(Instant::now()) {
+            self.seal_and_spool().await;
+        }
+
+        self.drain().await;
+    }
+
+    /// Run ticks forever on the seal cadence.
+    pub async fn run(mut self) {
+        let mut interval = tokio::time::interval(Duration::from_secs(SEAL_INTERVAL_SECS));
+        loop {
+            interval.tick().await;
+            self.tick().await;
+        }
+    }
+
+    fn push_event(&mut self, event: Event, priority: SpoolPriority) {
+        self.pending_priority = self.pending_priority.min(priority);
+        self.sealer.push(event);
+    }
+
+    /// Seal the buffered events and spool the batch. The watermark advances
+    /// only after the batch is durable on disk.
+    async fn seal_and_spool(&mut self) {
+        if self.sealer.is_empty() {
+            return;
+        }
+        let sequence = match self.identity.next_sequence() {
+            Ok(s) => s,
+            Err(e) => {
+                error!("[cloud] cannot advance batch sequence: {e}; events stay buffered");
+                return;
+            }
+        };
+        let ctx = SealContext {
+            tenant_id: &self.config.tenant_id,
+            cluster_id: self.identity.cluster_id(),
+            node_id: self.identity.node_id(),
+            agent_instance_id: self.identity.agent_instance_id(),
+            sequence,
+        };
+        let batch: Option<SealedBatch> = self.sealer.seal(&ctx);
+        let Some(batch) = batch else { return };
+        let priority = self.pending_priority;
+        match self.spool.store(&batch, priority) {
+            Ok(()) => {
+                if let Err(e) = self.identity.set_export_watermark(self.pushed_watermark) {
+                    error!("[cloud] spooled batch {sequence} but failed to persist watermark: {e}");
+                }
+                self.pending_priority = SpoolPriority::Heartbeat;
+            }
+            Err(e) => error!("[cloud] spool store failed for batch {sequence}: {e}"),
+        }
+    }
+
+    /// POST spooled batches oldest-first until acked, quarantined, or told
+    /// to back off.
+    async fn drain(&mut self) {
+        while let Some(view) = self.spool.oldest() {
+            let sequence = view.sequence();
+            let bytes = match self.spool.read(sequence) {
+                Ok(b) => b,
+                Err(e) => {
+                    warn!("[cloud] spooled batch {sequence} unreadable ({e}); dropping");
+                    let _ = self.spool.remove(sequence);
+                    continue;
+                }
+            };
+            match self.sender.post_batch(&bytes).await {
+                SendDecision::Acked => {
+                    let _ = self.spool.remove(sequence);
+                    self.consecutive_failures = 0;
+                }
+                SendDecision::Quarantine { reason } => {
+                    let _ = self.spool.quarantine(sequence, &reason);
+                    self.consecutive_failures = 0;
+                }
+                SendDecision::Retry { retry_after } => {
+                    self.consecutive_failures += 1;
+                    let delay = retry_after.max((self.backoff)(self.consecutive_failures));
+                    warn!(
+                        "[cloud] edge unavailable; backing off for {delay:?} ({} consecutive)",
+                        self.consecutive_failures
+                    );
+                    tokio::time::sleep(delay).await;
+                    break;
+                }
+            }
+        }
+    }
+
+    fn heartbeat_event(&mut self) -> Event {
+        let n = self.heartbeat_count;
+        let node_id = self.identity.node_id();
+        let quality = self.sealer.quality();
+        let evicted_total = self.blame.evictions();
+        let evicted_delta = evicted_total.saturating_sub(self.last_evictions);
+        self.last_evictions = evicted_total;
+        Event {
+            event_id: format!("hb-{node_id}-{n}"),
+            event_idempotency_key: format!("e:hb:{node_id}:{n}"),
+            event_type: EventType::Heartbeat,
+            occurred_at: rfc3339(Utc::now().timestamp()),
+            detail_level: DetailLevel::Summary,
+            payload: EventPayload::Heartbeat(HeartbeatPayload {
+                interval_seconds: HEARTBEAT_INTERVAL_SECS as u32,
+                uptime_seconds: self.start.elapsed().as_secs(),
+                agent_status: match quality {
+                    AttributionQuality::Full => AgentStatus::Healthy,
+                    AttributionQuality::PsiOnly => AgentStatus::Degraded,
+                },
+                transport: match quality {
+                    AttributionQuality::Full => Transport::Perf,
+                    AttributionQuality::PsiOnly => Transport::Userspace,
+                },
+                ebpf_attached: quality == AttributionQuality::Full,
+                btf_available: self.config.quality.btf_available,
+                active_node: true,
+                events_buffered: self.spool.pending_events(),
+                events_dropped_total: self.spool.dropped_total(),
+                blame_series_active: self
+                    .blame
+                    .victim_series()
+                    .saturating_add(self.blame.pair_series())
+                    as u32,
+                blame_series_evicted_total: evicted_total,
+                blame_series_evicted_delta: evicted_delta,
+            }),
+        }
+    }
+
+    fn degradation_event(&self) -> Event {
+        let node_id = self.identity.node_id();
+        let now = Utc::now().timestamp();
+        let quality = self.sealer.quality();
+        let (reason_code, reason, lost) = match quality {
+            AttributionQuality::Full => (
+                "none",
+                "all required kernel probes are attached",
+                Vec::new(),
+            ),
+            AttributionQuality::PsiOnly => (
+                "probe_attach_failed",
+                "eBPF probes are not attached; running userspace-only — PSI signals remain available but process-level offender attribution is unavailable",
+                vec![
+                    "process_attribution".to_string(),
+                    "offender_identity".to_string(),
+                    "process_tree".to_string(),
+                ],
+            ),
+        };
+        Event {
+            event_id: format!("deg-{node_id}-{}-{now}", quality.as_str()),
+            event_idempotency_key: format!("e:deg:{node_id}:{}:{now}", quality.as_str()),
+            event_type: EventType::DegradationState,
+            occurred_at: rfc3339(now),
+            detail_level: DetailLevel::Evidence,
+            payload: EventPayload::DegradationState(DegradationStatePayload {
+                attribution_quality: quality,
+                ebpf_attached: quality == AttributionQuality::Full,
+                fallback_mode: match quality {
+                    AttributionQuality::Full => FallbackMode::None,
+                    AttributionQuality::PsiOnly => FallbackMode::ProcPressureOnly,
+                },
+                transport: match quality {
+                    AttributionQuality::Full => Transport::Perf,
+                    AttributionQuality::PsiOnly => Transport::Userspace,
+                },
+                btf_available: self.config.quality.btf_available,
+                rss_probe: self.config.quality.rss_probe.clone(),
+                lost_capabilities: lost,
+                reason_code: reason_code.to_string(),
+                reason: reason.to_string(),
+                state_since: self.state_since.clone(),
+            }),
+        }
+    }
+
+    fn detection_event(&self, incident: &Incident) -> Option<Event> {
+        let id = incident.id?;
+        let detection_type = detection_type_for(&incident.event_type)?.to_string();
+        let occurred = incident.timestamp;
+        let (window_start, window_end) = detection_window(incident);
+        let details = scrub_snapshot(incident.system_snapshot.as_deref(), self.policy)
+            .unwrap_or_else(|| Value::Object(Default::default()));
+        let instance = self.identity.agent_instance_id();
+        Some(Event {
+            event_id: format!("incident-{id}"),
+            event_idempotency_key: format!("e:det:{instance}:{id}"),
+            event_type: EventType::Detection,
+            occurred_at: rfc3339(occurred),
+            detail_level: DetailLevel::Evidence,
+            payload: EventPayload::Detection(DetectionPayload {
+                detection_type: detection_type.clone(),
+                severity: severity_for(incident),
+                // v1: we don't resolve incidents to pod/namespace workload
+                // identity; workload attribution is a follow-up.
+                subject: None,
+                window: TimeRange {
+                    start: rfc3339(window_start),
+                    end: rfc3339(window_end),
+                },
+                rule_name: detection_type,
+                action: DetectionAction::Observe,
+                details,
+            }),
+        })
+    }
+}
+
+/// Detection window from the snapshot's `window_secs` when present,
+/// otherwise a 60s window ending at the incident timestamp.
+fn detection_window(incident: &Incident) -> (i64, i64) {
+    let end = incident.timestamp;
+    let secs = incident
+        .system_snapshot
+        .as_deref()
+        .and_then(|s| serde_json::from_str::<Value>(s).ok())
+        .and_then(|v| v.get("window_secs").and_then(Value::as_f64))
+        .unwrap_or(60.0)
+        .max(1.0) as i64;
+    (end.saturating_sub(secs), end)
+}
+
+fn snapshot_string(incident: &Incident, key: &str) -> Option<String> {
+    incident
+        .system_snapshot
+        .as_deref()
+        .and_then(|s| serde_json::from_str::<Value>(s).ok())
+        .and_then(|v| v.get(key).and_then(Value::as_str).map(str::to_string))
+}
+
+/// Critical verdicts stay critical; everything else ships as a warning.
+fn severity_for(incident: &Incident) -> Severity {
+    let critical = snapshot_string(incident, "verdict")
+        .map(|v| v.contains("Critical"))
+        .unwrap_or(false);
+    if critical {
+        Severity::Critical
+    } else {
+        Severity::Warning
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::VecDeque;
+    use std::sync::Mutex;
+
+    fn sample_incident(id: Option<i64>, event_type: &str, snapshot: Option<&str>) -> Incident {
+        Incident {
+            id,
+            timestamp: 1_700_000_000,
+            event_type: event_type.to_string(),
+            psi_cpu: 0.0,
+            psi_memory: 0.0,
+            cpu_percent: 0.0,
+            load_avg: "0.10,0.10,0.10".to_string(),
+            action: "alert".to_string(),
+            target_pid: None,
+            target_name: None,
+            system_snapshot: snapshot.map(str::to_string),
+            llm_analysis: None,
+            llm_analyzed_at: None,
+            investigation: None,
+            recovery_time_ms: None,
+            psi_after: None,
+        }
+    }
+
+    struct TestHarness {
+        exporter: Exporter,
+        store: Arc<IncidentStore>,
+        dir: tempfile::TempDir,
+    }
+
+    async fn harness(endpoint: &str) -> TestHarness {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Arc::new(
+            IncidentStore::new(dir.path().join("incidents.db"))
+                .await
+                .unwrap(),
+        );
+        let blame = Arc::new(BlameMetrics::new("test-node"));
+        let config = ExporterConfig {
+            endpoint: endpoint.to_string(),
+            token: "test-token".to_string(),
+            tenant_id: "tn_test".to_string(),
+            cluster_id_override: Some("clu_test".to_string()),
+            node_id_override: Some("node_test".to_string()),
+            export_process_identity: false,
+            state_dir: dir.path().to_path_buf(),
+            quality: QualitySnapshot {
+                transport: "userspace".to_string(),
+                btf_available: false,
+                rss_probe: "unavailable".to_string(),
+            },
+        };
+        let mut exporter = Exporter::new(config, store.clone(), blame).await.unwrap();
+        // Keep retry-path tests fast; production uses exponential backoff.
+        exporter.backoff = |_| Duration::from_millis(1);
+        TestHarness {
+            exporter,
+            store,
+            dir,
+        }
+    }
+
+    fn gunzip(bytes: &[u8]) -> Vec<u8> {
+        use std::io::Read as _;
+        let mut dec = flate2::read::GzDecoder::new(bytes);
+        let mut out = Vec::new();
+        dec.read_to_end(&mut out).unwrap();
+        out
+    }
+
+    #[tokio::test]
+    async fn detection_event_maps_all_types_and_scrubs() {
+        let h = harness("http://127.0.0.1:9/unused").await;
+        let cases = [
+            ("fork_storm", "fork_storm"),
+            ("memory_leak", "memory_leak"),
+            ("cpu_starvation", "cpu_starvation"),
+            ("blkio_stall", "blkio_stall"),
+            ("cgroup_pressure", "cgroup_pressure"),
+            ("oom_kill", "oom_kill"),
+            ("circuit_breaker", "circuit_breaker"),
+        ];
+        for (local, cloud) in cases {
+            let incident = sample_incident(
+                Some(1),
+                local,
+                Some(
+                    r#"{"verdict":"ForkStormCritical","window_secs":10,"comm":"evil","api_token":"sekrit"}"#,
+                ),
+            );
+            let event = h.exporter.detection_event(&incident).expect("must map");
+            let EventPayload::Detection(payload) = event.payload else {
+                panic!("expected detection payload");
+            };
+            assert_eq!(payload.detection_type, cloud);
+            assert_eq!(
+                event.event_idempotency_key,
+                format!("e:det:{}:1", h.exporter.identity.agent_instance_id())
+            );
+            assert_eq!(payload.window.start, rfc3339(1_700_000_000 - 10));
+            assert_eq!(payload.window.end, rfc3339(1_700_000_000));
+            // Privacy: process identity and secrets are scrubbed by default.
+            assert!(payload.details.get("comm").is_none(), "{local}");
+            assert!(payload.details.get("api_token").is_none(), "{local}");
+            // Non-identity facts survive.
+            assert_eq!(payload.details["verdict"], "ForkStormCritical");
+        }
+        // Unknown local types are skipped, never coerced into a wrong enum.
+        let bogus = sample_incident(Some(2), "bogus_type", None);
+        assert!(h.exporter.detection_event(&bogus).is_none());
+    }
+
+    #[tokio::test]
+    async fn severity_and_window_defaults() {
+        let h = harness("http://127.0.0.1:9/unused").await;
+        let warning = sample_incident(Some(1), "memory_leak", Some(r#"{"verdict":"LeakWarning"}"#));
+        let event = h.exporter.detection_event(&warning).unwrap();
+        let EventPayload::Detection(payload) = event.payload else {
+            panic!("expected detection payload");
+        };
+        assert_eq!(payload.severity, Severity::Warning);
+        // No window_secs in the snapshot: 60s window ending at the incident.
+        assert_eq!(payload.window.start, rfc3339(1_700_000_000 - 60));
+        assert_eq!(payload.window.end, rfc3339(1_700_000_000));
+        // Invalid snapshots export as empty details, never invented ones.
+        let broken = sample_incident(Some(2), "memory_leak", Some("not json"));
+        let event = h.exporter.detection_event(&broken).unwrap();
+        let EventPayload::Detection(payload) = event.payload else {
+            panic!("expected detection payload");
+        };
+        assert_eq!(payload.details, Value::Object(Default::default()));
+    }
+
+    #[tokio::test]
+    async fn watermark_advances_only_after_durable_spool() {
+        let h = harness("http://127.0.0.1:9/unused").await;
+        h.store
+            .insert(&sample_incident(None, "fork_storm", None))
+            .await
+            .unwrap();
+        h.store
+            .insert(&sample_incident(None, "oom_kill", None))
+            .await
+            .unwrap();
+        let mut exporter = h.exporter;
+        exporter.tick().await;
+        // Pulled into the in-memory sealer but not yet sealed: the persisted
+        // watermark is unchanged, so a crash here replays both rows.
+        assert_eq!(exporter.identity.export_watermark(), 0);
+        assert_eq!(exporter.pushed_watermark, 2);
+        exporter.seal_and_spool().await;
+        assert_eq!(exporter.identity.export_watermark(), 2);
+        // The next tick pulls nothing new — no duplicate events buffered.
+        exporter.tick().await;
+        assert_eq!(exporter.pushed_watermark, 2);
+    }
+
+    #[tokio::test]
+    async fn quality_transition_seals_and_emits_degradation() {
+        let h = harness("http://127.0.0.1:9/unused").await;
+        let mut exporter = h.exporter;
+        // Simulate kernel instrumentation coming online.
+        exporter.config.quality.transport = "perf".to_string();
+        exporter.tick().await;
+        // Old (psi_only) batch sealed, new sealer carries the transition.
+        assert_eq!(exporter.sealer.quality(), AttributionQuality::Full);
+        let EventPayload::DegradationState(payload) = &exporter
+            .sealer
+            .buffered_events()
+            .iter()
+            .find(|e| e.event_type == EventType::DegradationState)
+            .expect("degradation event buffered")
+            .payload
+        else {
+            panic!("expected degradation payload");
+        };
+        assert_eq!(payload.attribution_quality, AttributionQuality::Full);
+        assert_eq!(payload.fallback_mode, FallbackMode::None);
+        assert!(payload.ebpf_attached);
+    }
+
+    // --- Mock edge integration tests -------------------------------------
+
+    struct RecordedRequest {
+        authorization: Option<String>,
+        content_encoding: Option<String>,
+        body: Vec<u8>,
+    }
+
+    struct MockEdge {
+        /// Scripted (status, retry_after) responses, one per request.
+        script: Mutex<VecDeque<(u16, Option<String>)>>,
+        requests: Mutex<Vec<RecordedRequest>>,
+    }
+
+    async fn spawn_mock_edge() -> (String, Arc<MockEdge>) {
+        let edge = Arc::new(MockEdge {
+            script: Mutex::new(VecDeque::new()),
+            requests: Mutex::new(Vec::new()),
+        });
+        let handler_edge = edge.clone();
+        let app = axum::Router::new().route(
+            "/v1/event-batches",
+            axum::routing::post(move |req: axum::extract::Request| {
+                let edge = handler_edge.clone();
+                async move {
+                    let (parts, body) = req.into_parts();
+                    let bytes = axum::body::to_bytes(body, 16 * 1024 * 1024).await.unwrap();
+                    let (status, retry_after) = edge
+                        .script
+                        .lock()
+                        .unwrap()
+                        .pop_front()
+                        .unwrap_or((202, None));
+                    edge.requests.lock().unwrap().push(RecordedRequest {
+                        authorization: parts
+                            .headers
+                            .get(axum::http::header::AUTHORIZATION)
+                            .and_then(|v| v.to_str().ok())
+                            .map(str::to_string),
+                        content_encoding: parts
+                            .headers
+                            .get(axum::http::header::CONTENT_ENCODING)
+                            .and_then(|v| v.to_str().ok())
+                            .map(str::to_string),
+                        body: bytes.to_vec(),
+                    });
+                    let mut response = axum::http::Response::builder().status(status);
+                    if let Some(ra) = retry_after {
+                        response = response.header(axum::http::header::RETRY_AFTER, ra);
+                    }
+                    response.body(axum::body::Body::empty()).unwrap()
+                }
+            }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        (format!("http://{addr}/v1/event-batches"), edge)
+    }
+
+    #[tokio::test]
+    async fn mock_edge_happy_path_posts_gzip_batch_with_auth() {
+        let (url, edge) = spawn_mock_edge().await;
+        edge.script.lock().unwrap().push_back((202, None));
+        let mut h = harness(&url).await;
+        h.store
+            .insert(&sample_incident(
+                None,
+                "fork_storm",
+                Some(r#"{"verdict":"ForkStormWarning","comm":"x"}"#),
+            ))
+            .await
+            .unwrap();
+        h.store
+            .insert(&sample_incident(None, "oom_kill", None))
+            .await
+            .unwrap();
+        h.exporter.tick().await;
+        h.exporter.seal_and_spool().await;
+        assert_eq!(h.exporter.spool.batch_count(), 1);
+        h.exporter.drain().await;
+        assert_eq!(h.exporter.spool.batch_count(), 0);
+
+        let requests = edge.requests.lock().unwrap();
+        assert_eq!(requests.len(), 1);
+        let req = &requests[0];
+        assert_eq!(req.authorization.as_deref(), Some("Bearer test-token"));
+        assert_eq!(req.content_encoding.as_deref(), Some("gzip"));
+        let envelope: Value = serde_json::from_slice(&gunzip(&req.body)).unwrap();
+        assert_eq!(envelope["schema_version"], "1.0.0");
+        assert_eq!(envelope["tenant_id"], "tn_test");
+        assert_eq!(envelope["cluster_id"], "clu_test");
+        assert_eq!(envelope["node_id"], "node_test");
+        assert_eq!(envelope["attribution_quality"], "psi_only");
+        assert_eq!(
+            envelope["batch_idempotency_key"],
+            format!("b:node_test:{}", envelope["sequence"].as_u64().unwrap())
+        );
+        let types: Vec<&str> = envelope["events"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|e| e["event_type"].as_str().unwrap())
+            .collect();
+        assert_eq!(
+            types,
+            ["degradation_state", "detection", "detection", "heartbeat"]
+        );
+        assert!(
+            envelope["events"][1]["payload"]["details"]
+                .get("comm")
+                .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn mock_edge_429_then_202_retries_same_bytes() {
+        let (url, edge) = spawn_mock_edge().await;
+        edge.script
+            .lock()
+            .unwrap()
+            .push_back((429, Some("0".to_string())));
+        edge.script.lock().unwrap().push_back((202, None));
+        let mut h = harness(&url).await;
+        h.store
+            .insert(&sample_incident(None, "fork_storm", None))
+            .await
+            .unwrap();
+        h.exporter.tick().await;
+        h.exporter.seal_and_spool().await;
+        h.exporter.drain().await; // 429: batch stays spooled
+        assert_eq!(h.exporter.spool.batch_count(), 1);
+        h.exporter.drain().await; // 202: acked
+        assert_eq!(h.exporter.spool.batch_count(), 0);
+
+        let requests = edge.requests.lock().unwrap();
+        assert_eq!(requests.len(), 2);
+        // Retries preserve bytes and identity (schema §10).
+        assert_eq!(gunzip(&requests[0].body), gunzip(&requests[1].body));
+    }
+
+    #[tokio::test]
+    async fn mock_edge_409_quarantines_without_retry() {
+        let (url, edge) = spawn_mock_edge().await;
+        edge.script.lock().unwrap().push_back((409, None));
+        let mut h = harness(&url).await;
+        h.store
+            .insert(&sample_incident(None, "fork_storm", None))
+            .await
+            .unwrap();
+        h.exporter.tick().await;
+        h.exporter.seal_and_spool().await;
+        h.exporter.drain().await;
+        assert_eq!(h.exporter.spool.batch_count(), 0);
+        assert_eq!(
+            edge.requests.lock().unwrap().len(),
+            1,
+            "409 must quarantine, never retry"
+        );
+        let note = std::fs::read_to_string(
+            h.dir
+                .path()
+                .join(super::super::spool::SPOOL_DIR_NAME)
+                .join("quarantine")
+                .join("0.note"),
+        )
+        .unwrap();
+        assert!(note.contains("409"), "quarantine note explains why: {note}");
+    }
+}

--- a/cognitod/src/cloud/identity.rs
+++ b/cognitod/src/cloud/identity.rs
@@ -34,6 +34,13 @@ struct IdentityFile {
     agent_instance_id: String,
     next_sequence: u64,
     export_watermark: i64,
+    /// Monotonic heartbeat counter. Heartbeat idempotency keys must never
+    /// repeat with a different body — including across daemon restarts, when
+    /// every in-memory counter resets — so this one is persisted.
+    /// `#[serde(default)]` keeps identities written before this field
+    /// existed readable.
+    #[serde(default)]
+    heartbeat_seq: u64,
 }
 
 /// Resolve the node identity: explicit config override wins, then the
@@ -91,6 +98,7 @@ impl IdentityStore {
                     agent_instance_id: uuid::Uuid::new_v4().to_string(),
                     next_sequence: 0,
                     export_watermark: 0,
+                    heartbeat_seq: 0,
                 };
                 let store = Self {
                     path: path.clone(),
@@ -126,6 +134,19 @@ impl IdentityStore {
     pub fn next_sequence(&mut self) -> io::Result<u64> {
         let seq = self.identity.next_sequence;
         self.identity.next_sequence = seq.saturating_add(1);
+        self.persist()?;
+        Ok(seq)
+    }
+
+    /// Claim the next heartbeat sequence number (persisted immediately).
+    /// Heartbeat idempotency keys are `e:hb:{agent_instance_id}:{n}`: the
+    /// persisted counter keeps them unique across daemon restarts, where an
+    /// in-memory counter would restart at 0 and reuse a key with a
+    /// different body (a declared idempotency violation the edge could
+    /// quarantine a whole batch over).
+    pub fn next_heartbeat_seq(&mut self) -> io::Result<u64> {
+        let seq = self.identity.heartbeat_seq.saturating_add(1);
+        self.identity.heartbeat_seq = seq;
         self.persist()?;
         Ok(seq)
     }
@@ -197,6 +218,30 @@ mod tests {
         drop(store);
         let reopened = fresh_store(dir.path());
         assert_eq!(reopened.export_watermark(), 42);
+    }
+
+    #[test]
+    fn heartbeat_seq_is_persisted_and_monotonic() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut first = fresh_store(dir.path());
+        assert_eq!(first.next_heartbeat_seq().unwrap(), 1);
+        assert_eq!(first.next_heartbeat_seq().unwrap(), 2);
+        drop(first);
+        // A restart continues the counter — keys never repeat.
+        let mut second = fresh_store(dir.path());
+        assert_eq!(second.next_heartbeat_seq().unwrap(), 3);
+    }
+
+    #[test]
+    fn old_identity_files_without_heartbeat_seq_still_load() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join(IDENTITY_FILE_NAME),
+            r#"{"cluster_id":"c","node_id":"n","agent_instance_id":"i","next_sequence":0,"export_watermark":0}"#,
+        )
+        .unwrap();
+        let mut store = IdentityStore::load_or_create(dir.path(), None, None).unwrap();
+        assert_eq!(store.next_heartbeat_seq().unwrap(), 1);
     }
 
     #[test]

--- a/cognitod/src/cloud/mod.rs
+++ b/cognitod/src/cloud/mod.rs
@@ -14,12 +14,18 @@
 //!   leave the node unless explicitly opted in.
 //! - [`seal`] — batch assembly with the schema's seal triggers.
 //! - [`spool`] — crash-safe on-disk spool with caps and drop priorities.
+//! - [`sender`] — HTTPS POST with the schema's retry/quarantine semantics.
+//! - [`exporter`] — the background loop wiring it all together.
 
+pub mod exporter;
 pub mod identity;
 pub mod model;
 pub mod scrub;
 pub mod seal;
+pub mod sender;
 pub mod spool;
+
+pub use exporter::{ExporterConfig, QualitySnapshot, spawn_exporter};
 
 use std::io;
 use std::path::Path;

--- a/cognitod/src/cloud/seal.rs
+++ b/cognitod/src/cloud/seal.rs
@@ -220,7 +220,12 @@ impl BatchSealer {
 
     /// Seal the buffered events into an immutable batch. Returns `None`
     /// when there's nothing to seal (the schema requires 1–500 events).
-    pub fn seal(&mut self, ctx: &SealContext<'_>) -> Option<SealedBatch> {
+    ///
+    /// This does NOT drain the buffer: call [`clear`] only after the batch
+    /// is durable (spooled). A failed spool store leaves the events
+    /// buffered for retry, so a later successful batch can never advance
+    /// the watermark past them.
+    pub fn seal(&self, ctx: &SealContext<'_>) -> Option<SealedBatch> {
         if self.events.is_empty() {
             return None;
         }
@@ -230,10 +235,7 @@ impl BatchSealer {
         debug_assert_eq!(ctx.cluster_id, self.identity.cluster_id);
         debug_assert_eq!(ctx.node_id, self.identity.node_id);
         debug_assert_eq!(ctx.agent_instance_id, self.identity.agent_instance_id);
-        let events = std::mem::take(&mut self.events);
-        self.event_bytes = 0;
-        self.first_push = None;
-        let event_count = events.len();
+        let event_count = self.events.len();
 
         let envelope = BatchEnvelope {
             schema_version: SCHEMA_VERSION.to_string(),
@@ -246,7 +248,7 @@ impl BatchSealer {
             sequence: ctx.sequence,
             agent_instance_id: ctx.agent_instance_id.to_string(),
             attribution_quality: self.quality,
-            events,
+            events: self.events.clone(),
         };
         // Same inputs → same bytes: idempotency keys are stable across retries.
         let bytes = serde_json::to_vec(&envelope).expect("envelope serialization cannot fail");
@@ -267,6 +269,15 @@ impl BatchSealer {
             bytes,
             digest,
         })
+    }
+
+    /// Drain the buffer after the sealed batch is durable on disk. Only
+    /// call this once the batch bytes are safely spooled — otherwise the
+    /// buffered events are lost.
+    pub fn clear(&mut self) {
+        self.events.clear();
+        self.event_bytes = 0;
+        self.first_push = None;
     }
 }
 
@@ -520,6 +531,10 @@ mod tests {
         let batch = sealer.seal(&ctx()).unwrap();
         assert_eq!(batch.event_count, MAX_EVENTS_PER_BATCH);
         assert_eq!(batch.sequence, 7);
+        // seal() doesn't drain: the buffer clears only once the batch is
+        // durable (the exporter's seal_and_spool does this after spooling).
+        assert!(!sealer.is_empty());
+        sealer.clear();
         assert!(sealer.is_empty());
     }
 
@@ -533,6 +548,7 @@ mod tests {
         let batch = sealer.seal(&ctx()).unwrap();
         assert_eq!(batch.quality, AttributionQuality::PsiOnly);
         // Empty sealer seals to nothing: the schema requires ≥1 event.
+        sealer.clear();
         assert!(sealer.seal(&ctx()).is_none());
     }
 

--- a/cognitod/src/cloud/sender.rs
+++ b/cognitod/src/cloud/sender.rs
@@ -92,6 +92,19 @@ pub fn parse_retry_after(value: Option<&str>) -> Option<Duration> {
     value?.trim().parse::<u64>().ok().map(Duration::from_secs)
 }
 
+/// Extract `Retry-After` for retryable statuses: 429 and 5xx (schema §10:
+/// "honor Retry-After" — a `503 Retry-After: 120` must not fall back to the
+/// shorter local backoff). Pure, unit-tested.
+fn retry_after_for(status: u16, headers: &reqwest::header::HeaderMap) -> Option<Duration> {
+    if status != 429 && !(500..=599).contains(&status) {
+        return None;
+    }
+    headers
+        .get(reqwest::header::RETRY_AFTER)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| parse_retry_after(Some(v)))
+}
+
 pub fn gzip_body(bytes: &[u8]) -> Vec<u8> {
     let mut enc = GzEncoder::new(Vec::new(), Compression::default());
     enc.write_all(bytes).expect("gzip into memory cannot fail");
@@ -132,15 +145,7 @@ impl Sender {
         match response {
             Ok(resp) => {
                 let status = resp.status().as_u16();
-                // Honor Retry-After on 429 before falling back to backoff.
-                let retry_after = (status == 429)
-                    .then(|| {
-                        resp.headers()
-                            .get(reqwest::header::RETRY_AFTER)
-                            .and_then(|v| v.to_str().ok())
-                    })
-                    .flatten()
-                    .and_then(|v| parse_retry_after(Some(v)));
+                let retry_after = retry_after_for(status, resp.headers());
                 match classify_status(status) {
                     SendDecision::Retry { .. } => SendDecision::Retry {
                         retry_after: retry_after.unwrap_or(BACKOFF_BASE),
@@ -219,6 +224,40 @@ mod tests {
         );
         assert_eq!(parse_retry_after(None), None);
         assert_eq!(parse_retry_after(Some("not-a-number")), None);
+    }
+
+    fn headers_with_retry_after(value: &str) -> reqwest::header::HeaderMap {
+        let mut headers = reqwest::header::HeaderMap::new();
+        headers.insert(
+            reqwest::header::RETRY_AFTER,
+            reqwest::header::HeaderValue::from_str(value).unwrap(),
+        );
+        headers
+    }
+
+    #[test]
+    fn retry_after_honored_on_429_and_5xx_only() {
+        let headers = headers_with_retry_after("120");
+        let empty = reqwest::header::HeaderMap::new();
+        // 429 and retryable 5xx honor the header...
+        assert_eq!(
+            retry_after_for(429, &headers),
+            Some(Duration::from_secs(120))
+        );
+        assert_eq!(
+            retry_after_for(503, &headers),
+            Some(Duration::from_secs(120))
+        );
+        assert_eq!(
+            retry_after_for(500, &headers),
+            Some(Duration::from_secs(120))
+        );
+        // ...a missing header falls back to the caller's backoff...
+        assert_eq!(retry_after_for(503, &empty), None);
+        // ...and non-retryable statuses never honor it.
+        assert_eq!(retry_after_for(200, &headers), None);
+        assert_eq!(retry_after_for(409, &headers), None);
+        assert_eq!(retry_after_for(400, &headers), None);
     }
 
     #[test]

--- a/cognitod/src/cloud/sender.rs
+++ b/cognitod/src/cloud/sender.rs
@@ -1,0 +1,243 @@
+//! HTTPS sender for sealed batches.
+//!
+//! POSTs gzip-compressed batch bytes with bearer auth. Response handling
+//! follows schema §10 exactly:
+//!
+//! | Status      | Meaning                  | Action                              |
+//! |-------------|--------------------------|-------------------------------------|
+//! | 200 / 202   | accepted (202) or dup (200) | delete local batch               |
+//! | 409         | key reused, body differs | quarantine + local diagnostic, no retry |
+//! | 413 / 422   | invalid request          | quarantine, do not loop             |
+//! | other 4xx   | client error             | quarantine, do not loop             |
+//! | 429 / 5xx   | transient                | exponential backoff + jitter, honor `Retry-After` |
+//! | transport error | network failure      | same as transient                     |
+//!
+//! Batch bytes are immutable across retries: the same sealed bytes and the
+//! same idempotency key go out every attempt. The bearer token is never
+//! logged and is redacted from `Debug`.
+
+use std::io::Write as _;
+use std::time::Duration;
+
+use flate2::Compression;
+use flate2::write::GzEncoder;
+
+/// What to do after attempting a POST.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SendDecision {
+    /// 200/202: drop the local batch.
+    Acked,
+    /// 409/413/422/other 4xx: move to quarantine, never retry.
+    Quarantine { reason: String },
+    /// 429/5xx/network error: keep spooled, retry after `retry_after`.
+    Retry { retry_after: Duration },
+}
+
+/// Classify an HTTP status into a send decision (pure, unit-tested).
+pub fn classify_status(status: u16) -> SendDecision {
+    match status {
+        200 | 202 => SendDecision::Acked,
+        409 => SendDecision::Quarantine {
+            reason: "409: idempotency key reused with a different body".to_string(),
+        },
+        413 => SendDecision::Quarantine {
+            reason: "413: batch exceeds edge body limits".to_string(),
+        },
+        422 => SendDecision::Quarantine {
+            reason: "422: edge rejected the batch as a schema violation".to_string(),
+        },
+        429 => SendDecision::Retry {
+            retry_after: BACKOFF_BASE,
+        },
+        500..=599 => SendDecision::Retry {
+            retry_after: BACKOFF_BASE,
+        },
+        _ => SendDecision::Quarantine {
+            reason: format!("{status}: unexpected client error; not retrying"),
+        },
+    }
+}
+
+/// Base delay for the first retry; doubles per consecutive failure.
+pub const BACKOFF_BASE: Duration = Duration::from_secs(5);
+/// Upper bound for any single backoff.
+pub const BACKOFF_MAX: Duration = Duration::from_secs(300);
+
+/// Exponential backoff with ±25% jitter. `failures` counts consecutive
+/// retryable failures; resets on any ack. Jitter comes from a cheap
+/// time-based xorshift — no RNG dependency needed for this.
+pub fn backoff_delay(failures: u32) -> Duration {
+    let exp = failures.min(6);
+    let base = BACKOFF_BASE
+        .as_secs()
+        .saturating_mul(1 << exp)
+        .min(BACKOFF_MAX.as_secs());
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.subsec_nanos() as u64)
+        .unwrap_or(0);
+    // xorshift64* on the timestamp for jitter in [-25%, +25%].
+    let mut x = nanos.wrapping_add(0x9E3779B97F4A7C15).max(1);
+    x ^= x >> 12;
+    x ^= x << 25;
+    x ^= x >> 27;
+    let jitter_pct = (x % 51) as i64 - 25; // -25..=25
+    let adjusted = (base as i64 * (100 + jitter_pct) / 100).max(1) as u64;
+    Duration::from_secs(adjusted)
+}
+
+/// Parse a `Retry-After` header: delta-seconds, else `None` (HTTP dates are
+/// not worth the parsing dependency for a hint the backoff already covers).
+pub fn parse_retry_after(value: Option<&str>) -> Option<Duration> {
+    value?.trim().parse::<u64>().ok().map(Duration::from_secs)
+}
+
+pub fn gzip_body(bytes: &[u8]) -> Vec<u8> {
+    let mut enc = GzEncoder::new(Vec::new(), Compression::default());
+    enc.write_all(bytes).expect("gzip into memory cannot fail");
+    enc.finish().expect("gzip finish cannot fail")
+}
+
+pub struct Sender {
+    client: reqwest::Client,
+    endpoint: String,
+    token: String,
+}
+
+impl Sender {
+    pub fn new(endpoint: String, token: String) -> Result<Self, reqwest::Error> {
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(30))
+            .build()?;
+        Ok(Self {
+            client,
+            endpoint,
+            token,
+        })
+    }
+
+    /// POST one sealed batch. Returns the decision; the caller owns the
+    /// spool mutation (remove / quarantine / backoff).
+    pub async fn post_batch(&self, bytes: &[u8]) -> SendDecision {
+        let body = gzip_body(bytes);
+        let response = self
+            .client
+            .post(&self.endpoint)
+            .header("Content-Type", "application/json")
+            .header("Content-Encoding", "gzip")
+            .bearer_auth(&self.token)
+            .body(body)
+            .send()
+            .await;
+        match response {
+            Ok(resp) => {
+                let status = resp.status().as_u16();
+                // Honor Retry-After on 429 before falling back to backoff.
+                let retry_after = (status == 429)
+                    .then(|| {
+                        resp.headers()
+                            .get(reqwest::header::RETRY_AFTER)
+                            .and_then(|v| v.to_str().ok())
+                    })
+                    .flatten()
+                    .and_then(|v| parse_retry_after(Some(v)));
+                match classify_status(status) {
+                    SendDecision::Retry { .. } => SendDecision::Retry {
+                        retry_after: retry_after.unwrap_or(BACKOFF_BASE),
+                    },
+                    other => other,
+                }
+            }
+            Err(e) => {
+                log::warn!("[cloud] batch POST failed: {e}; will retry with backoff");
+                SendDecision::Retry {
+                    retry_after: BACKOFF_BASE,
+                }
+            }
+        }
+    }
+}
+
+// The token must never appear in logs or panic messages.
+impl std::fmt::Debug for Sender {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Sender")
+            .field("endpoint", &self.endpoint)
+            .field("token", &"<redacted>")
+            .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn decision_table() {
+        assert_eq!(classify_status(200), SendDecision::Acked);
+        assert_eq!(classify_status(202), SendDecision::Acked);
+        assert!(matches!(
+            classify_status(409),
+            SendDecision::Quarantine { .. }
+        ));
+        assert!(matches!(
+            classify_status(413),
+            SendDecision::Quarantine { .. }
+        ));
+        assert!(matches!(
+            classify_status(422),
+            SendDecision::Quarantine { .. }
+        ));
+        assert!(matches!(
+            classify_status(400),
+            SendDecision::Quarantine { .. }
+        ));
+        assert!(matches!(classify_status(429), SendDecision::Retry { .. }));
+        assert!(matches!(classify_status(500), SendDecision::Retry { .. }));
+        assert!(matches!(classify_status(503), SendDecision::Retry { .. }));
+    }
+
+    #[test]
+    fn backoff_grows_and_caps_with_jitter_bounds() {
+        let d0 = backoff_delay(0);
+        assert!(d0 >= Duration::from_secs(3) && d0 <= Duration::from_secs(7));
+        let d6 = backoff_delay(6);
+        assert!(d6 <= BACKOFF_MAX + Duration::from_secs(75));
+        let d99 = backoff_delay(99);
+        assert!(d99 <= BACKOFF_MAX + Duration::from_secs(75));
+    }
+
+    #[test]
+    fn retry_after_parses_delta_seconds() {
+        assert_eq!(
+            parse_retry_after(Some("120")),
+            Some(Duration::from_secs(120))
+        );
+        assert_eq!(
+            parse_retry_after(Some("  5 ")),
+            Some(Duration::from_secs(5))
+        );
+        assert_eq!(parse_retry_after(None), None);
+        assert_eq!(parse_retry_after(Some("not-a-number")), None);
+    }
+
+    #[test]
+    fn gzip_round_trips() {
+        let body = br#"{"events": []}"#;
+        let gz = gzip_body(body);
+        assert_ne!(gz, body);
+        let mut dec = flate2::read::GzDecoder::new(&gz[..]);
+        let mut out = Vec::new();
+        use std::io::Read as _;
+        dec.read_to_end(&mut out).unwrap();
+        assert_eq!(out, body);
+    }
+
+    #[test]
+    fn sender_debug_redacts_token() {
+        let s = Sender::new("https://example/v1".to_string(), "sekrit".to_string()).unwrap();
+        let rendered = format!("{:?}", s);
+        assert!(!rendered.contains("sekrit"));
+        assert!(rendered.contains("https://example/v1"));
+    }
+}

--- a/cognitod/src/main.rs
+++ b/cognitod/src/main.rs
@@ -973,6 +973,63 @@ async fn main() -> Result<(), Box<dyn Error>> {
             .unwrap_or_else(|| "unknown".to_string()),
     ));
 
+    // Linnix Cloud exporter: strictly opt-in. Spawns only when [cloud] is
+    // explicitly enabled with an endpoint, tenant, and token; anything that
+    // fails here logs and continues — export can never break monitoring or
+    // the local API. Absent or disabled config means no task and no network.
+    {
+        let cloud = &config.cloud;
+        let env_token = std::env::var("LINNIX_CLOUD_TOKEN").ok();
+        if cloud.usable(env_token.as_deref()) {
+            if !cloud.endpoint_allows_plaintext() {
+                warn!(
+                    "[cognitod] [cloud] endpoint {:?} rejected: plain http:// is only allowed for loopback test targets; cloud export disabled",
+                    cloud.endpoint.as_deref().unwrap_or("")
+                );
+            } else if let Some(store) = incident_store.clone() {
+                let token = cognitod::config::effective_cloud_token(
+                    env_token.as_deref(),
+                    cloud.bearer_token.as_deref(),
+                )
+                .expect("usable() checked the token");
+                // Identity and spool live next to the incident database.
+                let state_dir = incident_db_path
+                    .parent()
+                    .map(|p| p.to_path_buf())
+                    .unwrap_or_else(|| std::path::PathBuf::from("."));
+                let exporter_config = cognitod::cloud::ExporterConfig {
+                    endpoint: cloud
+                        .endpoint
+                        .clone()
+                        .expect("usable() checked the endpoint"),
+                    token,
+                    tenant_id: cloud
+                        .tenant_id
+                        .clone()
+                        .expect("usable() checked the tenant"),
+                    cluster_id_override: cloud.cluster_id.clone(),
+                    node_id_override: cloud.node_id.clone(),
+                    export_process_identity: cloud.export_process_identity,
+                    state_dir,
+                    quality: cognitod::cloud::QualitySnapshot {
+                        transport: transport.to_string(),
+                        btf_available: probe_state.btf_available,
+                        rss_probe: match probe_state.rss_probe {
+                            RssProbeMode::Disabled => "unavailable".to_string(),
+                            _ => "measured".to_string(),
+                        },
+                    },
+                };
+                cognitod::cloud::spawn_exporter(exporter_config, store, blame_metrics.clone());
+                info!("[cognitod] cloud exporter enabled");
+            } else {
+                warn!(
+                    "[cognitod] [cloud] enabled but the incident store failed to initialize; cloud export disabled"
+                );
+            }
+        }
+    }
+
     // Start PSI monitor (after incident store is ready)
     if let Some(ctx) = &k8s_context {
         let sink = Arc::new(


### PR DESCRIPTION
Agent-side Linnix Cloud exporter, part 2: sender + export loop + daemon wiring. #116 (the base — config, wire types, identity, scrub, seal, spool) has been merged into main; this branch is now rebased directly onto main.

## In scope

- HTTPS sender (`cloud/sender.rs`): gzip POST with bearer auth (redacted from `Debug`). Response table per schema §10: 200/202 → delete local batch; 409/413/422/other-4xx → quarantine with a note, never retried; 429/5xx/transport errors → exponential backoff + jitter, honors `Retry-After`. Batch bytes are immutable across retries (same idempotency key).
- Exporter loop (`cloud/exporter.rs`, 5 s tick): pulls incidents in row-ID order behind a persisted watermark — advanced **only after the batch is durably spooled**; converts them to scrubbed v1 detection events (unmapped types skipped, never coerced); 60 s heartbeats with spool/blame counters; `degradation_state` on quality transitions, which seal the old batch immediately (qualities never mixed). Drains the spool oldest-first. Every failure path logs and continues — exporter failures can never affect monitoring or the local API.
- Daemon wiring (`main.rs`): spawns only when `[cloud]` is explicitly usable (enabled + endpoint + tenant + token from config or `LINNIX_CLOUD_TOKEN`); remote plain-http endpoints refused; identity/spool live next to the incident DB. Absent/disabled config means no task and zero network.

## Out of scope

Server-side edge, `pressure_sample` events, pod/namespace workload attribution for detections (`subject` is null in v1).

## Validation

- `cargo test -p cognitod --lib` — 307 passed (12 new: unit tests for detection mapping/severity/window/scrubbing/watermark/quality-transition, plus mock-edge integration tests via an in-process axum server)
- `cargo test -p linnix-cli` — 2 passed
- `cargo +nightly fmt --all -- --check`, clippy clean for both packages with `-D warnings`
- Live smoke test: daemon with `[cloud] enabled = true` against a local mock edge posted a gzip batch (`b:smoke-node:0`, `psi_only`, degradation_state + heartbeat) with `Bearer` auth and got 202; with `enabled = false` no cloud files were created and no requests were made.
- No new HTTP dependency: the existing `reqwest`// sufficed.

**Do not merge** — awaiting review.

## Review follow-ups (addressed)

- **Mid-pull seal**: the pull loop buffers through `try_push`; on `BatchFull` the full batch seals and spools mid-pull and the pull continues into a fresh sealer. The watermark advances only after each event is buffered (or deliberately skipped), so a crash mid-pull replays the remainder idempotently.
- **Failed spool store**: `seal` no longer drains the buffer — `clear()` runs only after `spool.store` succeeds. A failed store leaves events buffered for retry; the watermark can never jump past undelivered events.
- **Heartbeat idempotency keys**: now `e:hb:{agent_instance_id}:{n}` with `n` from a persisted monotonic counter in the identity file (serde-defaulted for old identity files). Key reuse with a different body across restarts is impossible.
- **`circuit_breaker_*` variants**: covered by the #116 normalization; exporter test extended.
- **Retry-After**: honored on 429 and retryable 5xx via `retry_after_for`.

Validation after fixes: 323/323 `cognitod` lib tests (incl. mock-edge integration), CLI tests, fmt, clippy clean (both packages).


## Review follow-ups, round 2 (addressed)

Rebased onto the corrected #116 (`3c40350` → this branch at `49e87b9`); the `seal.rs` diff between the branches is now only the intentional `seal(&self)`/`clear()` split from round 1 (conflicts resolved in favor of #116's exact-accounting rewrite). Exporter-side changes in `49e87b9`:

- **`BatchSealer::new` call sites** updated for the new `SealIdentity` constructor (identity fields flow from the exporter config + identity store via a `new_sealer` helper).
- **Drain loop logs spool errors**: the three `let _ = self.spool.remove/quarantine(...)` sites now log failures (with retry-next-drain semantics) instead of discarding them silently.
- **`config.rs` plaintext fix flows through**: the exporter already gates startup on `endpoint_allows_plaintext`, which now uses WHATWG URL parsing — the `evil.example\@localhost` bypass is closed for the exporter too.

Validation after fixes: 336/336 `cognitod` lib tests (incl. 10 mock-edge exporter integration tests), CLI tests, fmt, clippy clean (both packages).

## Rebased onto main (2026-09-11)

#116 was squash-merged into main as `e463a5c`. The stacked #116 commits were dropped from this branch and the two #117 commits were replayed cleanly onto main (`aa6f359` sender/loop/wiring, `b7d94a3` review fixes) — the squash tree matched the branch's #116 tip exactly, so the rebase was conflict-free. Validation after rebase: 336/336 `cognitod` lib tests (incl. 10 mock-edge exporter integration tests), CLI tests, fmt, clippy clean (both packages).

**Do not merge** — awaiting review.
