### PR TITLE
Fix stall attribution when process events predate the daemon

### DIFF
--- a/cognitod/src/collectors/psi.rs
+++ b/cognitod/src/collectors/psi.rs
@@ -316,6 +316,28 @@ const MAX_CANDIDATE_OFFENDERS: usize = 10;
 /// meaningful offender candidates anyway.
 const SYSTEM_SCAN_TOP_N: usize = 32;
 
+/// Whether the cgroup-PSI peer fallback should supply offender candidates.
+///
+/// True when no process-event signal names a pod *other than* the victim.
+/// Victim-only entries don't count as "having signals":
+/// `calculate_blame_attributions` drops the victim from every candidate
+/// set, so treating them as real signals would suppress the fallback and
+/// still produce zero attributions. Pure so the victim-only trap is pinned
+/// by a test.
+fn needs_peer_fallback(
+    consumers: &[CpuConsumer],
+    fork_counts: &HashMap<String, u64>,
+    short_job_counts: &HashMap<String, u64>,
+    victim_key: &str,
+) -> bool {
+    let consumer_names_other = consumers
+        .iter()
+        .any(|c| format!("{}/{}", c.namespace, c.pod) != victim_key);
+    let forks_name_other = fork_counts.keys().any(|k| k.as_str() != victim_key);
+    let jobs_name_other = short_job_counts.keys().any(|k| k.as_str() != victim_key);
+    !(consumer_names_other || forks_name_other || jobs_name_other)
+}
+
 /// Builds last-resort offender candidates from the cgroup scan's own per-pod
 /// CPU stall deltas, for when the process-event paths produced nothing at
 /// all: no live consumers, no fork counts, no short-job counts.
@@ -836,17 +858,22 @@ impl PsiMonitor {
                                 .context
                                 .get_pod_activity_window(self.sustained_pressure_duration);
 
-                            // Last-resort offender discovery: if the
-                            // process-event paths produced nothing at all --
-                            // no live consumers, no fork counts, no short-job
-                            // counts (e.g. every offender predates the daemon
-                            // and left no events) -- fall back to the pods the
-                            // cgroup scan itself saw stalling this window, so
-                            // pair attribution degrades instead of vanishing.
-                            let consumers = if consumers.is_empty()
-                                && fork_counts.is_empty()
-                                && short_job_counts.is_empty()
-                            {
+                            // Last-resort offender discovery. The process-event
+                            // paths count as "having offenders" only if some
+                            // entry names a pod OTHER than the victim:
+                            // calculate_blame_attributions drops the victim
+                            // from every candidate set, so victim-only signals
+                            // would otherwise suppress the fallback and still
+                            // yield zero attributions. Fall back to the pods
+                            // the cgroup scan itself saw stalling this window,
+                            // so pair attribution degrades instead of
+                            // vanishing.
+                            let consumers = if needs_peer_fallback(
+                                &consumers,
+                                &fork_counts,
+                                &short_job_counts,
+                                &key,
+                            ) {
                                 let peers = cgroup_peer_consumers(&stalled_peers, &key);
                                 if !peers.is_empty() {
                                     info!(
@@ -1810,5 +1837,87 @@ workingset_refault_file 7
         assert_eq!(attr.victim_pod, "victim-workload");
         assert!(attr.attributed_stall_us > 0);
         assert!((attr.cpu_share - 1.0).abs() < 0.001);
+    }
+
+    fn peer_consumer(pod: &str) -> CpuConsumer {
+        CpuConsumer {
+            pod: pod.to_string(),
+            namespace: "default".to_string(),
+            cpu_percent: 42.0,
+        }
+    }
+
+    #[test]
+    fn test_needs_peer_fallback_victim_only_signals() {
+        // The Codex P1 trap: the only process-derived entries belong to the
+        // victim itself. calculate_blame_attributions drops the victim from
+        // every candidate set, so these must NOT suppress the fallback.
+        let consumers = vec![peer_consumer("victim-workload")];
+        let mut forks = HashMap::new();
+        forks.insert("default/victim-workload".to_string(), 7u64);
+        let mut jobs = HashMap::new();
+        jobs.insert("default/victim-workload".to_string(), 3u64);
+        assert!(needs_peer_fallback(
+            &consumers,
+            &forks,
+            &jobs,
+            "default/victim-workload"
+        ));
+        // Each signal class alone is enough to trigger the trap.
+        assert!(needs_peer_fallback(
+            &consumers,
+            &HashMap::new(),
+            &HashMap::new(),
+            "default/victim-workload"
+        ));
+        assert!(needs_peer_fallback(
+            &[],
+            &forks,
+            &HashMap::new(),
+            "default/victim-workload"
+        ));
+        assert!(needs_peer_fallback(
+            &[],
+            &HashMap::new(),
+            &jobs,
+            "default/victim-workload"
+        ));
+        assert!(needs_peer_fallback(
+            &[],
+            &HashMap::new(),
+            &HashMap::new(),
+            "default/victim-workload"
+        ));
+    }
+
+    #[test]
+    fn test_needs_peer_fallback_suppressed_by_real_offender_signal() {
+        let mut forks = HashMap::new();
+        forks.insert("default/forkstorm-offender".to_string(), 7u64);
+        // A non-victim fork entry suppresses the fallback even when the
+        // victim also appears as a consumer.
+        assert!(!needs_peer_fallback(
+            &[peer_consumer("victim-workload")],
+            &forks,
+            &HashMap::new(),
+            "default/victim-workload"
+        ));
+        // Same for a non-victim consumer alongside victim fork noise.
+        let mut victim_forks = HashMap::new();
+        victim_forks.insert("default/victim-workload".to_string(), 7u64);
+        assert!(!needs_peer_fallback(
+            &[peer_consumer("forkstorm-offender")],
+            &victim_forks,
+            &HashMap::new(),
+            "default/victim-workload"
+        ));
+        let mut jobs = HashMap::new();
+        jobs.insert("default/forkstorm-offender".to_string(), 3u64);
+        assert!(!needs_peer_fallback(
+            &[],
+            &HashMap::new(),
+            &jobs,
+            "default/victim-workload"
+        ));
     }
 }

--- a/cognitod/src/collectors/psi.rs
+++ b/cognitod/src/collectors/psi.rs
@@ -310,6 +310,55 @@ const CONSUMER_BUSY_CPU_PERCENT: f32 = 5.0;
 /// Bounds episode-capture size on a node with many concurrent consumers.
 const MAX_CANDIDATE_OFFENDERS: usize = 10;
 
+/// Upper bound on the system-wide top-CPU scan in
+/// `get_concurrent_cpu_consumers`. Only the hottest few pids ever get a
+/// `/proc/<pid>/cgroup` read for metadata resolution; the rest cannot be
+/// meaningful offender candidates anyway.
+const SYSTEM_SCAN_TOP_N: usize = 32;
+
+/// Builds last-resort offender candidates from the cgroup scan's own per-pod
+/// CPU stall deltas, for when the process-event paths produced nothing at
+/// all: no live consumers, no fork counts, no short-job counts.
+///
+/// `peers` is `(namespace, pod, delta_stall_us)` for every pod the scan saw
+/// stalling this window; the victim is excluded by `victim_key`
+/// (`"namespace/pod"`). Each peer's `cpu_percent` is its share of the peers'
+/// total stall as a percent, so it feeds the same `cpu_share` term of the
+/// blame score a measured `CpuConsumer` would -- the blame math only ever
+/// uses relative shares.
+///
+/// This is deliberately the degraded tier: a pod showing CPU pressure is
+/// contending for CPU, but pressure alone cannot say whether it is the
+/// offender or a fellow victim (a pure busy-loop offender may show no
+/// pressure at all, since it never waits). It exists so the pair-attribution
+/// path degrades to "the pods that were also stalled" instead of to
+/// nothing. Pure so it can be tested without driving the scan loop.
+fn cgroup_peer_consumers(peers: &[(String, String, u64)], victim_key: &str) -> Vec<CpuConsumer> {
+    let total: u64 = peers
+        .iter()
+        .filter(|(ns, pod, _)| format!("{ns}/{pod}") != victim_key)
+        .map(|(_, _, delta)| *delta)
+        .sum();
+    if total == 0 {
+        return Vec::new();
+    }
+    let mut out: Vec<CpuConsumer> = peers
+        .iter()
+        .filter(|(ns, pod, _)| format!("{ns}/{pod}") != victim_key)
+        .map(|(ns, pod, delta)| CpuConsumer {
+            pod: pod.clone(),
+            namespace: ns.clone(),
+            cpu_percent: (*delta as f64 / total as f64 * 100.0) as f32,
+        })
+        .collect();
+    out.sort_by(|a, b| {
+        b.cpu_percent
+            .partial_cmp(&a.cpu_percent)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+    out
+}
+
 /// How many samples of history (at the scan loop's 1-second cadence) to keep
 /// per signal per pod/container.
 ///
@@ -746,6 +795,15 @@ impl PsiMonitor {
                 }
             }
 
+            // Snapshot of the pods this scan saw stalling, for the cgroup-peer
+            // fallback below. Taken before `pod_deltas` is consumed by the
+            // trigger loop.
+            let stalled_peers: Vec<(String, String, u64)> = pod_deltas
+                .iter()
+                .filter(|(_, d)| d.has_previous_sample && d.delta_stall_us > 0)
+                .map(|(_, d)| (d.namespace.clone(), d.pod_name.clone(), d.delta_stall_us))
+                .collect();
+
             for (key, pod_delta) in pod_deltas {
                 if let Some(delta_stall) = pod_delta
                     .has_previous_sample
@@ -777,6 +835,31 @@ impl PsiMonitor {
                             let (fork_counts, short_job_counts) = self
                                 .context
                                 .get_pod_activity_window(self.sustained_pressure_duration);
+
+                            // Last-resort offender discovery: if the
+                            // process-event paths produced nothing at all --
+                            // no live consumers, no fork counts, no short-job
+                            // counts (e.g. every offender predates the daemon
+                            // and left no events) -- fall back to the pods the
+                            // cgroup scan itself saw stalling this window, so
+                            // pair attribution degrades instead of vanishing.
+                            let consumers = if consumers.is_empty()
+                                && fork_counts.is_empty()
+                                && short_job_counts.is_empty()
+                            {
+                                let peers = cgroup_peer_consumers(&stalled_peers, &key);
+                                if !peers.is_empty() {
+                                    info!(
+                                        "[psi] no process-event offenders for {}/{}; attributing from {} cgroup-PSI peer(s)",
+                                        pod_delta.namespace,
+                                        pod_delta.pod_name,
+                                        peers.len()
+                                    );
+                                }
+                                peers
+                            } else {
+                                consumers
+                            };
 
                             let mut victim_pre_window: BTreeMap<String, Vec<f64>> = BTreeMap::new();
                             victim_pre_window.insert(
@@ -1014,17 +1097,41 @@ impl PsiMonitor {
     }
 
     fn get_concurrent_cpu_consumers(&self) -> Vec<CpuConsumer> {
-        let live = self.context.get_live_map();
         let mut consumers: Vec<CpuConsumer> = Vec::new();
+        let mut seen_pids = std::collections::HashSet::new();
 
-        for (proc, meta_opt) in live.values() {
-            if let Some(cpu_pct) = proc.cpu_percent()
-                && cpu_pct > 0.0
-                && let Some(k8s_meta) = meta_opt
-            {
+        {
+            let live = self.context.get_live_map();
+            for (pid, (proc, meta_opt)) in live.iter() {
+                if let (Some(cpu_pct), Some(k8s_meta)) = (proc.cpu_percent(), meta_opt)
+                    && cpu_pct > 0.0
+                {
+                    seen_pids.insert(*pid);
+                    consumers.push(CpuConsumer {
+                        pod: k8s_meta.pod_name.clone(),
+                        namespace: k8s_meta.namespace.clone(),
+                        cpu_percent: cpu_pct,
+                    });
+                }
+            }
+        }
+
+        // The live map is event-sourced: a process that started before the
+        // daemon -- or whose Fork/Exec events were dropped under fork-storm
+        // load -- never appears in it, which is how a sustained StallEvent
+        // used to report "0 concurrent consumers" on a box with an obvious
+        // busy loop. Supplement with a system-wide scan; k8s metadata
+        // resolves per pid straight from /proc, so this covers exactly the
+        // processes the live map misses.
+        for (pid, cpu_pct) in self.context.top_cpu_pids_systemwide(SYSTEM_SCAN_TOP_N) {
+            if seen_pids.contains(&pid) {
+                continue;
+            }
+            if let Some(meta) = self.k8s_ctx.get_metadata_for_pid(pid) {
+                seen_pids.insert(pid);
                 consumers.push(CpuConsumer {
-                    pod: k8s_meta.pod_name.clone(),
-                    namespace: k8s_meta.namespace.clone(),
+                    pod: meta.pod_name.clone(),
+                    namespace: meta.namespace.clone(),
                     cpu_percent: cpu_pct,
                 });
             }
@@ -1612,5 +1719,96 @@ workingset_refault_file 7
         let mut acc: Option<u64> = None;
         accumulate_optional(&mut acc, None);
         assert_eq!(acc, None);
+    }
+
+    #[test]
+    fn test_cgroup_peer_consumers_excludes_victim_and_shares_stall() {
+        let peers = vec![
+            (
+                "default".to_string(),
+                "victim-workload".to_string(),
+                900_000,
+            ),
+            (
+                "default".to_string(),
+                "forkstorm-offender".to_string(),
+                300_000,
+            ),
+            (
+                "default".to_string(),
+                "quiet-neighbour".to_string(),
+                100_000,
+            ),
+        ];
+        let consumers = cgroup_peer_consumers(&peers, "default/victim-workload");
+
+        assert_eq!(consumers.len(), 2);
+        // Sorted by share descending; shares are of the 400_000 peer total.
+        assert_eq!(consumers[0].pod, "forkstorm-offender");
+        assert!((consumers[0].cpu_percent - 75.0).abs() < 0.001);
+        assert_eq!(consumers[1].pod, "quiet-neighbour");
+        assert!((consumers[1].cpu_percent - 25.0).abs() < 0.001);
+        assert!(
+            consumers.iter().all(|c| c.namespace == "default"),
+            "namespace must survive the fallback"
+        );
+    }
+
+    #[test]
+    fn test_cgroup_peer_consumers_empty_when_only_victim_stalled() {
+        let peers = vec![(
+            "default".to_string(),
+            "victim-workload".to_string(),
+            500_000,
+        )];
+        assert!(cgroup_peer_consumers(&peers, "default/victim-workload").is_empty());
+        assert!(cgroup_peer_consumers(&[], "default/victim-workload").is_empty());
+    }
+
+    #[test]
+    fn test_cgroup_peer_consumers_feeds_blame_attribution() {
+        // The whole point of the fallback: with no process-event signals at
+        // all, a stalling peer still produces a pair attribution naming it.
+        let peers = vec![
+            (
+                "default".to_string(),
+                "victim-workload".to_string(),
+                1_000_000,
+            ),
+            (
+                "default".to_string(),
+                "forkstorm-offender".to_string(),
+                1_000_000,
+            ),
+        ];
+        let consumers = cgroup_peer_consumers(&peers, "default/victim-workload");
+        let event = StallEvent {
+            event_id: "peer-fallback".to_string(),
+            victim_pod: "victim-workload".to_string(),
+            victim_namespace: "default".to_string(),
+            stall_delta_us: 1_000_000,
+            timestamp: Instant::now(),
+            concurrent_consumers: consumers,
+            fork_counts: HashMap::new(),
+            short_job_counts: HashMap::new(),
+            memory_stall_delta_us: 0,
+            io_stall_delta_us: 0,
+            memory_bytes: 0,
+            io_bytes: 0,
+            memory_anon_bytes: None,
+            memory_file_bytes: None,
+            memory_slab_bytes: None,
+            memory_pgmajfault_delta: None,
+            workingset_refault_delta: None,
+            candidates: vec![],
+        };
+
+        let attributions = calculate_blame_attributions(&event);
+        assert_eq!(attributions.len(), 1);
+        let attr = &attributions[0];
+        assert_eq!(attr.offender_pod, "forkstorm-offender");
+        assert_eq!(attr.victim_pod, "victim-workload");
+        assert!(attr.attributed_stall_us > 0);
+        assert!((attr.cpu_share - 1.0).abs() < 0.001);
     }
 }

--- a/cognitod/src/context.rs
+++ b/cognitod/src/context.rs
@@ -140,15 +140,19 @@ impl ContextStore {
                             "[context] no k8s metadata yet for pid {} (event_type={})",
                             event.pid, event.event_type
                         );
-                        if event.event_type == 1 {
-                            // Fork fallback: inherit parent's metadata if we can't find
-                            // child's yet (race condition: process created but cgroup
-                            // not yet populated). Re-resolve rather than trusting a
-                            // stale cached `None` -- the watcher may have caught up
-                            // with the parent's pod since the parent's own Exec/Fork.
-                            let mut live = self.live.lock().unwrap();
-                            metadata = resolve_live_metadata(ctx, &mut live, event.ppid);
-                        }
+                        // The child itself may already be gone (a fork-bomb
+                        // child can live microseconds), but its parent is
+                        // usually long-lived: inherit the parent's metadata.
+                        // Consult the live map first (it also covers
+                        // exited-but-retained parents), then read the parent's
+                        // cgroup straight from /proc -- a parent that started
+                        // before the daemon, or whose own Fork/Exec event was
+                        // dropped under load, is absent from the live map too,
+                        // and the old live-map-only fallback left exactly
+                        // those children permanently unattributed.
+                        let mut live = self.live.lock().unwrap();
+                        metadata = resolve_live_metadata(ctx, &mut live, event.ppid)
+                            .or_else(|| ctx.get_metadata_for_pid(event.ppid).map(Arc::new));
                     }
                 }
                 2 => {
@@ -472,6 +476,36 @@ impl ContextStore {
         }
     }
 
+    /// `(pid, cpu_percent)` for the hottest processes on the box, straight from
+    /// sysinfo rather than the event-sourced live map.
+    ///
+    /// The live map only ever learns about processes it saw Fork/Exec for: a
+    /// process that started before the daemon -- or whose events were dropped
+    /// under fork-storm load -- is invisible to it forever, which is how a
+    /// sustained StallEvent used to report "0 concurrent consumers" on a box
+    /// with an obvious busy loop. The PSI monitor supplements the live map
+    /// with this. Callers resolve k8s metadata per pid themselves (via
+    /// `K8sContext::get_metadata_for_pid`, which reads `/proc` directly and
+    /// works for exactly the processes the live map misses) and dedupe
+    /// against live-map pids.
+    pub fn top_cpu_pids_systemwide(&self, limit: usize) -> Vec<(u32, f32)> {
+        use std::cmp::Ordering;
+
+        let sys = self.sys.lock().unwrap();
+        let mut entries: Vec<(u32, f32)> = sys
+            .processes()
+            .values()
+            .filter_map(|proc| {
+                let cpu = proc.cpu_usage();
+                (cpu > 0.0).then(|| (proc.pid().as_u32(), cpu))
+            })
+            .collect();
+
+        entries.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(Ordering::Equal));
+        entries.truncate(limit);
+        entries
+    }
+
     /// Get top CPU processes from the entire system (not just eBPF-tracked ones).
     /// This is a fallback for circuit breaker when no eBPF-tracked processes exist.
     pub fn top_cpu_processes_systemwide(&self, limit: usize) -> Vec<ProcessMemorySummary> {
@@ -601,6 +635,7 @@ impl ContextStore {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::k8s::Priority;
     use crate::{PERCENT_MILLI_UNKNOWN, ProcessEvent, ProcessEventWire};
     use linnix_ai_ebpf_common::EventType;
 
@@ -725,5 +760,102 @@ mod tests {
             "exit event should remain after exec eviction"
         );
         assert_eq!(recent[0].event_type, EventType::Exit as u32);
+    }
+
+    /// Fixture helpers for the metadata-race regression tests below: a fake
+    /// `/proc`-style tree where `<pid>/cgroup` carries a synthetic container
+    /// id, plus a constructor stamping that id's pod metadata.
+    fn fixture_proc_tree(pids: &[(u32, &str)]) -> tempfile::TempDir {
+        let tmp = tempfile::tempdir().unwrap();
+        for (pid, container_id) in pids {
+            let pid_dir = tmp.path().join(pid.to_string());
+            std::fs::create_dir(&pid_dir).unwrap();
+            std::fs::write(
+                pid_dir.join("cgroup"),
+                format!(
+                    "0::/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod9d2.slice/cri-containerd-{container_id}.scope\n"
+                ),
+            )
+            .unwrap();
+        }
+        tmp
+    }
+
+    fn offender_metadata(pod_name: &str) -> K8sMetadata {
+        K8sMetadata {
+            pod_name: pod_name.to_string(),
+            namespace: "default".to_string(),
+            container_name: "app".to_string(),
+            owner_kind: None,
+            owner_name: None,
+            priority: Priority::default(),
+            slo_tier: None,
+        }
+    }
+
+    /// The reported production failure, deterministically: a Fork ingested
+    /// while the watcher's container map is still empty stamps `None`
+    /// metadata, and the periodic rescan heals the live entry once the map
+    /// warms -- the entry must not stay attributionless forever.
+    #[test]
+    fn rescan_heals_sticky_null_once_container_map_warms() {
+        let container_id = "c".repeat(64);
+        let tmp = fixture_proc_tree(&[(4343, &container_id)]);
+        let k8s = K8sContext::new_for_test(tmp.path().to_path_buf());
+        let store = ContextStore::new(Duration::from_secs(60), 1000, Some(k8s.clone()));
+
+        // Ingest before the watcher has learned the container: the pid
+        // resolves to a real container id, but the map is empty.
+        store.add(sample_event(4343, 1, EventType::Fork));
+        {
+            let live = store.get_live_map();
+            let (_, meta) = live.get(&4343).expect("fork should register live");
+            assert!(
+                meta.is_none(),
+                "metadata must be None while the container map is cold"
+            );
+        }
+
+        // The watcher catches up.
+        k8s.insert_metadata(container_id, offender_metadata("forkstorm-offender"));
+
+        store.rescan_unresolved_k8s_metadata();
+
+        let live = store.get_live_map();
+        let (_, meta) = live.get(&4343).expect("fork should register live");
+        let meta = meta.as_ref().expect("rescan should have healed the entry");
+        assert_eq!(meta.pod_name, "forkstorm-offender");
+        assert_eq!(meta.namespace, "default");
+    }
+
+    /// A fork-bomb child can exit before its Fork event is even processed, so
+    /// its own `/proc` entry is gone -- but the forking parent is long-lived.
+    /// When that parent started before the daemon (or its own events were
+    /// dropped), it is absent from the live map too; the fallback must read
+    /// the parent's cgroup straight from `/proc`, not just the live map.
+    #[test]
+    fn fork_event_inherits_parent_metadata_from_proc_when_parent_predates_daemon() {
+        let container_id = "d".repeat(64);
+        // Only the parent (5000) has a /proc entry; the child (6000) is
+        // already gone -- the fork-bomb churn case.
+        let tmp = fixture_proc_tree(&[(5000, &container_id)]);
+        let k8s = K8sContext::new_for_test(tmp.path().to_path_buf());
+        k8s.insert_metadata(container_id, offender_metadata("forkstorm-offender"));
+        let store = ContextStore::new(Duration::from_secs(60), 1000, Some(k8s));
+
+        // The parent never emitted any event the daemon saw: it is NOT in the
+        // live map. Only the child's Fork arrives.
+        store.add(sample_event(6000, 5000, EventType::Fork));
+
+        let live = store.get_live_map();
+        assert!(
+            !live.contains_key(&5000),
+            "test setup: parent must be absent from the live map"
+        );
+        let (_, meta) = live.get(&6000).expect("fork should register live");
+        let meta = meta
+            .as_ref()
+            .expect("child should inherit the parent's pod via /proc fallback");
+        assert_eq!(meta.pod_name, "forkstorm-offender");
     }
 }

--- a/cognitod/src/k8s.rs
+++ b/cognitod/src/k8s.rs
@@ -2,6 +2,7 @@ use log::{debug, info, trace, warn};
 use reqwest::Client;
 use serde::Deserialize;
 use std::collections::HashMap;
+use std::path::PathBuf;
 use std::sync::{Arc, RwLock};
 use std::time::Duration;
 use tokio::time::sleep;
@@ -46,6 +47,38 @@ pub struct K8sContext {
     api_url: String,
     token: String,
     pub node_name: String,
+    /// Root under which `<pid>/cgroup` is read. Always `/proc` in
+    /// production; tests point it at a fixture tree so metadata-resolution
+    /// races can be exercised without a live `/proc`.
+    proc_root: PathBuf,
+}
+
+/// Extracts a 64-char container id from `/proc/<pid>/cgroup` content, or
+/// `None` when no line carries one.
+///
+/// Pure so the heuristic is unit-testable without a live `/proc`: cgroup v2
+/// writes a single `0::/...` line, cgroup v1 writes one line per controller,
+/// and both bury the id in the last path segment as
+/// `cri-containerd-<id>.scope`, `docker-<id>.scope`, or a bare `<id>`.
+fn container_id_from_cgroup_content(content: &str) -> Option<String> {
+    for line in content.lines() {
+        // Simple heuristic: look for last part that looks like a container ID
+        if let Some(last_part) = line.split('/').next_back() {
+            // Remove .scope suffix if present
+            let clean = last_part.trim_end_matches(".scope");
+            // Remove prefix like "cri-containerd-" or "docker-"
+            let id = if let Some(idx) = clean.rfind('-') {
+                &clean[idx + 1..]
+            } else {
+                clean
+            };
+
+            if id.len() == 64 {
+                return Some(id.to_string());
+            }
+        }
+    }
+    None
 }
 
 enum K8sTlsConfig {
@@ -118,17 +151,63 @@ impl K8sContext {
             api_url,
             token,
             node_name,
+            proc_root: PathBuf::from("/proc"),
         }))
+    }
+
+    #[cfg(test)]
+    /// Test seam: builds a context reading `<pid>/cgroup` from a fixture
+    /// tree instead of the real `/proc`, so metadata-resolution races can
+    /// be driven deterministically. Same-crate only; production always
+    /// goes through `new()` and reads the real `/proc`.
+    pub(crate) fn new_for_test(proc_root: PathBuf) -> Arc<Self> {
+        Arc::new(Self {
+            container_map: RwLock::new(HashMap::new()),
+            client: Client::new(),
+            api_url: "http://127.0.0.1:1".to_string(),
+            token: "test".to_string(),
+            node_name: "test-node".to_string(),
+            proc_root,
+        })
     }
 
     pub fn start_watcher(self: Arc<Self>) {
         tokio::spawn(async move {
             info!("[k8s] starting pod watcher for node {}", self.node_name);
+            let mut consecutive_failures: u32 = 0;
             loop {
-                if let Err(e) = self.refresh_pods().await {
-                    warn!("[k8s] failed to refresh pods: {}", e);
+                // Stringify the error immediately: `refresh_pods` fails with
+                // `Box<dyn Error>` (not `Send`), which must not live across
+                // the awaits below in this spawned future.
+                match self.refresh_pods().await.map_err(|e| e.to_string()) {
+                    Ok(()) => {
+                        if consecutive_failures > 0 {
+                            info!(
+                                "[k8s] pod watcher recovered after {consecutive_failures} failed refresh(es)"
+                            );
+                        }
+                        consecutive_failures = 0;
+                        sleep(Duration::from_secs(30)).await;
+                    }
+                    Err(detail) => {
+                        consecutive_failures += 1;
+                        // Retry fast at first: a startup race (API not up yet
+                        // when the daemon starts) used to leave container_map
+                        // empty for a full 30s per failed attempt, which is
+                        // exactly the window where early Fork/Exec events lose
+                        // the metadata race. Back off to the normal 30s
+                        // cadence only after repeated failures.
+                        let backoff_secs = match consecutive_failures {
+                            1 => 5,
+                            2 => 10,
+                            _ => 30,
+                        };
+                        warn!(
+                            "[k8s] failed to refresh pods (failure #{consecutive_failures}): {detail}; retrying in {backoff_secs}s"
+                        );
+                        sleep(Duration::from_secs(backoff_secs)).await;
+                    }
                 }
-                sleep(Duration::from_secs(30)).await;
             }
         });
     }
@@ -225,48 +304,31 @@ impl K8sContext {
     }
 
     pub fn get_metadata_for_pid(&self, pid: u32) -> Option<K8sMetadata> {
-        // Read /proc/<pid>/cgroup
-        let Ok(content) = std::fs::read_to_string(format!("/proc/{}/cgroup", pid)) else {
+        // Read <proc_root>/<pid>/cgroup (`proc_root` is /proc in production,
+        // a fixture tree in tests).
+        let path = self.proc_root.join(pid.to_string()).join("cgroup");
+        let Ok(content) = std::fs::read_to_string(&path) else {
             // Expected for pids that have already exited (e.g. a fork-bomb
             // child that lived microseconds) -- not itself evidence of a
             // container-map race.
-            trace!("[k8s] pid {pid} has no /proc/<pid>/cgroup (already exited?)");
+            trace!("[k8s] pid {pid} has no {path:?} (already exited?)");
             return None;
         };
 
-        // Parse cgroup to find container ID
-        // Format: 0::/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod<uid>.slice/cri-containerd-<id>.scope
-        // Or similar. We look for a 64-char hex string.
+        let id = container_id_from_cgroup_content(&content)?;
 
-        for line in content.lines() {
-            // Simple heuristic: look for last part that looks like a container ID
-            if let Some(last_part) = line.split('/').next_back() {
-                // Remove .scope suffix if present
-                let clean = last_part.trim_end_matches(".scope");
-                // Remove prefix like "cri-containerd-" or "docker-"
-                let id = if let Some(idx) = clean.rfind('-') {
-                    &clean[idx + 1..]
-                } else {
-                    clean
-                };
-
-                if id.len() == 64 {
-                    let meta = self.get_metadata(id);
-                    if meta.is_none() {
-                        // The pid resolved to a real container ID, but that
-                        // ID isn't (yet) in the watcher's container map --
-                        // the container-map race: the pod's process started
-                        // before the last 30s poll picked up its containerID.
-                        debug!(
-                            "[k8s] pid {pid} -> container {id} has no entry in container_map ({} entries tracked)",
-                            self.container_map.read().unwrap().len()
-                        );
-                    }
-                    return meta;
-                }
-            }
+        let meta = self.get_metadata(&id);
+        if meta.is_none() {
+            // The pid resolved to a real container ID, but that ID isn't
+            // (yet) in the watcher's container map -- the container-map race:
+            // the pod's process started before the last poll picked up its
+            // containerID.
+            debug!(
+                "[k8s] pid {pid} -> container {id} has no entry in container_map ({} entries tracked)",
+                self.container_map.read().unwrap().len()
+            );
         }
-        None
+        meta
     }
 
     pub fn get_metadata(&self, container_id: &str) -> Option<K8sMetadata> {
@@ -358,5 +420,77 @@ mod tests {
         assert!(!flag_value_is_true("1"));
         assert!(!flag_value_is_true("yes"));
         assert!(!flag_value_is_true(""));
+    }
+
+    #[test]
+    fn container_id_parses_cgroup_v2_unified_line() {
+        let id = "e".repeat(64);
+        let content = format!(
+            "0::/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod123abc.slice/cri-containerd-{id}.scope\n"
+        );
+        assert_eq!(container_id_from_cgroup_content(&content), Some(id));
+    }
+
+    #[test]
+    fn container_id_parses_cgroup_v1_per_controller_lines() {
+        let id = "f".repeat(64);
+        let content = format!(
+            "2:cpu,cpuacct:/kubepods.slice/kubepods-burstable.slice/docker-{id}.scope\n\
+             1:name=systemd:/kubepods.slice/kubepods-burstable.slice/docker-{id}.scope\n"
+        );
+        assert_eq!(container_id_from_cgroup_content(&content), Some(id));
+    }
+
+    #[test]
+    fn container_id_parses_bare_id_without_runtime_prefix() {
+        let id = "a".repeat(64);
+        let content = format!("0::/kubepods/{id}\n");
+        assert_eq!(container_id_from_cgroup_content(&content), Some(id));
+    }
+
+    #[test]
+    fn container_id_is_none_without_a_64_char_segment() {
+        assert_eq!(container_id_from_cgroup_content("0::/\n"), None);
+        assert_eq!(
+            container_id_from_cgroup_content("0::/kubepods.slice/short-id.scope\n"),
+            None
+        );
+        assert_eq!(container_id_from_cgroup_content(""), None);
+    }
+
+    #[test]
+    fn new_for_test_reads_cgroup_from_the_fixture_tree() {
+        let tmp = tempfile::tempdir().unwrap();
+        let id = "b".repeat(64);
+        let pid_dir = tmp.path().join("4242");
+        std::fs::create_dir(&pid_dir).unwrap();
+        std::fs::write(
+            pid_dir.join("cgroup"),
+            format!("0::/kubepods.slice/cri-containerd-{id}.scope\n"),
+        )
+        .unwrap();
+
+        let ctx = K8sContext::new_for_test(tmp.path().to_path_buf());
+        // Map empty: the pid resolves to a container id, but nothing is known
+        // about it yet -- the container-map race, deterministically.
+        assert!(ctx.get_metadata_for_pid(4242).is_none());
+
+        ctx.insert_metadata(
+            id.clone(),
+            K8sMetadata {
+                pod_name: "victim-workload".to_string(),
+                namespace: "default".to_string(),
+                container_name: "app".to_string(),
+                owner_kind: None,
+                owner_name: None,
+                priority: Priority::default(),
+                slo_tier: None,
+            },
+        );
+        let meta = ctx
+            .get_metadata_for_pid(4242)
+            .expect("map warmed after the race; resolution should heal");
+        assert_eq!(meta.pod_name, "victim-workload");
+        assert_eq!(meta.namespace, "default");
     }
 }

--- a/cognitod/tests/attribution_eval.rs
+++ b/cognitod/tests/attribution_eval.rs
@@ -867,3 +867,118 @@ async fn poll_until<T>(timeout: Duration, mut check: impl FnMut() -> Option<T>) 
         tokio::time::sleep(Duration::from_millis(100)).await;
     }
 }
+
+/// Regression test for the production "0 concurrent consumers" gap: with an
+/// empty live-process map and no process events at all (every offender
+/// predates the daemon, so the event-sourced map never learned them), a
+/// stalling victim must still produce a pair attribution -- via the
+/// cgroup-PSI peer fallback -- naming the stalled neighbour as the offender,
+/// and the `linnix_stall_induced_seconds_total` series must appear.
+///
+/// This is the `kind-linnix-demo` shape: `forkstorm-offender` and
+/// `victim-workload` both show CPU pressure, but no Fork/Exec event ever
+/// reached the daemon for either pod's long-lived processes.
+#[tokio::test]
+async fn scan_loop_attributes_stall_to_cgroup_peer_with_no_process_events() {
+    use cognitod::collectors::psi::PsiMonitor;
+    use cognitod::context::ContextStore;
+    use cognitod::k8s::{K8sContext, K8sMetadata, Priority};
+
+    // K8sContext::new reads its endpoint from the environment; the watcher is
+    // never started, so nothing is actually dialled.
+    unsafe {
+        std::env::set_var("K8S_API_URL", "http://127.0.0.1:1");
+        std::env::set_var("K8S_TOKEN", "dummy");
+    }
+    let k8s_ctx = K8sContext::new().expect("K8sContext should build from env");
+
+    for (container_id, pod_name) in [
+        ("e".repeat(64), "victim-workload"),
+        ("f".repeat(64), "forkstorm-offender"),
+    ] {
+        k8s_ctx.insert_metadata(
+            container_id,
+            K8sMetadata {
+                pod_name: pod_name.to_string(),
+                namespace: "default".to_string(),
+                container_name: "app".to_string(),
+                owner_kind: None,
+                owner_name: None,
+                priority: Priority::default(),
+                slo_tier: None,
+            },
+        );
+    }
+
+    let tmp = tempfile::tempdir().unwrap();
+    let mut pressure_files = Vec::new();
+    for (container_id, pod_slice) in [("e".repeat(64), "pod-e"), ("f".repeat(64), "pod-f")] {
+        let cgroup_dir = tmp.path().join("kubepods.slice").join(format!(
+            "kubepods-burstable-{pod_slice}.slice/cri-containerd-{container_id}.scope"
+        ));
+        std::fs::create_dir_all(&cgroup_dir).unwrap();
+        pressure_files.push(cgroup_dir.join("cpu.pressure"));
+    }
+    let write_pressure = |total: u64| {
+        for pressure_file in &pressure_files {
+            std::fs::write(
+                pressure_file,
+                format!(
+                    "some avg10=10.00 avg60=5.00 avg300=1.00 total={total}\n\
+                     full avg10=0.00 avg60=0.00 avg300=0.00 total=0\n"
+                ),
+            )
+            .unwrap();
+        }
+    };
+    write_pressure(1_000_000);
+
+    let metrics = Arc::new(BlameMetrics::new("node-1"));
+    let sink = Arc::new(AttributionSink::new(metrics.clone(), None, "node-1"));
+    // Deliberately no process events: the live map and the history queue stay
+    // empty, exactly like a daemon that started after its workloads.
+    let context = Arc::new(ContextStore::new(
+        Duration::from_secs(60),
+        1000,
+        Some(k8s_ctx.clone()),
+    ));
+
+    let monitor = PsiMonitor::new(k8s_ctx, context, None, 0, sink)
+        .with_cgroup_root(tmp.path())
+        .with_max_iterations(60);
+    let handle = tokio::spawn(monitor.run());
+
+    // Both pods keep stalling while the monitor scans.
+    tokio::time::sleep(Duration::from_millis(1_200)).await;
+    write_pressure(2_500_000);
+
+    // The pair series must name forkstorm-offender -> victim-workload. (The
+    // reverse pair also appears: with no process signals the fallback cannot
+    // tell offender from fellow victim, which is the documented cost of the
+    // degraded tier.)
+    let line = poll_until(Duration::from_secs(30), || {
+        let mut body = String::new();
+        metrics.render_prometheus(&mut body);
+        body.lines()
+            .find(|l| {
+                l.starts_with("linnix_stall_induced_seconds_total{")
+                    && l.contains(r#"offender_pod="forkstorm-offender""#)
+                    && l.contains(r#"victim_pod="victim-workload""#)
+            })
+            .map(str::to_string)
+    })
+    .await
+    .expect("cgroup-peer fallback never produced the offender->victim pair series");
+    handle.abort();
+
+    assert!(
+        line.contains(r#"offender_namespace="default""#),
+        "line was: {line}"
+    );
+    assert!(
+        line.contains(r#"victim_namespace="default""#),
+        "line was: {line}"
+    );
+    // Note: unlike `linnix_pod_psi_pressure_total`, the pair series carries no
+    // `node` label -- the (offender, victim) key is the whole identity.
+}


### PR DESCRIPTION
Fixes the S2 paid-pilot gap: PSI stalls showed `0 concurrent consumers`, zero `stall_attributions` rows, and no `linnix_stall_induced_seconds_total` series on clusters where every offender predated the daemon.

**Root causes**
- Consumer discovery read only the event-sourced live map; processes predating the daemon (or lost to event gaps) never appeared, and consumers required positive cached CPU *plus* k8s metadata simultaneously.
- Short-lived fork children vanished before their `/proc` path was read, and the fork fallback only consulted the live parent entry.
- The pod watcher slept a full 30s between early refresh failures, widening the cold-`container_map` race exactly when early Fork/Exec events arrive.

**Changes**
- `k8s.rs`: pure `container_id_from_cgroup_content` parser (cgroup v1/v2/bare IDs), `proc_root` test seam for deterministic fixtures, watcher backoff 5s → 10s → 30s on consecutive refresh failures.
- `context.rs`: Fork/Exec parent metadata falls back to a direct `/proc/<ppid>/cgroup` read when the live map has no parent entry; new `top_cpu_pids_systemwide()` accessor over the refreshed sysinfo System.
- `psi.rs`: `get_concurrent_cpu_consumers` supplements the live map with the top-32 hottest system PIDs resolved via `/proc` cgroup; new last-resort cgroup-PSI peer fallback so pair attribution *degrades* (stalled peers named as offenders) instead of vanishing when all process signals are empty. Process-event paths still take precedence whenever non-empty.

**Known trade-off (documented in the regression test):** the degraded peer tier cannot distinguish offender from fellow victim — both pair directions are emitted. Only fires when every process-event signal is empty.

**Validation:** 359 lib tests + 13/13 `attribution_eval` integration tests pass, including a new two-pod fixture regression (no process events, cold map) asserting the `forkstorm-offender → victim-workload` pair series appears. `cargo fmt --check` and `clippy -D warnings` clean.